### PR TITLE
Add temporary build workflow for AOSM extension

### DIFF
--- a/.github/workflows/BuildAOSMWheel.yml
+++ b/.github/workflows/BuildAOSMWheel.yml
@@ -1,0 +1,23 @@
+on:
+  push:
+    branches:
+      - add-aosm-extension
+
+jobs:
+  build_aosm:
+    runs-on: ubuntu-latest
+    container: mcr.microsoft.com/azure-cli/tools:latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      - name: Build AOSM Wheel
+        run: |
+          # Pretend we have a valid git repo to satisfy azdev.
+          mkdir .git
+          azdev setup -r .
+          azdev extension build aosm
+      - name: Upload AOSM Wheel
+        uses: actions/upload-artifact@v3
+        with:
+          name: aosm-extension
+          path: dist/*.whl


### PR DESCRIPTION
Add a workflow that, on pushing to the add-aosm-extension branch, does a build of the extension and uploads the wheel as an artifact such that it can be obtained by anybody wishing to test or use it internally whilst development is ongoing.

The long-term intent is for the extension to be published as normal, and so this should be removed before merging cross-fork to the main repo.