### PR TITLE
Add empty init files to inner modules so setuptools recognises them

### DIFF
--- a/src/aosm/azext_aosm/delete/__init__.py
+++ b/src/aosm/azext_aosm/delete/__init__.py
@@ -1,0 +1,5 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# -----------------------------------------------------------------------------

--- a/src/aosm/azext_aosm/deploy/__init__.py
+++ b/src/aosm/azext_aosm/deploy/__init__.py
@@ -1,0 +1,5 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# -----------------------------------------------------------------------------

--- a/src/aosm/azext_aosm/generate_nfd/__init__.py
+++ b/src/aosm/azext_aosm/generate_nfd/__init__.py
@@ -1,0 +1,5 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# -----------------------------------------------------------------------------

--- a/src/aosm/azext_aosm/util/__init__.py
+++ b/src/aosm/azext_aosm/util/__init__.py
@@ -1,0 +1,5 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# -----------------------------------------------------------------------------


### PR DESCRIPTION
After installing from the packaged wheel, any attempts to use commands beneath the top level "aosm" currently fail, because the submodules can't be found within the extension. This includes help commands:

```
developer@Ephemera:~$ az aosm definition --help
The command failed with an unexpected error. Here is the traceback:
No module named 'azext_aosm.generate_nfd'
```
A lengthy stack trace also follows, but the key thing here is that `generate_nfd` is not found within `azext_aosm`.

This is because when building the list of packages to include we use `setuptools`, specifically the `find_packages()` function, which doesn't recognise this as a valid submodule because it lacks an `__init__.py`. The same is true of other modules within the extension, this just happens to be the one we hit first.
