### PR TITLE
Use latest RG model to remove unnecessary dependency on version

### DIFF
--- a/src/aosm/azext_aosm/deploy/pre_deploy.py
+++ b/src/aosm/azext_aosm/deploy/pre_deploy.py
@@ -8,7 +8,7 @@ from knack.log import get_logger
 
 from azure.core import exceptions as azure_exceptions
 from azure.cli.core.azclierror import AzCLIError
-from azure.mgmt.resource.resources.v2022_09_01.models import ResourceGroup
+from azure.mgmt.resource.resources.models import ResourceGroup
 
 from azext_aosm.util.management_clients import ApiClients
 from azext_aosm.vendored_sdks.models import (


### PR DESCRIPTION
azure.mgmt.resource provides a generic set of models (which just uses the set from the latest version available). Move to use that instead of a specific model for Resource Group creation because otherwise we depend on a specific minimum version (where we haven't declared a specific dependency), despite not actually using any version-specific properties.