### PR TITLE
Use latest Deployment model to remove unnecessary dependency on version

### DIFF
--- a/src/aosm/azext_aosm/deploy/deploy_with_arm.py
+++ b/src/aosm/azext_aosm/deploy/deploy_with_arm.py
@@ -13,7 +13,7 @@ import tempfile
 from knack.log import get_logger
 from azext_aosm.deploy.artifact_manifest import ArtifactManifestOperator
 from azext_aosm.util.management_clients import ApiClients
-from azure.mgmt.resource.resources.v2021_04_01.models import DeploymentExtended
+from azure.mgmt.resource.resources.models import DeploymentExtended
 
 from azext_aosm.deploy.pre_deploy import PreDeployerViaSDK
 from azext_aosm._configuration import NFConfiguration, VNFConfiguration


### PR DESCRIPTION
Just like with RGs, use the azure.mgmt.resource generic set of models (which just uses the set from the latest version available) instead of a specific model for Deployment creation because otherwise we depend on a specific minimum version (where we haven't declared a specific dependency), despite not actually using any version-specific properties.