### PR TITLE
Name uploaded VHD correctly

### DIFF
--- a/src/aosm/azext_aosm/_configuration.py
+++ b/src/aosm/azext_aosm/_configuration.py
@@ -31,7 +31,6 @@ DESCRIPTION_MAP: Dict[str, str] = {
     "acr_artifact_store_name": "Name of the ACR Artifact Store resource. Will be created if it does not exist.",
     "location": "Azure location to use when creating resources.",
     "blob_artifact_store_name": "Name of the storage account Artifact Store resource. Will be created if it does not exist.",
-    "artifact_name": "Name of the artifact",
     "file_path": (
         "Optional. File path of the artifact you wish to upload from your "
         "local disk. Delete if not required."
@@ -67,7 +66,6 @@ DESCRIPTION_MAP: Dict[str, str] = {
 
 @dataclass
 class ArtifactConfig:
-    artifact_name: str = DESCRIPTION_MAP["artifact_name"]
     # artifact.py checks for the presence of the default descriptions, change there if
     # you change the descriptions.
     file_path: Optional[str] = DESCRIPTION_MAP["file_path"]
@@ -179,8 +177,7 @@ class NSConfiguration:
     @property
     def resource_element_name(self) -> str:
         """Return the name of the resource element."""
-        artifact_name = self.arm_template.artifact_name
-        return f"{artifact_name}-resource-element"
+        return f"{self.nsdg_name.lower()}-resource-element"
 
     @property
     def network_function_name(self) -> str:
@@ -206,7 +203,6 @@ class NSConfiguration:
     def arm_template(self) -> ArtifactConfig:
         """Return the parameters of the ARM template to be uploaded as part of the NSDV."""
         artifact = ArtifactConfig()
-        artifact.artifact_name = f"{self.nsdg_name.lower()}_nf_artifact"
         artifact.version = self.nsd_version
         artifact.file_path = os.path.join(
             self.build_output_folder_name, NF_DEFINITION_JSON_FILE

--- a/src/aosm/azext_aosm/_configuration.py
+++ b/src/aosm/azext_aosm/_configuration.py
@@ -116,15 +116,6 @@ class NSConfiguration:
     nsd_version: str = DESCRIPTION_MAP["nsd_version"]
     nsdv_description: str = DESCRIPTION_MAP["nsdv_description"]
 
-    def __post_init__(self):
-        """
-        Cope with deserializing subclasses from dicts to ArtifactConfig.
-
-        Used when creating VNFConfiguration object from a loaded json config file.
-        """
-        if isinstance(self.arm_template, dict):
-            self.arm_template = ArtifactConfig(**self.arm_template)
-
     def validate(self):
         ## validate that all of the configuration parameters are set
 
@@ -208,6 +199,11 @@ class NSConfiguration:
             self.build_output_folder_name, NF_DEFINITION_JSON_FILE
         )
         return artifact
+    
+    @property
+    def arm_template_artifact_name(self) -> str:
+        """Return the artifact name for the ARM template"""
+        return f"{self.network_function_definition_group_name}_nfd_artifact"
 
 
 @dataclass

--- a/src/aosm/azext_aosm/deploy/artifact.py
+++ b/src/aosm/azext_aosm/deploy/artifact.py
@@ -6,7 +6,7 @@ from knack.log import get_logger
 from dataclasses import dataclass
 from typing import Union
 
-from azure.storage.blob import BlobClient
+from azure.storage.blob import BlobClient, BlobType
 from azext_aosm._configuration import ArtifactConfig
 from oras.client import OrasClient
 
@@ -68,7 +68,7 @@ class Artifact:
         if artifact_config.file_path:
             logger.info("Upload to blob store")
             with open(artifact_config.file_path, "rb") as artifact:
-                self.artifact_client.upload_blob(artifact, overwrite=True)
+                self.artifact_client.upload_blob(artifact, overwrite=True, blob_type=BlobType.PAGEBLOB)
             logger.info(
                 f"Successfully uploaded {artifact_config.file_path} to {self.artifact_client.account_name}"
             )

--- a/src/aosm/azext_aosm/deploy/artifact_manifest.py
+++ b/src/aosm/azext_aosm/deploy/artifact_manifest.py
@@ -131,7 +131,7 @@ class ArtifactManifestOperator:
                     f"{CredentialType.AZURE_STORAGE_ACCOUNT_TOKEN} are not expected "
                     f"for Artifacts of type {artifact.artifact_type}"
                 )
-                
+
             container_basename = artifact.artifact_name.replace("-", "")
             container_name = f"{container_basename}-{artifact.artifact_version}"
 
@@ -153,6 +153,7 @@ class ArtifactManifestOperator:
         Get the URL for the blob to be uploaded to the storage account artifact store.
 
         :param container_name: name of the container
+        :param blob_name: the name that the blob will get uploaded with
         """
         for container_credential in self._manifest_credentials["container_credentials"]:
             if container_credential["container_name"] == container_name:

--- a/src/aosm/azext_aosm/deploy/deploy_with_arm.py
+++ b/src/aosm/azext_aosm/deploy/deploy_with_arm.py
@@ -207,7 +207,7 @@ class DeployerViaArm:
                 "publisherName": {"value": self.config.publisher_name},
                 "acrArtifactStoreName": {"value": self.config.acr_artifact_store_name},
                 "acrManifestName": {"value": self.config.acr_manifest_name},
-                "armTemplateName": {"value": f"{self.config.network_function_definition_group_name}_nfd_artifact"},
+                "armTemplateName": {"value": self.config.arm_template_artifact_name},
                 "armTemplateVersion": {"value": self.config.arm_template.version},
             }
         else:

--- a/src/aosm/azext_aosm/deploy/deploy_with_arm.py
+++ b/src/aosm/azext_aosm/deploy/deploy_with_arm.py
@@ -197,9 +197,8 @@ class DeployerViaArm:
                 "saArtifactStoreName": {"value": self.config.blob_artifact_store_name},
                 "acrManifestName": {"value": self.config.acr_manifest_name},
                 "saManifestName": {"value": self.config.sa_manifest_name},
-                "vhdName": {"value": self.config.vhd.artifact_name},
+                'nfName': {"value": self.config.nf_name},
                 "vhdVersion": {"value": self.config.vhd.version},
-                "armTemplateName": {"value": self.config.arm_template.artifact_name},
                 "armTemplateVersion": {"value": self.config.arm_template.version},
             }
         elif isinstance(self.config, NSConfiguration):
@@ -208,7 +207,7 @@ class DeployerViaArm:
                 "publisherName": {"value": self.config.publisher_name},
                 "acrArtifactStoreName": {"value": self.config.acr_artifact_store_name},
                 "acrManifestName": {"value": self.config.acr_manifest_name},
-                "armTemplateName": {"value": self.config.arm_template.artifact_name},
+                "armTemplateName": {"value": f"{self.config.network_function_definition_group_name}_nfd_artifact"},
                 "armTemplateVersion": {"value": self.config.arm_template.version},
             }
         else:

--- a/src/aosm/azext_aosm/generate_nfd/templates/vnfartifactmanifests.bicep
+++ b/src/aosm/azext_aosm/generate_nfd/templates/vnfartifactmanifests.bicep
@@ -12,13 +12,11 @@ param saArtifactStoreName string
 param acrManifestName string
 @description('Name of the manifest to deploy for the Storage Account-backed Artifact Store')
 param saManifestName string
-@description('The name under which to store the VHD')
-param vhdName string
+@description('Name of Network Function. Used predominantly as a prefix for other variable names')
+param nfName string
 @description('The version that you want to name the NFM VHD artifact, in format A-B-C. e.g. 6-13-0')
 param vhdVersion string
 @description('The name under which to store the ARM template')
-param armTemplateName string
-@description('The version that you want to name the NFM template artifact, in format A.B.C. e.g. 6.13.0. If testing for development, you can use any numbers you like.')
 param armTemplateVersion string
 
 // Created by the az aosm definition publish command before the template is deployed
@@ -46,7 +44,7 @@ resource saArtifactManifest 'Microsoft.Hybridnetwork/publishers/artifactStores/a
   properties: {
     artifacts: [
       {
-        artifactName: '${vhdName}'
+        artifactName: '${nfName}-vhd'
         artifactType: 'VhdImageFile'
         artifactVersion: vhdVersion
       }
@@ -61,7 +59,7 @@ resource acrArtifactManifest 'Microsoft.Hybridnetwork/publishers/artifactStores/
   properties: {
     artifacts: [
       {
-        artifactName: '${armTemplateName}'
+        artifactName: '${nfName}-arm-template'
         artifactType: 'ArmTemplate'
         artifactVersion: armTemplateVersion
       }

--- a/src/aosm/azext_aosm/generate_nsd/nsd_generator.py
+++ b/src/aosm/azext_aosm/generate_nsd/nsd_generator.py
@@ -161,7 +161,7 @@ class NSDGenerator:
         """Write out the NSD bicep file."""
         params = {
             "nfvi_site_name": self.config.nfvi_site_name,
-            "armTemplateName": self.config.arm_template.artifact_name,
+            "armTemplateName": f"{self.config.network_function_definition_group_name}_nfd_artifact",
             "armTemplateVersion": self.config.arm_template.version,
             "cg_schema_name": self.config.cg_schema_name,
             "nsdv_description": self.config.nsdv_description,

--- a/src/aosm/azext_aosm/generate_nsd/nsd_generator.py
+++ b/src/aosm/azext_aosm/generate_nsd/nsd_generator.py
@@ -161,7 +161,7 @@ class NSDGenerator:
         """Write out the NSD bicep file."""
         params = {
             "nfvi_site_name": self.config.nfvi_site_name,
-            "armTemplateName": f"{self.config.network_function_definition_group_name}_nfd_artifact",
+            "armTemplateName": self.config.arm_template_artifact_name,
             "armTemplateVersion": self.config.arm_template.version,
             "cg_schema_name": self.config.cg_schema_name,
             "nsdv_description": self.config.nsdv_description,


### PR DESCRIPTION
Fix for https://dev.azure.com/msazuredev/AzureForOperators/_workitems/edit/735056

This PR fixes three things:
- A different name for the VHD artifact was used in different places.  This PR makes them consistent and of the form {nf-name}-vhd.  Therefore we no longer ask the user to supply an artifact name.
- When the VHD is uploaded to blob store the blob name must end in ".vhd"
- When the VHD is uploaded to blob store it must be uploaded as a page blob.

I haven't actually managed to get as far as deploying the SNS, as I was testing with a vnet ARM template and supplying an empty VHD.  It turns out that isn't allowed.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
