### PR TITLE
Fix for oras target string with erroneous spaces

### DIFF
--- a/src/aosm/azext_aosm/deploy/artifact.py
+++ b/src/aosm/azext_aosm/deploy/artifact.py
@@ -47,8 +47,10 @@ class Artifact:
         # the field.
 
         if artifact_config.file_path:
-            target = f"{self.artifact_client.remote.hostname.replace('https://', '')}\
-                /{self.artifact_name}:{self.artifact_version}"
+            target = (
+                f"{self.artifact_client.remote.hostname.replace('https://', '')}"
+                f"/{self.artifact_name}:{self.artifact_version}"
+            )
             logger.debug("Uploading %s to %s", artifact_config.file_path, target)
             self.artifact_client.push(
                 files=[artifact_config.file_path],


### PR DESCRIPTION
Small fix for broken ORAS target string.

Original error seen:
```
The command failed with an unexpected error. Here is the traceback:
HTTPSConnectionPool(host='ac4mitestingac4mitestingacred058481d7.azurecr.io%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20', port=443):
```
Those `%20`s are spaces that have crept in.