### PR TITLE
Fix Artifact upload on Windows

### DIFF
--- a/src/aosm/HISTORY.rst
+++ b/src/aosm/HISTORY.rst
@@ -16,6 +16,7 @@ unreleased
 * Add the ability to skip bicep publish or artifact upload during publish commands.
 * Fix Manifest name for NSDs so it isn't the same as that for NFDs
 * Add validation of source_registry_id format for CNF configuration
+* Workaround Oras client bug (#90) on Windows for Artifact upload to ACR
 
 0.2.0
 ++++++

--- a/src/aosm/setup.md
+++ b/src/aosm/setup.md
@@ -12,7 +12,7 @@ Clone both azure-cli and azure-cli-extensions
 Note for azure-cli-extensions we are currently on a fork : https://github.com/jddarby/azure-cli-extensions
 ```bash
 # Go into your git clone of az-cli-extensions
-cd az-cli-extensions
+cd azure-cli-extensions
 
 # Create a virtual environment to run in
 python3.8 -m venv ~/.virtualenvs/az-cli-env
@@ -23,6 +23,8 @@ python -m pip install -U pip
 
 # Install azdev
 pip install azdev
+
+git checkout add-aosm-extension
 
 # Install all the python dependencies you need
 azdev setup --cli /home/developer/code/azure-cli --repo .


### PR DESCRIPTION
Workaround for https://github.com/oras-project/oras-py/issues/90 to fix Artifact upload when running on Windows. 
This can be reverted when https://github.com/oras-project/oras-py/pull/91 is released and oras is bumped.
