### PR TITLE
Dry the deploy_nfd_from_bicep() code

### DIFF
--- a/src/aosm/azext_aosm/_params.py
+++ b/src/aosm/azext_aosm/_params.py
@@ -6,7 +6,7 @@
 from argcomplete.completers import FilesCompleter
 from azure.cli.core import AzCommandsLoader
 
-from .util.constants import CNF, VNF, BICEP_PUBLISH, ARTIFACT_UPLOAD
+from .util.constants import CNF, VNF, BICEP_PUBLISH, ARTIFACT_UPLOAD, IMAGE_UPLOAD
 
 
 def load_arguments(self: AzCommandsLoader, _):
@@ -17,7 +17,8 @@ def load_arguments(self: AzCommandsLoader, _):
     )
 
     definition_type = get_enum_type([VNF, CNF])
-    skip_steps = get_enum_type([BICEP_PUBLISH, ARTIFACT_UPLOAD])
+    nf_skip_steps = get_enum_type([BICEP_PUBLISH, ARTIFACT_UPLOAD, IMAGE_UPLOAD])
+    ns_skip_steps = get_enum_type([BICEP_PUBLISH, ARTIFACT_UPLOAD])
 
     # Set the argument context so these options are only available when this specific command
     # is called.
@@ -110,7 +111,7 @@ def load_arguments(self: AzCommandsLoader, _):
                 " alternative parameters."
             ),
         )
-        c.argument("skip", arg_type=skip_steps, help="Optional skip steps")
+        c.argument("skip", arg_type=nf_skip_steps, help="Optional skip steps. 'bicep-publish' will skip deploying the bicep template; 'artifact-upload' will skip uploading any artifacts; 'image-upload' will skip uploading the VHD image (for VNFs) or the container images (for CNFs).")
 
     with self.argument_context("aosm nsd") as c:
         c.argument(
@@ -120,4 +121,4 @@ def load_arguments(self: AzCommandsLoader, _):
             completer=FilesCompleter(allowednames="*.json"),
             help="The path to the configuration file.",
         )
-        c.argument("skip", arg_type=skip_steps, help="Optional skip steps")
+        c.argument("skip", arg_type=ns_skip_steps, help="Optional skip steps")

--- a/src/aosm/azext_aosm/custom.py
+++ b/src/aosm/azext_aosm/custom.py
@@ -165,34 +165,25 @@ def publish_definition(
         container_registry_client=cf_acr_registries(cmd.cli_ctx),
     )
 
+    if definition_type not in (VNF, CNF):
+        raise ValueError(
+            "Definition type must be either 'vnf' or 'cnf'. Definition type"
+            f" '{definition_type}' is not valid for network function definitions."
+        )
+
     config = _get_config_from_file(
         config_file=config_file, configuration_type=definition_type
     )
 
-    if definition_type == VNF:
-        deployer = DeployerViaArm(api_clients, config=config)
-        deployer.deploy_vnfd_from_bicep(
-            bicep_path=definition_file,
-            parameters_json_file=parameters_json_file,
-            manifest_bicep_path=manifest_file,
-            manifest_parameters_json_file=manifest_parameters_json_file,
-            skip=skip,
-        )
-    elif definition_type == CNF:
-        deployer = DeployerViaArm(api_clients, config=config)
-        deployer.deploy_cnfd_from_bicep(
-            cli_ctx=cmd.cli_ctx,
-            bicep_path=definition_file,
-            parameters_json_file=parameters_json_file,
-            manifest_bicep_path=manifest_file,
-            manifest_parameters_json_file=manifest_parameters_json_file,
-            skip=skip,
-        )
-    else:
-        raise ValueError(
-            "Definition type must be either 'vnf' or 'cnf'. Definition type"
-            f" {definition_type} is not recognised."
-        )
+    deployer = DeployerViaArm(api_clients, config=config)
+    deployer.deploy_nfd_from_bicep(
+        cli_ctx=cmd.cli_ctx,
+        bicep_path=definition_file,
+        parameters_json_file=parameters_json_file,
+        manifest_bicep_path=manifest_file,
+        manifest_parameters_json_file=manifest_parameters_json_file,
+        skip=skip,
+    )
 
 
 def delete_published_definition(

--- a/src/aosm/azext_aosm/custom.py
+++ b/src/aosm/azext_aosm/custom.py
@@ -32,7 +32,7 @@ from azext_aosm.generate_nfd.cnf_nfd_generator import CnfNfdGenerator
 from azext_aosm.generate_nfd.nfd_generator_base import NFDGenerator
 from azext_aosm.generate_nfd.vnf_nfd_generator import VnfNfdGenerator
 from azext_aosm.generate_nsd.nsd_generator import NSDGenerator
-from azext_aosm.util.constants import CNF, NSD, VNF
+from azext_aosm.util.constants import CNF, DeployableResourceTypes, NSD, SkipSteps, VNF
 from azext_aosm.util.management_clients import ApiClients
 from azext_aosm.vendored_sdks import HybridNetworkManagementClient
 
@@ -136,7 +136,7 @@ def publish_definition(
     parameters_json_file: Optional[str] = None,
     manifest_file: Optional[str] = None,
     manifest_parameters_json_file: Optional[str] = None,
-    skip: Optional[str] = None,
+    skip: Optional[SkipSteps] = None,
 ):
     """
     Publish a generated definition.
@@ -175,15 +175,18 @@ def publish_definition(
         config_file=config_file, configuration_type=definition_type
     )
 
-    deployer = DeployerViaArm(api_clients, config=config)
-    deployer.deploy_nfd_from_bicep(
-        cli_ctx=cmd.cli_ctx,
+    deployer = DeployerViaArm(
+        api_clients,
+        resource_type=definition_type,
+        config=config,
         bicep_path=definition_file,
         parameters_json_file=parameters_json_file,
         manifest_bicep_path=manifest_file,
         manifest_parameters_json_file=manifest_parameters_json_file,
         skip=skip,
+        cli_ctx=cmd.cli_ctx,
     )
+    deployer.deploy_nfd_from_bicep()
 
 
 def delete_published_definition(
@@ -327,7 +330,7 @@ def publish_design(
     parameters_json_file: Optional[str] = None,
     manifest_file: Optional[str] = None,
     manifest_parameters_json_file: Optional[str] = None,
-    skip: Optional[str] = None,
+    skip: Optional[SkipSteps] = None,
 ):
     """
     Publish a generated design.
@@ -357,9 +360,10 @@ def publish_design(
     assert isinstance(config, NSConfiguration)
     config.validate()
 
-    deployer = DeployerViaArm(api_clients, config=config)
-
-    deployer.deploy_nsd_from_bicep(
+    deployer = DeployerViaArm(
+        api_clients,
+        resource_type=DeployableResourceTypes.NSD,
+        config=config,
         bicep_path=design_file,
         parameters_json_file=parameters_json_file,
         manifest_bicep_path=manifest_file,
@@ -367,6 +371,7 @@ def publish_design(
         skip=skip,
     )
 
+    deployer.deploy_nsd_from_bicep()
 
 def _generate_nsd(config: NSConfiguration, api_clients: ApiClients):
     """Generate a Network Service Design for the given config."""

--- a/src/aosm/azext_aosm/deploy/deploy_with_arm.py
+++ b/src/aosm/azext_aosm/deploy/deploy_with_arm.py
@@ -72,7 +72,9 @@ class DeployerViaArm:
             self.resource_type = NSD
         else:
             raise TypeError(
-                f"Unexpected config type. Expected [VNFConfiguration|CNFConfiguration|NSConfiguration], received {type(self.config)}"
+                "Unexpected config type. Expected"
+                " [VNFConfiguration|CNFConfiguration|NSConfiguration], received"
+                f" {type(self.config)}"
             )
 
     @staticmethod
@@ -322,7 +324,8 @@ class DeployerViaArm:
                 "nfDefinitionVersion": {"value": self.config.version},
             }
         raise TypeError(
-            f"Unexpected config type. Expected [VNFConfiguration|CNFConfiguration], received {type(self.config)}"
+            "Unexpected config type. Expected [VNFConfiguration|CNFConfiguration],"
+            f" received {type(self.config)}"
         )
 
     def construct_manifest_parameters(self) -> Dict[str, Any]:

--- a/src/aosm/azext_aosm/deploy/deploy_with_arm.py
+++ b/src/aosm/azext_aosm/deploy/deploy_with_arm.py
@@ -71,7 +71,9 @@ class DeployerViaArm:
         elif isinstance(self.config, NSConfiguration):
             self.resource_type = NSD
         else:
-            raise TypeError(f"Unexpected config type. Expected [VNFConfiguration|CNFConfiguration|NSConfiguration], received {type(self.config)}")
+            raise TypeError(
+                f"Unexpected config type. Expected [VNFConfiguration|CNFConfiguration|NSConfiguration], received {type(self.config)}"
+            )
 
     @staticmethod
     def read_parameters_from_file(parameters_json_file: str) -> Dict[str, Any]:
@@ -124,8 +126,7 @@ class DeployerViaArm:
                 if self.resource_type == CNF:
                     file_name = CNF_DEFINITION_BICEP_TEMPLATE_FILENAME
                 bicep_path = os.path.join(
-                    self.config.output_directory_for_build,
-                    file_name
+                    self.config.output_directory_for_build, file_name
                 )
 
             if parameters_json_file:
@@ -174,9 +175,7 @@ class DeployerViaArm:
         if self.resource_type == CNF:
             self._cnfd_artifact_upload(cli_ctx)
 
-    def _vnfd_artifact_upload(
-        self
-    ) -> None:
+    def _vnfd_artifact_upload(self) -> None:
         """
         Uploads the VHD and ARM template artifacts
         """
@@ -203,10 +202,7 @@ class DeployerViaArm:
         arm_template_artifact.upload(self.config.arm_template)
         print("Done")
 
-    def _cnfd_artifact_upload(
-        self,
-        cli_ctx
-    ) -> None:
+    def _cnfd_artifact_upload(self, cli_ctx) -> None:
         """
         Uploads the Helm chart and any additional images.
         """
@@ -325,7 +321,9 @@ class DeployerViaArm:
                 "nfDefinitionGroup": {"value": self.config.nfdg_name},
                 "nfDefinitionVersion": {"value": self.config.version},
             }
-        raise TypeError(f"Unexpected config type. Expected [VNFConfiguration|CNFConfiguration], received {type(self.config)}")
+        raise TypeError(
+            f"Unexpected config type. Expected [VNFConfiguration|CNFConfiguration], received {type(self.config)}"
+        )
 
     def construct_manifest_parameters(self) -> Dict[str, Any]:
         """Create the parmeters dictionary for VNF, CNF or NSD."""

--- a/src/aosm/azext_aosm/util/constants.py
+++ b/src/aosm/azext_aosm/util/constants.py
@@ -4,15 +4,29 @@
 # --------------------------------------------------------------------------------------------
 """Constants used across aosm cli extension."""
 
+from enum import Enum
+
 # The types of definition that can be generated
 VNF = "vnf"
 CNF = "cnf"
 NSD = "nsd"
 SCHEMA = "schema"
 
+
+class DeployableResourceTypes(str, Enum):
+    VNF = VNF
+    CNF = CNF
+    NSD = NSD
+
 # Skip steps
 BICEP_PUBLISH = "bicep-publish"
 ARTIFACT_UPLOAD = "artifact-upload"
+IMAGE_UPLOAD = "image-upload"
+
+class SkipSteps(Enum):
+    BICEP_PUBLISH = BICEP_PUBLISH
+    ARTIFACT_UPLOAD = ARTIFACT_UPLOAD
+    IMAGE_UPLOAD = IMAGE_UPLOAD
 
 # Names of files used in the repo
 


### PR DESCRIPTION
This is a small refactor to remove some duplicated code in the deploy_(x)nfd_from_bicep() methods.

The VNF And CNF versions shared a considerable amount of code. This has now been refactored out into a common method.

There was some associated tidying that came with this, such as removing a bizarrely garbled docblock for the former vnf method, and no longer passing around the configuration type as a method parameter.

I've moved the new _cnfd_artifact_upload() method to be immediately below the equivalent vnf method, which makes the changes look greater than they are. If that makes the review harder than it needs to be, I can show the reviewer the copy/paste to do to make the diff cleaner.

No testing done yet, I'll do it all after I've added the new "skip VHD upload" feature. This is a "pre-review", as we should be reviewing refactoring and new features separately.