### PR TITLE
Add skip steps, improve typing, stop passing variables around in method signatures

### DIFF
--- a/src/aosm/azext_aosm/_params.py
+++ b/src/aosm/azext_aosm/_params.py
@@ -6,7 +6,7 @@
 from argcomplete.completers import FilesCompleter
 from azure.cli.core import AzCommandsLoader
 
-from .util.constants import CNF, VNF, BICEP_PUBLISH, ARTIFACT_UPLOAD
+from .util.constants import CNF, VNF, BICEP_PUBLISH, ARTIFACT_UPLOAD, IMAGE_UPLOAD
 
 
 def load_arguments(self: AzCommandsLoader, _):
@@ -17,7 +17,8 @@ def load_arguments(self: AzCommandsLoader, _):
     )
 
     definition_type = get_enum_type([VNF, CNF])
-    skip_steps = get_enum_type([BICEP_PUBLISH, ARTIFACT_UPLOAD])
+    nf_skip_steps = get_enum_type([BICEP_PUBLISH, ARTIFACT_UPLOAD, IMAGE_UPLOAD])
+    ns_skip_steps = get_enum_type([BICEP_PUBLISH, ARTIFACT_UPLOAD])
 
     # Set the argument context so these options are only available when this specific command
     # is called.
@@ -110,7 +111,9 @@ def load_arguments(self: AzCommandsLoader, _):
                 " alternative parameters."
             ),
         )
-        c.argument("skip", arg_type=skip_steps, help="Optional skip steps")
+        c.argument("skip", arg_type=nf_skip_steps, help="Optional skip steps. 'bicep-publish' will skip ")
+        # TODO: Rename 'bicep-publish'? E.g. 'deploy-nfd' (but maybe that implies the whole thing)
+        # TODO: improve this help text
 
     with self.argument_context("aosm nsd") as c:
         c.argument(
@@ -120,4 +123,4 @@ def load_arguments(self: AzCommandsLoader, _):
             completer=FilesCompleter(allowednames="*.json"),
             help="The path to the configuration file.",
         )
-        c.argument("skip", arg_type=skip_steps, help="Optional skip steps")
+        c.argument("skip", arg_type=ns_skip_steps, help="Optional skip steps")

--- a/src/aosm/azext_aosm/_params.py
+++ b/src/aosm/azext_aosm/_params.py
@@ -111,9 +111,7 @@ def load_arguments(self: AzCommandsLoader, _):
                 " alternative parameters."
             ),
         )
-        c.argument("skip", arg_type=nf_skip_steps, help="Optional skip steps. 'bicep-publish' will skip ")
-        # TODO: Rename 'bicep-publish'? E.g. 'deploy-nfd' (but maybe that implies the whole thing)
-        # TODO: improve this help text
+        c.argument("skip", arg_type=nf_skip_steps, help="Optional skip steps. 'bicep-publish' will skip deploying the bicep template; 'artifact-upload' will skip uploading any artifacts; 'image-upload' will skip uploading the VHD image (for VNFs) or the container images (for CNFs).")
 
     with self.argument_context("aosm nsd") as c:
         c.argument(

--- a/src/aosm/azext_aosm/custom.py
+++ b/src/aosm/azext_aosm/custom.py
@@ -32,7 +32,7 @@ from azext_aosm.generate_nfd.cnf_nfd_generator import CnfNfdGenerator
 from azext_aosm.generate_nfd.nfd_generator_base import NFDGenerator
 from azext_aosm.generate_nfd.vnf_nfd_generator import VnfNfdGenerator
 from azext_aosm.generate_nsd.nsd_generator import NSDGenerator
-from azext_aosm.util.constants import CNF, NSD, VNF
+from azext_aosm.util.constants import CNF, DeployableResourceTypes, NSD, SkipSteps, VNF
 from azext_aosm.util.management_clients import ApiClients
 from azext_aosm.vendored_sdks import HybridNetworkManagementClient
 
@@ -136,7 +136,7 @@ def publish_definition(
     parameters_json_file: Optional[str] = None,
     manifest_file: Optional[str] = None,
     manifest_parameters_json_file: Optional[str] = None,
-    skip: Optional[str] = None,
+    skip: Optional[SkipSteps] = None,
 ):
     """
     Publish a generated definition.
@@ -175,15 +175,18 @@ def publish_definition(
         config_file=config_file, configuration_type=definition_type
     )
 
-    deployer = DeployerViaArm(api_clients, config=config)
-    deployer.deploy_nfd_from_bicep(
-        cli_ctx=cmd.cli_ctx,
+    deployer = DeployerViaArm(
+        api_clients,
+        resource_type=definition_type,
+        config=config,
         bicep_path=definition_file,
         parameters_json_file=parameters_json_file,
         manifest_bicep_path=manifest_file,
         manifest_parameters_json_file=manifest_parameters_json_file,
         skip=skip,
+        cli_ctx=cmd.cli_ctx,
     )
+    deployer.deploy_nfd_from_bicep()
 
 
 def delete_published_definition(
@@ -327,7 +330,7 @@ def publish_design(
     parameters_json_file: Optional[str] = None,
     manifest_file: Optional[str] = None,
     manifest_parameters_json_file: Optional[str] = None,
-    skip: Optional[str] = None,
+    skip: Optional[SkipSteps] = None,
 ):
     """
     Publish a generated design.
@@ -357,9 +360,10 @@ def publish_design(
     assert isinstance(config, NSConfiguration)
     config.validate()
 
-    deployer = DeployerViaArm(api_clients, config=config)
-
-    deployer.deploy_nsd_from_bicep(
+    deployer = DeployerViaArm(
+        api_clients,
+        resource_type=DeployableResourceTypes.NSD,
+        config=config,
         bicep_path=design_file,
         parameters_json_file=parameters_json_file,
         manifest_bicep_path=manifest_file,
@@ -367,6 +371,7 @@ def publish_design(
         skip=skip,
     )
 
+    deployer.deploy_nsd_from_bicep()
 
 def _generate_nsd(config: NSConfiguration, api_clients: ApiClients):
     """Generate a Network Service Design for the given config."""

--- a/src/aosm/azext_aosm/deploy/deploy_with_arm.py
+++ b/src/aosm/azext_aosm/deploy/deploy_with_arm.py
@@ -471,7 +471,7 @@ class DeployerViaArm:
         return self.pre_deployer.do_config_artifact_manifests_exist()
 
     def deploy_bicep_template(
-        self, bicep_template_path: str, parameters: Dict[Any, Any]   # TODO: Need to check carefully whether these params are different from self.parameters
+        self, bicep_template_path: str, parameters: Dict[Any, Any]
     ) -> Any:
         """
         Deploy a bicep template.

--- a/src/aosm/azext_aosm/deploy/deploy_with_arm.py
+++ b/src/aosm/azext_aosm/deploy/deploy_with_arm.py
@@ -128,8 +128,7 @@ class DeployerViaArm:
             print("Done")
             return
 
-        # if self.resource_type == VNF:
-        if isinstance(self.config, VNFConfiguration):
+        if self.resource_type == VNF:
             self._vnfd_artifact_upload()
         if self.resource_type == CNF:
             self._cnfd_artifact_upload()

--- a/src/aosm/azext_aosm/util/constants.py
+++ b/src/aosm/azext_aosm/util/constants.py
@@ -13,7 +13,7 @@ NSD = "nsd"
 SCHEMA = "schema"
 
 
-class DeployableResourceTypes(Enum):
+class DeployableResourceTypes(str, Enum):
     VNF = VNF
     CNF = CNF
     NSD = NSD

--- a/src/aosm/azext_aosm/util/constants.py
+++ b/src/aosm/azext_aosm/util/constants.py
@@ -4,15 +4,29 @@
 # --------------------------------------------------------------------------------------------
 """Constants used across aosm cli extension."""
 
+from enum import Enum
+
 # The types of definition that can be generated
 VNF = "vnf"
 CNF = "cnf"
 NSD = "nsd"
 SCHEMA = "schema"
 
+
+class DeployableResourceTypes(Enum):
+    VNF = VNF
+    CNF = CNF
+    NSD = NSD
+
 # Skip steps
 BICEP_PUBLISH = "bicep-publish"
 ARTIFACT_UPLOAD = "artifact-upload"
+IMAGE_UPLOAD = "image-upload"
+
+class SkipSteps(Enum):
+    BICEP_PUBLISH = BICEP_PUBLISH
+    ARTIFACT_UPLOAD = ARTIFACT_UPLOAD
+    IMAGE_UPLOAD = IMAGE_UPLOAD
 
 # Names of files used in the repo
 


### PR DESCRIPTION
# Main changes:

 - Moved variables onto the class instance and stop passing them around in the method signatures
   - Also made the deployer class a dataclass for cleaner \_\_init\_\_
 - Made `parameters` a property of the class, and moved the logic for getting/generating them into that property method
 - Improved the typing
   - Included adding enums for `SkipStep`s and `DeployableResourceTypes`
 - Added the new skip step logic for image uploads
   - Added a new skip step type of `IMAGE_UPLOAD`

# Testing

- No MyPy errors
- Following live tests
## VNF
  - `az aosm nfd publish -f input_files/input.json_nfd --definition-type vnf`
  - `az aosm nfd publish -f input_files/input.json_nfd --definition-type vnf --skip image-upload`
  - `az aosm nfd publish -f input_files/input.json_nfd --definition-type vnf --skip artifact-upload`
  - `az aosm nfd publish -f input_files/input.json_nfd --definition-type vnf --skip bicep-publish`
  - `az aosm nsd build -f input_files/input.json_nsd`
  - `az aosm nsd publish -f input_files/input.json_nsd`
  - `az aosm nsd publish -f input_files/input.json_nsd --skip bicep-publish`
  - `az aosm nsd publish -f input_files/input.json_nsd --skip artifact-upload`

## CNF
  - `az aosm nfd generate-config --definition-type cnf`
  - `az aosm nfd build -f input_files/input.json_nfd --definition-type cnf --interactive`
  - `az aosm nfd publish -f input_files/input.json_nfd --definition-type cnf`
  - `az aosm nfd publish -f input_files/input.json_nfd --definition-type cnf --skip bicep-publish`
  - `az aosm nfd publish -f input_files/input.json_nfd --definition-type cnf --skip image-upload`
  - `az aosm nfd publish -f input_files/input.json_nfd --definition-type cnf --skip artifact-upload`