### PR TITLE
Fix bicep render on Windows

### DIFF
--- a/src/aosm/HISTORY.rst
+++ b/src/aosm/HISTORY.rst
@@ -23,6 +23,7 @@ unreleased
 * Take Oras 0.1.18 so above Workaround could be removed
 * Take Oras 0.1.19 to fix NSD Artifact upload on Windows
 * Support deploying multiple instances of the same NF in an SNS
+* Fix CNF publish on Windows by using Linux style paths in rendered NFD bicep templates (bicep always requires Linux style paths).
 
 0.2.0
 ++++++

--- a/src/aosm/azext_aosm/generate_nfd/cnf_nfd_generator.py
+++ b/src/aosm/azext_aosm/generate_nfd/cnf_nfd_generator.py
@@ -59,7 +59,7 @@ class NFApplicationConfiguration:
     dependsOnProfile: List[str]
     registryValuesPaths: List[str]
     imagePullSecretsValuesPaths: List[str]
-    valueMappingsPath: Path
+    valueMappingsFile: str
 
 
 @dataclass
@@ -295,7 +295,6 @@ class CnfNfdGenerator(NFDGenerator):  # pylint: disable=too-many-instance-attrib
             )
 
         bicep_contents: str = template.render(
-            deployParametersPath=Path(SCHEMAS_DIR_NAME, DEPLOYMENT_PARAMETERS_FILENAME),
             nf_application_configurations=self.nf_application_configurations,
         )
 
@@ -382,7 +381,7 @@ class CnfNfdGenerator(NFDGenerator):  # pylint: disable=too-many-instance-attrib
             dependsOnProfile=helm_package.depends_on,
             registryValuesPaths=list(registry_values_paths),
             imagePullSecretsValuesPaths=list(image_pull_secrets_values_paths),
-            valueMappingsPath=self._jsonify_value_mappings(helm_package),
+            valueMappingsFile=self._jsonify_value_mappings(helm_package),
         )
 
     @staticmethod
@@ -768,8 +767,8 @@ class CnfNfdGenerator(NFDGenerator):  # pylint: disable=too-many-instance-attrib
 
         return (chart_name, chart_version)
 
-    def _jsonify_value_mappings(self, helm_package: HelmPackageConfig) -> Path:
-        """Yaml->JSON values mapping file, then return path to it."""
+    def _jsonify_value_mappings(self, helm_package: HelmPackageConfig) -> str:
+        """Yaml->JSON values mapping file, then return the filename."""
         assert self._tmp_dir
         mappings_yaml_file = helm_package.path_to_mappings
         mappings_dir = self._tmp_dir / CONFIG_MAPPINGS_DIR_NAME
@@ -784,4 +783,4 @@ class CnfNfdGenerator(NFDGenerator):  # pylint: disable=too-many-instance-attrib
             json.dump(data, file, indent=4)
 
         logger.debug("Generated parameter mappings for %s", helm_package.name)
-        return Path(CONFIG_MAPPINGS_DIR_NAME, f"{helm_package.name}-mappings.json")
+        return f"{helm_package.name}-mappings.json"

--- a/src/aosm/azext_aosm/generate_nfd/templates/cnfdefinition.bicep.j2
+++ b/src/aosm/azext_aosm/generate_nfd/templates/cnfdefinition.bicep.j2
@@ -36,7 +36,10 @@ resource nfdv 'Microsoft.Hybridnetwork/publishers/networkfunctiondefinitiongroup
   properties: {
     // versionState should be changed to 'Active' once it is finalized.
     versionState: 'Preview'
-    deployParameters: string(loadJsonContent('{{ deployParametersPath }}'))
+    {#- Note that all paths in bicep must be specified using the forward slash #}
+    {#-  (/) character even if running on Windows. #}
+    {#- See https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/modules#local-file #}
+    deployParameters: string(loadJsonContent('schemas/deploymentParameters.json'))
     networkFunctionType: 'ContainerizedNetworkFunction'
     networkFunctionTemplate: {
       nfviType: 'AzureArcKubernetes'
@@ -65,7 +68,7 @@ resource nfdv 'Microsoft.Hybridnetwork/publishers/networkfunctiondefinitiongroup
               releaseNamespace: '{{ configuration.chartName }}'
               releaseName: '{{ configuration.chartName }}'
               helmPackageVersion: '{{ configuration.chartVersion }}'
-              values: string(loadJsonContent('{{ configuration.valueMappingsPath }}'))
+              values: string(loadJsonContent('configMappings/{{ configuration.valueMappingsFile }}'))
             }
           }
         }


### PR DESCRIPTION
For CNF NFD template rendering, we were building up Python Path objects using constants, and passing these the bicep template.

On Windows, this (you would think correctly), ended up with things like loadJsonContents('schemas\deploymentParameters") in the rendered bicep.

Sadly, bicep only supports Linux style paths and so, when running the CLI on Windows, this resulted in these errors at publish time (during az bicep build step)

```
C:\Users\sunnycarter\OneDrive - Microsoft\Documents\work\Automation\Turtle\examples\nginx-cnf\nfd-bicep-nginx\cnfdefinition.bicep(39,46) : Error BCP032: The value must be a compile-time constant.
C:\Users\sunnycarter\OneDrive - Microsoft\Documents\work\Automation\Turtle\examples\nginx-cnf\nfd-bicep-nginx\cnfdefinition.bicep(39,54) : Error BCP006: The specified escape sequence is not recognized. Only the following escape sequences are allowed: "\$", "\'", "\\", "\n", "\r", "\t", "\u{...}".
C:\Users\sunnycarter\OneDrive - Microsoft\Documents\work\Automation\Turtle\examples\nginx-cnf\nfd-bicep-nginx\cnfdefinition.bicep(67,46) : Error BCP111: The specified file path contains invalid control code characters.
```

All our other templates which are rendered just hard-code the directory and path separator, so these were all fine on Windows. We were trying to do something better for CNFs (as different people have written and reviewed the code), and use constants from constants.py everywhere for maintainability.

I could have fixed this by still using those constants and getting the python to return a string with Linux separators.  Instead I've just made cnf templates look the same as all our other ones, with hard-coded directory names and separators.

Tested with nginx-cnf nfd build.  Yet to test publish as I want to get a wheel from the build to test with first, but pretty certain it will work.