### PR TITLE
Label input files as nsd or nfd respectively

### DIFF
--- a/src/aosm/azext_aosm/custom.py
+++ b/src/aosm/azext_aosm/custom.py
@@ -72,12 +72,12 @@ def build_definition(
     )
 
 
-def generate_definition_config(definition_type: str, output_file: str = "input.json"):
+def generate_definition_config(definition_type: str, output_file: str = "input-nfd.json"):
     """
     Generate an example config file for building a definition.
 
     :param definition_type: CNF, VNF
-    :param output_file: path to output config file, defaults to "input.json"
+    :param output_file: path to output config file, defaults to "input-nfd.json"
     :type output_file: str, optional
     """
     _generate_config(configuration_type=definition_type, output_file=output_file)
@@ -235,11 +235,11 @@ def delete_published_definition(
         )
 
 
-def generate_design_config(output_file: str = "input.json"):
+def generate_design_config(output_file: str = "input-nsd.json"):
     """
     Generate an example config file for building a NSD.
 
-    :param output_file: path to output config file, defaults to "input.json"
+    :param output_file: path to output config file, defaults to "input-nsd.json"
     :type output_file: str, optional
     """
     _generate_config(NSD, output_file)


### PR DESCRIPTION
Small usability request from Sushant, to label the generated config files as `input-nfd.json` or `input-nsd.json` instead of both being `input.json`.

I've not updated the quickstarts in pez-networkservicedesigns as they don't reference these filenames directly. They use their own `input.json_nfd`/`input.json_nsd`, which although ugly, does at least distinguish between NFD/NSD. Fixing those to a more normal format is more work than the super simple fix in this PR.

Testing, ran `az aosm generate-config` on an NSD and an NFD, both worked.