### PR TITLE
Label generated config input files as nsd or nfd respectively

### DIFF
--- a/src/aosm/azext_aosm/custom.py
+++ b/src/aosm/azext_aosm/custom.py
@@ -83,12 +83,12 @@ def build_definition(
     )
 
 
-def generate_definition_config(definition_type: str, output_file: str = "input.json"):
+def generate_definition_config(definition_type: str, output_file: str = "input-nfd.json"):
     """
     Generate an example config file for building a definition.
 
     :param definition_type: CNF, VNF
-    :param output_file: path to output config file, defaults to "input.json"
+    :param output_file: path to output config file, defaults to "input-nfd.json"
     :type output_file: str, optional
     """
     _generate_config(configuration_type=definition_type, output_file=output_file)
@@ -317,11 +317,11 @@ def delete_published_definition(
         )
 
 
-def generate_design_config(output_file: str = "input.json"):
+def generate_design_config(output_file: str = "input-nsd.json"):
     """
     Generate an example config file for building a NSD.
 
-    :param output_file: path to output config file, defaults to "input.json"
+    :param output_file: path to output config file, defaults to "input-nsd.json"
     :type output_file: str, optional
     """
     _generate_config(NSD, output_file)

--- a/src/aosm/azext_aosm/tests/latest/scenario_test_mocks/mock_input_templates/nsd_input.json
+++ b/src/aosm/azext_aosm/tests/latest/scenario_test_mocks/mock_input_templates/nsd_input.json
@@ -1,0 +1,21 @@
+{
+    "location": "westcentralus",
+    "publisher_name": "ubuntuPublisher",
+    "publisher_resource_group_name": "cli_test_vnf_nsd_000001",
+    "acr_artifact_store_name": "ubuntu-acr",
+    "network_functions": [
+        {
+            "name": "ubuntu-vm-nfdg",
+            "version": "1.0.0",
+            "publisher_offering_location": "westcentralus",
+            "type": "vnf",
+            "multiple_instances": false,
+            "publisher": "ubuntuPublisher",
+            "publisher_scope": "private",
+            "publisher_resource_group": "cli_test_vnf_nsd_000001"
+        }
+    ],
+    "nsdg_name": "ubuntu",
+    "nsd_version": "1.0.0",
+    "nsdv_description": "Plain ubuntu VM"
+}

--- a/src/aosm/azext_aosm/tests/latest/scenario_test_mocks/mock_input_templates/vnf_input.json
+++ b/src/aosm/azext_aosm/tests/latest/scenario_test_mocks/mock_input_templates/vnf_input.json
@@ -1,0 +1,18 @@
+{
+    "publisher_name": "ubuntuPublisher",
+    "publisher_resource_group_name": "cli_test_vnf_nsd_000001",
+    "acr_artifact_store_name": "ubuntu-acr",
+    "location": "westcentralus",
+    "nf_name": "ubuntu-vm",
+    "version": "1.0.0",
+    "blob_artifact_store_name": "ubuntu-blob-store",
+    "image_name_parameter": "imageName",
+    "arm_template": {
+        "file_path": "../vnf_mocks/ubuntu_template.json",
+        "version": "1.0.0"
+    },
+    "vhd": {
+        "file_path": "../vnf_mocks/ubuntu.vhd",
+        "version": "1-0-0"
+    }
+}

--- a/src/aosm/azext_aosm/tests/latest/test_cnf.py
+++ b/src/aosm/azext_aosm/tests/latest/test_cnf.py
@@ -15,14 +15,14 @@ mock_cnf_folder = ((Path(__file__).parent) / "mock_cnf").resolve()
 
 class TestCNF(unittest.TestCase):
     def test_generate_config(self):
-        """Test generating a config file for a VNF."""
+        """Test generating a config file for a CNF."""
         starting_directory = os.getcwd()
         with TemporaryDirectory() as test_dir:
             os.chdir(test_dir)
 
             try:
                 generate_definition_config("cnf")
-                assert os.path.exists("input.json")
+                assert os.path.exists("input-nfd.json")
             finally:
                 os.chdir(starting_directory)
 

--- a/src/aosm/azext_aosm/tests/latest/test_nsd.py
+++ b/src/aosm/azext_aosm/tests/latest/test_nsd.py
@@ -274,7 +274,7 @@ class TestNSDGenerator:
 
             try:
                 generate_design_config()
-                assert os.path.exists("input.json")
+                assert os.path.exists("input-nsd.json")
             finally:
                 os.chdir(starting_directory)
 

--- a/src/aosm/azext_aosm/tests/latest/test_vnf.py
+++ b/src/aosm/azext_aosm/tests/latest/test_vnf.py
@@ -22,7 +22,7 @@ class TestVNF(unittest.TestCase):
 
             try:
                 generate_definition_config("vnf")
-                assert os.path.exists("input.json")
+                assert os.path.exists("input-nfd.json")
             finally:
                 os.chdir(starting_directory)
 

--- a/src/aosm/development.md
+++ b/src/aosm/development.md
@@ -124,11 +124,11 @@ python-static-checks fmt
 ```
 
 ### Tests
-The tests in this repository are split into unit tests and integration tests. Both tests live in the `tests/latest` folder and can be run using the `azdev test aosm` command (you can optionally use the `--live` flag with this command as some integration tests are run only in live mode, e.g. CNF tests). All tests are expected to pass. All unit tests and Integration tests are run as part of the pipeline. 
+The tests in this repository are split into unit tests and integration tests. Both tests live in the `tests/latest` folder and can be run using the `azdev test aosm` command (you can optionally use the `--live` flag with this command as some integration tests are run only in live mode, e.g. CNF tests). All tests are expected to pass. All unit tests and Integration tests are run as part of the pipeline.
 ### Unit tests
 To get code coverage run:
 ```bash
-pip install coverage 
+pip install coverage
 cd src/aosm
 coverage erase
 coverage run -m pytest .
@@ -136,7 +136,7 @@ coverage report --include="*/src/aosm/*" --omit="*/src/aosm/azext_aosm/vendored_
 ```
 
 #### Integration tests
-The integration tests are tests which run real azure CLI commands such as `az aosm nsd publish`. When running for the first time in a repository these tests will create a real resource group (with a randomly generated name starting with "cli_test_") in the subscription that is active on your account and deploy real AOSM resources. These resources will be cleaned up after the tests have run. After the first "live" run these tests will be automatically recorded in the `tests/latest/recordings` folder. These recordings record all communication between the CLI and Azure which mean that the next time the test is run it will no longer be run live but instead will be will be run against the recorded responses. This means that the tests will run much faster and will not create any real resources. The recording also does not rely on the knowledge of a subscription and the credentials will be removed from the recordings.
+The integration tests run real azure CLI commands such as `az aosm nsd publish`. When running for the first time in a repository these tests will create a real resource group (with a randomly generated name starting with "cli_test_") in the subscription that is active on your account and deploy real AOSM resources. These resources will be cleaned up after the tests have run. After the first "live" run these tests will be automatically recorded in the `tests/latest/recordings` folder. These recordings record all communication between the CLI and Azure which mean that the next time the test is run it will no longer be run live but instead will be will be run against the recorded responses. This means that the tests will run much faster and will not create any real resources. The recording also does not rely on the knowledge of a subscription and the credentials will be removed from the recordings.
 
 If one of the publish tests fails, then it might be because you have made small tweaks and the recording is now out of date.
 Delete the relevant file under tests/latest/recordings (the file names match the name of the tests), and re-run the test.


### PR DESCRIPTION
Small usability request from Sushant, to label the generated config files as input-nfd.json or input-nsd.json instead of both being input.json.

I've not updated the quickstarts in pez-networkservicedesigns as they don't reference these filenames directly. They use their own input.json_nfd/input.json_nsd, which although ugly, does at least distinguish between NFD/NSD. Fixing those to a more normal format is more work than the super simple fix in this PR.

#Testing
Ran az aosm generate-config on an NSD and an NFD, both worked.
Also checked in the generated config files, because they'll get generated every time we run tests (which might cause confusion if we get new files to check in), plus if they change, that's another useful test.