### PR TITLE
Andy/catchup with ga branch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,6 +16,8 @@
 
 /src/alias/ @Juliehzl
 
+/src/aosm/ @sunnycarter
+
 /src/managementpartner/ @jeffrey-ace
 
 /src/eventgrid/ @kalyanaj

--- a/src/aosm/HISTORY.rst
+++ b/src/aosm/HISTORY.rst
@@ -27,7 +27,13 @@ upcoming
 * Re-order publish steps so that artifacts are uploaded before the NFD/NSD is published.
 * Add progress information for VHD upload
 * Change optional argument from `manifest_parameters_json_file` to `manifest_params_file` to appease linter.
- *NB CHANGE TO PREVIOUS CONFIG FILE FORMAT FOR NSDs - Added publisher scope and removed publisher resource group from network function object, as now using proxy references
+* NB CHANGE TO PREVIOUS CONFIG FILE FORMAT FOR NFDS
+  - Add options for CNF image upload. By default CNF images are copied from a source ACR using `az acr import` which is fast but requires subscription-wide permissions.
+  - If permissions are not available then CNF images can be copies from the source ACR using `docker pull` then `docker push`, which is slower and requires Docker to be installed. This is governed by a new --no-subscription-permissions flag.
+  - Also, if only a single image is required, it can be specified in the config file and uploaded from local docker registry using `docker push`
+  - CNF image config has been moved into an `images` section of the config file. Please run `az aosm nfd generate-config --definition-type cnf` to generate a new config file.
+  - Remove pre-deploy check to check source ACR exists. This will be found at the time that images are copied / accessed.
+  - Change from using ContainerRegistryManagementClient to `az acr import` subprocess call, so that we don't need to know the Resource Group.
 
 0.2.0
 ++++++

--- a/src/aosm/HISTORY.rst
+++ b/src/aosm/HISTORY.rst
@@ -34,7 +34,8 @@ upcoming
   - CNF image config has been moved into an `images` section of the config file. Please run `az aosm nfd generate-config --definition-type cnf` to generate a new config file.
   - Remove pre-deploy check to check source ACR exists. This will be found at the time that images are copied / accessed.
   - Change from using ContainerRegistryManagementClient to `az acr import` subprocess call, so that we don't need to know the Resource Group.
-
+* NB CHANGE TO PREVIOUS CONFIG FILE FORMAT FOR NSDs
+  - Added publisher scope and removed publisher resource group from network function object, as now using proxy references
 0.2.0
 ++++++
 Breaking change to commands - now use `nfd` instead of `definition`. Publish option removed from build.

--- a/src/aosm/azext_aosm/_client_factory.py
+++ b/src/aosm/azext_aosm/_client_factory.py
@@ -25,15 +25,3 @@ def cf_features(cli_ctx, subscription_id=None):
     return get_mgmt_service_client(
         cli_ctx, ResourceType.MGMT_RESOURCE_FEATURES, subscription_id=subscription_id
     )
-
-
-def cf_acr_registries(cli_ctx, *_) -> ContainerRegistryManagementClient:
-    """
-    Returns the client for managing container registries.
-
-    :param cli_ctx: CLI context
-    :return: ContainerRegistryManagementClient object
-    """
-    return get_mgmt_service_client(
-        cli_ctx, ResourceType.MGMT_CONTAINERREGISTRY
-    ).registries

--- a/src/aosm/azext_aosm/_client_factory.py
+++ b/src/aosm/azext_aosm/_client_factory.py
@@ -20,6 +20,13 @@ def cf_resources(cli_ctx, subscription_id=None):
     )
 
 
+def cf_features(cli_ctx, subscription_id=None):
+    """Return the client for checking feature enablement."""
+    return get_mgmt_service_client(
+        cli_ctx, ResourceType.MGMT_RESOURCE_FEATURES, subscription_id=subscription_id
+    )
+
+
 def cf_acr_registries(cli_ctx, *_) -> ContainerRegistryManagementClient:
     """
     Returns the client for managing container registries.

--- a/src/aosm/azext_aosm/_client_factory.py
+++ b/src/aosm/azext_aosm/_client_factory.py
@@ -5,7 +5,6 @@
 
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.profiles import ResourceType
-from azure.mgmt.containerregistry import ContainerRegistryManagementClient
 
 from .vendored_sdks import HybridNetworkManagementClient
 

--- a/src/aosm/azext_aosm/_client_factory.py
+++ b/src/aosm/azext_aosm/_client_factory.py
@@ -5,6 +5,7 @@
 
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.profiles import ResourceType
+from azure.mgmt.containerregistry import ContainerRegistryManagementClient
 
 from .vendored_sdks import HybridNetworkManagementClient
 

--- a/src/aosm/azext_aosm/_configuration.py
+++ b/src/aosm/azext_aosm/_configuration.py
@@ -338,12 +338,23 @@ class CNFConfiguration(NFConfiguration):
             and self.images.source_local_docker_image
             != DESCRIPTION_MAP["source_local_docker_image"]
         )
+        source_reg_namespace_set = (
+            self.images.source_registry_namespace
+            and self.images.source_registry_namespace
+            != DESCRIPTION_MAP["source_registry_namespace"]
+        )
 
         # If these are the same, either neither is set or both are, both of which are errors
         if source_reg_set == source_local_set:
             raise ValidationError(
                 "Config validation error. Images config must have either a local docker image"
-                " or a source registry."
+                " or a source registry, but not both."
+            )
+
+        if source_reg_namespace_set and not source_reg_set:
+            raise ValidationError(
+                "Config validation error. The image source registry namespace should "
+                "only be configured if a source registry is configured."
             )
 
 

--- a/src/aosm/azext_aosm/_configuration.py
+++ b/src/aosm/azext_aosm/_configuration.py
@@ -20,7 +20,6 @@ from azext_aosm.util.constants import (
     NSD,
     NSD_OUTPUT_BICEP_PREFIX,
     VNF,
-    SOURCE_ACR_REGEX,
 )
 
 logger = logging.getLogger(__name__)
@@ -87,13 +86,21 @@ DESCRIPTION_MAP: Dict[str, str] = {
         "The parameter name in the VM ARM template which specifies the name of the "
         "image to use for the VM."
     ),
-    "source_registry_id": (
-        "Resource ID of the source acr registry from which to pull the image."
+    "source_registry": (
+        "Optional. Login server of the source acr registry from which to pull the "
+        "image(s). For example sourceacr.azurecr.io. Leave blank if you have set "
+        "source_local_docker_image."
+    ),
+    "source_local_docker_image": (
+        "Optional. Image name of the source docker image from local machine. For "
+        "limited use case where the CNF only requires a single docker image and exists "
+        "in the local docker repository. Set to blank of not required."
     ),
     "source_registry_namespace": (
         "Optional. Namespace of the repository of the source acr registry from which "
         "to pull. For example if your repository is samples/prod/nginx then set this to"
-        " samples/prod . Leave blank if the image is in the root namespace."
+        " samples/prod . Leave blank if the image is in the root namespace or you have "
+        "set source_local_docker_image."
         "See https://learn.microsoft.com/en-us/azure/container-registry/"
         "container-registry-best-practices#repository-namespaces for further details."
     ),
@@ -277,12 +284,19 @@ class HelmPackageConfig:
     depends_on: List[str] = field(
         default_factory=lambda: [DESCRIPTION_MAP["helm_depends_on"]]
     )
+    
+@dataclass
+class CNFImageConfig:
+    """CNF Image config settings."""
+    source_registry: str = DESCRIPTION_MAP["source_registry"]
+    source_registry_namespace: str = DESCRIPTION_MAP["source_registry_namespace"]
+    source_local_docker_image: str = DESCRIPTION_MAP["source_local_docker_image"]
 
 
 @dataclass
 class CNFConfiguration(NFConfiguration):
-    source_registry_id: str = DESCRIPTION_MAP["source_registry_id"]
-    source_registry_namespace: str = DESCRIPTION_MAP["source_registry_namespace"]
+
+    images: Any = CNFImageConfig()
     helm_packages: List[Any] = field(default_factory=lambda: [HelmPackageConfig()])
 
     def __post_init__(self):
@@ -300,6 +314,9 @@ class CNFConfiguration(NFConfiguration):
                     package["path_to_mappings"]
                 )
                 self.helm_packages[package_index] = HelmPackageConfig(**dict(package))
+        if isinstance(self.images, dict):
+            self.images = CNFImageConfig(**self.images)
+        self.validate()
 
     @property
     def output_directory_for_build(self) -> Path:
@@ -312,15 +329,20 @@ class CNFConfiguration(NFConfiguration):
 
         :raises ValidationError: If source registry ID doesn't match the regex
         """
-        if self.source_registry_id == DESCRIPTION_MAP["source_registry_id"]:
-            # Config has not been filled in. Don't validate.
-            return
+        source_reg_set = (
+            self.images.source_registry
+            and self.images.source_registry != DESCRIPTION_MAP["source_registry"]
+        )
+        source_local_set = (
+            self.images.source_local_docker_image
+            and self.images.source_local_docker_image != DESCRIPTION_MAP["source_local_docker_image"]
+        )
 
-        source_registry_match = re.search(SOURCE_ACR_REGEX, self.source_registry_id)
-        if not source_registry_match or len(source_registry_match.groups()) < 2:
+        # If these are the same, either neither is set or both are, both of which are errors
+        if source_reg_set == source_local_set:
             raise ValidationError(
-                "CNF config has an invalid source registry ID. Please run `az aosm "
-                "nfd generate-config` to see the valid formats."
+                "Config validation error. Images config must have either a local docker image"
+                " or a source registry."
             )
 
 
@@ -528,22 +550,31 @@ def get_configuration(
     :return: The configuration object
     """
     if config_file:
-        with open(config_file, "r", encoding="utf-8") as f:
-            config_as_dict = json.loads(f.read())
+        try:
+            with open(config_file, "r", encoding="utf-8") as f:
+                config_as_dict = json.loads(f.read())
+        except json.decoder.JSONDecodeError as e:
+            raise InvalidArgumentValueError(
+                f"Config file {config_file} is not valid JSON: {e}"
+            )
     else:
         config_as_dict = {}
 
     config: Configuration
-
-    if configuration_type == VNF:
-        config = VNFConfiguration(config_file=config_file, **config_as_dict)
-    elif configuration_type == CNF:
-        config = CNFConfiguration(config_file=config_file, **config_as_dict)
-    elif configuration_type == NSD:
-        config = NSConfiguration(config_file=config_file, **config_as_dict)
-    else:
+    try:
+        if configuration_type == VNF:
+            config = VNFConfiguration(config_file=config_file, **config_as_dict)
+        elif configuration_type == CNF:
+            config = CNFConfiguration(config_file=config_file, **config_as_dict)
+        elif configuration_type == NSD:
+            config = NSConfiguration(config_file=config_file, **config_as_dict)
+        else:
+            raise InvalidArgumentValueError(
+                "Definition type not recognized, options are: vnf, cnf or nsd"
+            )
+    except TypeError as typeerr:
         raise InvalidArgumentValueError(
-            "Definition type not recognized, options are: vnf, cnf or nsd"
-        )
+            f"Config file {config_file} is not valid: {typeerr}"
+        ) from typeerr
 
     return config

--- a/src/aosm/azext_aosm/_configuration.py
+++ b/src/aosm/azext_aosm/_configuration.py
@@ -377,7 +377,7 @@ MULTIPLE_INSTANCES = (
 
 
 @dataclass
-class NFDRETConfiguration:
+class NFDRETConfiguration:  # pylint: disable=too-many-instance-attributes
     """The configuration required for an NFDV that you want to include in an NSDV."""
 
     publisher: str = PUBLISHER_NAME

--- a/src/aosm/azext_aosm/_configuration.py
+++ b/src/aosm/azext_aosm/_configuration.py
@@ -284,10 +284,12 @@ class HelmPackageConfig:
     depends_on: List[str] = field(
         default_factory=lambda: [DESCRIPTION_MAP["helm_depends_on"]]
     )
-    
+
+
 @dataclass
 class CNFImageConfig:
     """CNF Image config settings."""
+
     source_registry: str = DESCRIPTION_MAP["source_registry"]
     source_registry_namespace: str = DESCRIPTION_MAP["source_registry_namespace"]
     source_local_docker_image: str = DESCRIPTION_MAP["source_local_docker_image"]
@@ -295,7 +297,6 @@ class CNFImageConfig:
 
 @dataclass
 class CNFConfiguration(NFConfiguration):
-
     images: Any = CNFImageConfig()
     helm_packages: List[Any] = field(default_factory=lambda: [HelmPackageConfig()])
 
@@ -335,7 +336,8 @@ class CNFConfiguration(NFConfiguration):
         )
         source_local_set = (
             self.images.source_local_docker_image
-            and self.images.source_local_docker_image != DESCRIPTION_MAP["source_local_docker_image"]
+            and self.images.source_local_docker_image
+            != DESCRIPTION_MAP["source_local_docker_image"]
         )
 
         # If these are the same, either neither is set or both are, both of which are errors

--- a/src/aosm/azext_aosm/_configuration.py
+++ b/src/aosm/azext_aosm/_configuration.py
@@ -7,7 +7,6 @@ import abc
 import logging
 import json
 import os
-import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
@@ -558,7 +557,7 @@ def get_configuration(
         except json.decoder.JSONDecodeError as e:
             raise InvalidArgumentValueError(
                 f"Config file {config_file} is not valid JSON: {e}"
-            )
+            ) from e
     else:
         config_as_dict = {}
 

--- a/src/aosm/azext_aosm/_configuration.py
+++ b/src/aosm/azext_aosm/_configuration.py
@@ -316,7 +316,7 @@ class CNFConfiguration(NFConfiguration):
                 self.helm_packages[package_index] = HelmPackageConfig(**dict(package))
         if isinstance(self.images, dict):
             self.images = CNFImageConfig(**self.images)
-        self.validate()
+            self.validate()
 
     @property
     def output_directory_for_build(self) -> Path:

--- a/src/aosm/azext_aosm/_params.py
+++ b/src/aosm/azext_aosm/_params.py
@@ -121,6 +121,21 @@ def load_arguments(self: AzCommandsLoader, _):
                 "container images (for CNFs)."
             ),
         )
+        c.argument(
+            "no_subscription_permissions",
+            options_list=["--no-subscription-permissions", "-u"],
+            arg_type=get_three_state_flag(),
+            help=(
+                "CNF definition_type publish only - ignored for VNF."
+                " Set to True if you do not "
+                "have permission to import to the Publisher subscription (Contributor "
+                "role + AcrPush role, or a custom role that allows the importImage "
+                "action and AcrPush over the "
+                "whole subscription). This means that the image artifacts will be "
+                "pulled to your local machine and then pushed to the Artifact Store. "
+                "Requires Docker to be installed locally."
+            ),
+        )
 
     with self.argument_context("aosm nsd") as c:
         c.argument(

--- a/src/aosm/azext_aosm/custom.py
+++ b/src/aosm/azext_aosm/custom.py
@@ -19,7 +19,7 @@ from azure.cli.core.commands import AzCliCommand
 from azure.core import exceptions as azure_exceptions
 from knack.log import get_logger
 
-from azext_aosm._client_factory import cf_acr_registries, cf_features, cf_resources
+from azext_aosm._client_factory import cf_features, cf_resources
 from azext_aosm._configuration import (
     CNFConfiguration,
     Configuration,
@@ -202,6 +202,7 @@ def publish_definition(
     manifest_file: Optional[str] = None,
     manifest_params_file: Optional[str] = None,
     skip: Optional[SkipSteps] = None,
+    no_subscription_permissions: bool = False,
 ):
     """
     Publish a generated definition.
@@ -217,16 +218,22 @@ def publish_definition(
     :param definition_type: VNF or CNF
     :param config_file: Path to the config file for the NFDV
     :param definition_file: Optional path to a bicep template to deploy, in case the
-        user wants to edit the built NFDV template.
-        If omitted, the default built NFDV template will be used.
+        user wants to edit the built NFDV template. If omitted, the default built NFDV
+        template will be used.
     :param parameters_json_file: Optional path to a parameters file for the bicep file,
-        in case the user wants to edit the built NFDV template. If omitted,
-        parameters from config will be turned into parameters for the bicep file
+        in case the user wants to edit the built NFDV template. If omitted, parameters
+        from config will be turned into parameters for the bicep file
     :param manifest_file: Optional path to an override bicep template to deploy
         manifests
-    :param manifest_params_file: Optional path to an override bicep parameters
-        file for manifest parameters
+    :param manifest_params_file: Optional path to an override bicep parameters file for
+        manifest parameters
     :param skip: options to skip, either publish bicep or upload artifacts
+    :param no_subscription_permissions:
+            CNF definition_type publish only - ignored for VNF. Causes the image
+            artifact copy from a source ACR to be done via docker pull and push,
+            rather than `az acr import`. This is slower but does not require
+            Contributor (or importImage action) and AcrPush permissions on the publisher
+            subscription. It requires Docker to be installed.
     """
     # Check that the required features are enabled on the subscription
     _check_features_enabled(cmd)
@@ -235,7 +242,6 @@ def publish_definition(
     api_clients = ApiClients(
         aosm_client=client,
         resource_client=cf_resources(cmd.cli_ctx),
-        container_registry_client=cf_acr_registries(cmd.cli_ctx),
     )
 
     if definition_type not in (VNF, CNF):
@@ -258,6 +264,7 @@ def publish_definition(
         manifest_params_file=manifest_params_file,
         skip=skip,
         cli_ctx=cmd.cli_ctx,
+        use_manifest_permissions=no_subscription_permissions,
     )
     deployer.deploy_nfd_from_bicep()
 

--- a/src/aosm/azext_aosm/custom.py
+++ b/src/aosm/azext_aosm/custom.py
@@ -15,9 +15,11 @@ from azure.cli.core.azclierror import (
     InvalidArgumentValueError,
     UnclassifiedUserFault,
 )
+from azure.cli.core.commands import AzCliCommand
+from azure.core import exceptions as azure_exceptions
 from knack.log import get_logger
 
-from azext_aosm._client_factory import cf_acr_registries, cf_resources
+from azext_aosm._client_factory import cf_acr_registries, cf_features, cf_resources
 from azext_aosm._configuration import (
     CNFConfiguration,
     Configuration,
@@ -32,7 +34,15 @@ from azext_aosm.generate_nfd.cnf_nfd_generator import CnfNfdGenerator
 from azext_aosm.generate_nfd.nfd_generator_base import NFDGenerator
 from azext_aosm.generate_nfd.vnf_nfd_generator import VnfNfdGenerator
 from azext_aosm.generate_nsd.nsd_generator import NSDGenerator
-from azext_aosm.util.constants import CNF, DeployableResourceTypes, NSD, SkipSteps, VNF
+from azext_aosm.util.constants import (
+    AOSM_FEATURE_NAMESPACE,
+    AOSM_REQUIRED_FEATURES,
+    CNF,
+    NSD,
+    VNF,
+    DeployableResourceTypes,
+    SkipSteps,
+)
 from azext_aosm.util.management_clients import ApiClients
 from azext_aosm.vendored_sdks import HybridNetworkManagementClient
 
@@ -49,10 +59,11 @@ def build_definition(
     """
     Build a definition.
 
-    :param cmd:
-    :type cmd: _type_
+    :param definition_type: VNF or CNF
     :param config_file: path to the file
     :param definition_type: VNF, CNF
+    :param interactive - whether to prompt for input when creating deploy parameters
+                         mapping files
     :param force: force the build even if the design has already been built
     """
 
@@ -135,8 +146,54 @@ def _generate_nfd(
     nfd_generator.generate_nfd()
 
 
+def _check_features_enabled(cmd: AzCliCommand):
+    """
+    Check that the required Azure features are enabled on the subscription.
+
+    :param cmd: The AzCLICommand object for the original command that was run, we use
+        this to retrieve the CLI context in order to get the features client for access
+        to the features API.
+    """
+    features_client = cf_features(cmd.cli_ctx)
+    # Check that the required features are enabled on the subscription
+    for feature in AOSM_REQUIRED_FEATURES:
+        try:
+            feature_result = features_client.features.get(
+                resource_provider_namespace=AOSM_FEATURE_NAMESPACE,
+                feature_name=feature,
+            )
+            if (
+                not feature_result
+                or not feature_result.properties.state == "Registered"
+            ):
+                # We don't want to log the name of the feature to the user as it is
+                # a hidden feature.  We do want to log it to the debug log though.
+                logger.debug(
+                    "Feature %s is not registered on the subscription.", feature
+                )
+                raise CLIInternalError(
+                    "Your Azure subscription has not been fully onboarded to AOSM. "
+                    "Please see the AOSM onboarding documentation for more information."
+                )
+        except azure_exceptions.ResourceNotFoundError as rerr:
+            # If the feature is not found, it is not registered, but also something has
+            # gone wrong with the CLI code and onboarding instructions.
+            logger.debug(
+                "Feature not found error - Azure doesn't recognise the feature %s."
+                "This indicates a coding error or error with the AOSM onboarding "
+                "instructions.",
+                feature,
+            )
+            logger.debug(rerr)
+            raise CLIInternalError(
+                "CLI encountered an error checking that your "
+                "subscription has been onboarded to AOSM. Please raise an issue against"
+                " the CLI."
+            ) from rerr
+
+
 def publish_definition(
-    cmd,
+    cmd: AzCliCommand,
     client: HybridNetworkManagementClient,
     definition_type,
     config_file,
@@ -149,8 +206,13 @@ def publish_definition(
     """
     Publish a generated definition.
 
-    :param cmd:
-    :param client:
+    :param cmd: The AzCLICommand object for the command that was run, we use this to
+                find the CLI context (from which, for example, subscription id and
+                credentials can be found, and other clients can be generated.)
+    :param client: The AOSM client. This is created in _client_factory.py and passed
+                   in by commands.py - we could alternatively just use cf_aosm as
+                   we use cf_resources, but other extensions seem to pass a client
+                   around like this.
     :type client: HybridNetworkManagementClient
     :param definition_type: VNF or CNF
     :param config_file: Path to the config file for the NFDV
@@ -166,6 +228,9 @@ def publish_definition(
         file for manifest parameters
     :param skip: options to skip, either publish bicep or upload artifacts
     """
+    # Check that the required features are enabled on the subscription
+    _check_features_enabled(cmd)
+
     print("Publishing definition.")
     api_clients = ApiClients(
         aosm_client=client,
@@ -198,7 +263,7 @@ def publish_definition(
 
 
 def delete_published_definition(
-    cmd,
+    cmd: AzCliCommand,
     client: HybridNetworkManagementClient,
     definition_type,
     config_file,
@@ -208,6 +273,13 @@ def delete_published_definition(
     """
     Delete a published definition.
 
+    :param cmd: The AzCLICommand object for the command that was run, we use this to
+                find the CLI context (from which, for example, subscription id and
+                credentials can be found, and other clients can be generated.)
+    :param client: The AOSM client. This is created in _client_factory.py and passed
+                   in by commands.py - we could alternatively just use cf_aosm as
+                   we use cf_resources, but other extensions seem to pass a client
+                   around like this.
     :param definition_type: CNF or VNF
     :param config_file: Path to the config file
     :param clean: if True, will delete the NFDG, artifact stores and publisher too.
@@ -215,6 +287,9 @@ def delete_published_definition(
         with care.
     :param force: if True, will not prompt for confirmation before deleting the resources.
     """
+    # Check that the required features are enabled on the subscription
+    _check_features_enabled(cmd)
+
     config = _get_config_from_file(
         config_file=config_file, configuration_type=definition_type
     )
@@ -282,14 +357,21 @@ def _generate_config(configuration_type: str, output_file: str = "input.json"):
 
 
 def build_design(
-    cmd, client: HybridNetworkManagementClient, config_file: str, force: bool = False
+    cmd: AzCliCommand,
+    client: HybridNetworkManagementClient,
+    config_file: str,
+    force: bool = False,
 ):
     """
     Build a Network Service Design.
 
-    :param cmd:
-    :type cmd: _type_
-    :param client:
+    :param cmd: The AzCLICommand object for the command that was run, we use this to
+                find the CLI context (from which, for example, subscription id and
+                credentials can be found, and other clients can be generated.)
+    :param client: The AOSM client. This is created in _client_factory.py and passed
+                   in by commands.py - we could alternatively just use cf_aosm as
+                   we use cf_resources, but other extensions seem to pass a client
+                   around like this.
     :type client: HybridNetworkManagementClient
     :param config_file: path to the file
     :param force: force the build, even if the design has already been built
@@ -314,7 +396,7 @@ def build_design(
 
 
 def delete_published_design(
-    cmd,
+    cmd: AzCliCommand,
     client: HybridNetworkManagementClient,
     config_file,
     clean=False,
@@ -323,6 +405,13 @@ def delete_published_design(
     """
     Delete a published NSD.
 
+    :param cmd: The AzCLICommand object for the command that was run, we use this to
+                find the CLI context (from which, for example, subscription id and
+                credentials can be found, and other clients can be generated.)
+    :param client: The AOSM client. This is created in _client_factory.py and passed
+                   in by commands.py - we could alternatively just use cf_aosm as
+                   we use cf_resources, but other extensions seem to pass a client
+                   around like this.
     :param config_file: Path to the config file
     :param clean: if True, will delete the NSDG, artifact stores and publisher too.
                   Defaults to False. Only works if no resources have those as a parent.
@@ -330,6 +419,9 @@ def delete_published_design(
     :param clean: if True, will delete the NSDG on top of the other resources.
     :param force: if True, will not prompt for confirmation before deleting the resources.
     """
+    # Check that the required features are enabled on the subscription
+    _check_features_enabled(cmd)
+
     config = _get_config_from_file(config_file=config_file, configuration_type=NSD)
 
     api_clients = ApiClients(
@@ -341,7 +433,7 @@ def delete_published_design(
 
 
 def publish_design(
-    cmd,
+    cmd: AzCliCommand,
     client: HybridNetworkManagementClient,
     config_file,
     design_file: Optional[str] = None,
@@ -353,8 +445,13 @@ def publish_design(
     """
     Publish a generated design.
 
-    :param cmd:
-    :param client:
+    :param cmd: The AzCLICommand object for the command that was run, we use this to
+                find the CLI context (from which, for example, subscription id and
+                credentials can be found, and other clients can be generated.)
+    :param client: The AOSM client. This is created in _client_factory.py and passed
+                   in by commands.py - we could alternatively just use cf_aosm as
+                   we use cf_resources, but other extensions seem to pass a client
+                   around like this.
     :type client: HybridNetworkManagementClient
     :param config_file: Path to the config file for the NSDV
     :param design_file: Optional path to an override bicep template to deploy the NSDV.
@@ -368,6 +465,8 @@ def publish_design(
                         file for manifest parameters
     :param skip: options to skip, either publish bicep or upload artifacts
     """
+    # Check that the required features are enabled on the subscription
+    _check_features_enabled(cmd)
 
     print("Publishing design.")
     api_clients = ApiClients(

--- a/src/aosm/azext_aosm/deploy/artifact.py
+++ b/src/aosm/azext_aosm/deploy/artifact.py
@@ -311,8 +311,8 @@ class Artifact:
         """Format the acr url, artifact name and version into a target image string."""
         if include_hostname:
             return f"{self._get_acr()}" f"/{self.artifact_name}:{self.artifact_version}"
-        else:
-            return f"{self.artifact_name}:{self.artifact_version}"
+
+        return f"{self.artifact_name}:{self.artifact_version}"
 
     def _check_tool_installed(self, tool_name: str) -> None:
         """
@@ -566,16 +566,16 @@ class Artifact:
                     " only to the store. This requires Docker to be installed"
                     " locally."
                 ) from error
-            else:
-                # The most likely failure is that the image already exists in the
-                # artifact store, so don't fail at this stage, log the error.
-                logger.error(
-                    (
-                        "Failed to import %s to %s. Check if this image exists in the"
-                        " source registry or is already present in the target registry.\n"
-                        "%s"
-                    ),
-                    source_image,
-                    target_acr,
-                    error,
-                )
+
+            # The most likely failure is that the image already exists in the artifact
+            # store, so don't fail at this stage, log the error.
+            logger.error(
+                (
+                    "Failed to import %s to %s. Check if this image exists in the"
+                    " source registry or is already present in the target registry.\n"
+                    "%s"
+                ),
+                source_image,
+                target_acr,
+                error,
+            )

--- a/src/aosm/azext_aosm/deploy/artifact.py
+++ b/src/aosm/azext_aosm/deploy/artifact.py
@@ -100,7 +100,7 @@ class Artifact:
             logger.debug("Failed to run %s with %s", cmd, error)
 
             all_output: str = (
-                f"Command 401: {'' ''.join(cmd)}\n"
+                f"Command: {'' ''.join(cmd)}\n"
                 f"Output: {error.stdout}\n"
                 f"Error output: {error.stderr}\n"
                 f"Return code: {error.returncode}"
@@ -293,10 +293,9 @@ class Artifact:
 
     def _get_acr(self) -> str:
         """
-        _summary_
+        Get the name of the ACR
 
-        :return: _description_
-        :rtype: str
+        :return: The name of the ACR
         """
         if not self.artifact_client.remote.hostname:
             raise ValueError(
@@ -310,7 +309,7 @@ class Artifact:
     ) -> str:
         """Format the acr url, artifact name and version into a target image string."""
         if include_hostname:
-            return f"{self._get_acr()}" f"/{self.artifact_name}:{self.artifact_version}"
+            return f"{self._get_acr()}/{self.artifact_name}:{self.artifact_version}"
 
         return f"{self.artifact_name}:{self.artifact_version}"
 

--- a/src/aosm/azext_aosm/deploy/artifact.py
+++ b/src/aosm/azext_aosm/deploy/artifact.py
@@ -545,13 +545,15 @@ class Artifact:
                 # As we shell out the the subprocess, I think checking for these strings
                 # is the best check we can do for permission failures.
                 raise CLIError(
-                    " Failed to import image.\nIt looks like you do not have"
+                    " Failed to import image.\nIt looks like either the source_registry"
+                    " in your config file does not exist or the image doesn't exist or"
+                    " you do not have"
                     " permissions to import images. You need to have Reader/AcrPull"
                     f" from {source_registry_login_server}, and Contributor role +"
                     " AcrPush role, or a custom"
                     " role that allows the importImage action and AcrPush over the"
                     " whole subscription in order to be able to import to the new"
-                    " Artifact store.\n\n If you do not have the latter then you"
+                    " Artifact store.\n\nIf you do not have the latter then you"
                     " can re-run the command using the --no-subscription-permissions"
                     " flag to pull the image to your local machine and then"
                     " push it to the Artifact Store using manifest credentials scoped"

--- a/src/aosm/azext_aosm/deploy/artifact.py
+++ b/src/aosm/azext_aosm/deploy/artifact.py
@@ -297,6 +297,7 @@ class Artifact:
 
         :return: The name of the ACR
         """
+        assert hasattr(self.artifact_client, "remote")
         if not self.artifact_client.remote.hostname:
             raise ValueError(
                 "Cannot upload artifact. Oras client has no remote hostname."
@@ -390,6 +391,7 @@ class Artifact:
         :param target_password: The password to use for the az acr login attempt
         :type target_password: str
         """
+        assert hasattr(self.artifact_client, "remote")
         target_acr = self._get_acr()
         try:
             target = self._get_acr_target_image()

--- a/src/aosm/azext_aosm/deploy/artifact_manifest.py
+++ b/src/aosm/azext_aosm/deploy/artifact_manifest.py
@@ -26,6 +26,7 @@ from azext_aosm.vendored_sdks.models import (
 
 logger = get_logger(__name__)
 
+
 class ArtifactManifestOperator:
     """ArtifactManifest class."""
 

--- a/src/aosm/azext_aosm/deploy/artifact_manifest.py
+++ b/src/aosm/azext_aosm/deploy/artifact_manifest.py
@@ -26,14 +26,6 @@ from azext_aosm.vendored_sdks.models import (
 
 logger = get_logger(__name__)
 
-class BearerTokenCredential(TokenCredential):
-    def __init__(self, token: str, expiry: int):
-        self._token: AccessToken = AccessToken(token, expiry)
-        #self._token.token = token
-        
-    def get_token(self, *scopes, **kwargs):
-        return self._token
-
 class ArtifactManifestOperator:
     """ArtifactManifest class."""
 
@@ -75,25 +67,6 @@ class ArtifactManifestOperator:
             username=self._manifest_credentials["username"],
             password=self._manifest_credentials["acr_token"],
         )
-
-        return client
-
-    @lru_cache(maxsize=32)  # noqa: B019
-    def container_registry_client(self, subscription_id: str) -> ContainerRegistryManagementClient:
-        """Get a container registry client authenticated with the manifest credentials.
-
-        :param subscription_id: _description_
-        :type subscription_id: str
-        :return: _description_
-        :rtype: ContainerRegistryManagementClient
-        """
-        expiry_dt = parser.parse(self._manifest_credentials["expiry"])
-        client = ContainerRegistryManagementClient(
-            credential=BearerTokenCredential(
-                self._manifest_credentials["acr_token"],
-                int(round(expiry_dt.timestamp()))),
-            subscription_id=subscription_id,
-        )
         return client
 
     def _get_artifact_list(self) -> List[Artifact]:
@@ -129,6 +102,7 @@ class ArtifactManifestOperator:
                         artifact_type=artifact.artifact_type,
                         artifact_version=artifact.artifact_version,
                         artifact_client=self._get_artifact_client(artifact),
+                        manifest_credentials=self._manifest_credentials,
                     )
                 )
 

--- a/src/aosm/azext_aosm/deploy/artifact_manifest.py
+++ b/src/aosm/azext_aosm/deploy/artifact_manifest.py
@@ -1,16 +1,11 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Highly Confidential Material
 """A module to handle interacting with artifact manifests."""
-import datetime
-import math
-from dateutil import parser
 from functools import cached_property, lru_cache
 from typing import Any, List, Union
 
 from azure.cli.core.azclierror import AzCLIError
 from azure.storage.blob import BlobClient
-from azure.mgmt.containerregistry import ContainerRegistryManagementClient
-from azure.core.credentials import TokenCredential, AccessToken
 from knack.log import get_logger
 from oras.client import OrasClient
 

--- a/src/aosm/azext_aosm/deploy/deploy_with_arm.py
+++ b/src/aosm/azext_aosm/deploy/deploy_with_arm.py
@@ -248,7 +248,10 @@ class DeployerViaArm:  # pylint: disable=too-many-instance-attributes
 
         # This is the first time we have easy access to the number of images to upload
         # so we validate the config file here.
-        if (len(artifact_dictionary.values()) > 1 and self.config.images.source_local_docker_image):
+        if (
+            len(artifact_dictionary.values()) > 1
+            and self.config.images.source_local_docker_image
+        ):
             raise ValidationError(
                 "Multiple image artifacts found to upload and a local docker image"
                 " was specified in the config file. source_local_docker_image is only "

--- a/src/aosm/azext_aosm/deploy/deploy_with_arm.py
+++ b/src/aosm/azext_aosm/deploy/deploy_with_arm.py
@@ -517,8 +517,8 @@ class DeployerViaArm:  # pylint: disable=too-many-instance-attributes
         Deploy a bicep template.
 
         :param bicep_template_path: Path to the bicep template
-        :param parameters: Parameters for the bicep template :return Any output that the
-            template produces
+        :param parameters: Parameters for the bicep template
+        :return Any output that the template produces
         """
         logger.info("Deploy %s", bicep_template_path)
         logger.debug("Parameters: %s", parameters)
@@ -559,8 +559,9 @@ class DeployerViaArm:  # pylint: disable=too-many-instance-attributes
         :param template: The JSON contents of the template to deploy
         :param parameters: The JSON contents of the parameters file
         :param resource_group: The name of the resource group that has been deployed
-            :raise RuntimeError if validation or deploy fails
+
         :return: Output dictionary from the bicep template.
+        :raise RuntimeError if validation or deploy fails
         """
         # Get current time from the time module and remove all digits after the decimal
         # point

--- a/src/aosm/azext_aosm/deploy/pre_deploy.py
+++ b/src/aosm/azext_aosm/deploy/pre_deploy.py
@@ -4,7 +4,6 @@
 # --------------------------------------------------------------------------------------
 """Contains class for deploying resources required by NFDs/NSDs via the SDK."""
 
-import re
 from typing import Optional
 
 from azure.cli.core.azclierror import AzCLIError

--- a/src/aosm/azext_aosm/deploy/pre_deploy.py
+++ b/src/aosm/azext_aosm/deploy/pre_deploy.py
@@ -16,9 +16,7 @@ from knack.log import get_logger
 from azext_aosm._configuration import (
     Configuration,
     VNFConfiguration,
-    CNFConfiguration,
 )
-from azext_aosm.util.constants import SOURCE_ACR_REGEX
 from azext_aosm.util.management_clients import ApiClients
 from azext_aosm.vendored_sdks.models import (
     ArtifactStore,
@@ -136,37 +134,6 @@ class PreDeployerViaSDK:
             publisher_name=self.config.publisher_name,
             location=self.config.location,
         )
-
-    def ensure_config_source_registry_exists(self) -> None:
-        """
-        Ensures that the source registry exists.
-
-        Finds the parameters from self.config
-        """
-        assert isinstance(self.config, CNFConfiguration)
-        logger.info(
-            "Check if the source registry %s exists",
-            self.config.source_registry_id,
-        )
-
-        # Match the source registry format
-        source_registry_match = re.search(
-            SOURCE_ACR_REGEX, self.config.source_registry_id
-        )
-        # Config validation has already checked and raised an error if the regex doesn't
-        # match
-        if source_registry_match and len(source_registry_match.groups()) > 1:
-            source_registry_resource_group_name = source_registry_match.group(
-                "resource_group"
-            )
-            source_registry_name = source_registry_match.group("registry_name")
-
-            # This will raise an error if the registry does not exist
-            assert self.api_clients.container_registry_client
-            self.api_clients.container_registry_client.get(
-                resource_group_name=source_registry_resource_group_name,
-                registry_name=source_registry_name,
-            )
 
     def ensure_artifact_store_exists(
         self,

--- a/src/aosm/azext_aosm/tests/latest/mock_cnf/input-nf-agent-cnf.json
+++ b/src/aosm/azext_aosm/tests/latest/mock_cnf/input-nf-agent-cnf.json
@@ -5,7 +5,9 @@
     "version": "0.1.0",
     "acr_artifact_store_name": "sunny-nfagent-acr-2",
     "location": "uksouth",
-    "source_registry_id": "--this was copied here and renamed from https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/4a0479c0-b795-4d0f-96fd-c7edd2a2928f/resourceGroups/pez-nfagent-pipelines/providers/Microsoft.ContainerRegistry/registries/peznfagenttemp/overview new one was /subscriptions/c7bd9d96-70dd-4f61-af56-6e0abd8d80b5/resourceGroups/sunny-nfagent-acr-HostedResources-4CDE264A/providers/Microsoft.ContainerRegistry/registries/SunnyclipubSunnyNfagentAcre00abc1832",
+    "images": {
+        "source_registry": "--this was copied here and renamed from https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/4a0479c0-b795-4d0f-96fd-c7edd2a2928f/resourceGroups/pez-nfagent-pipelines/providers/Microsoft.ContainerRegistry/registries/peznfagenttemp/overview new one was /subscriptions/c7bd9d96-70dd-4f61-af56-6e0abd8d80b5/resourceGroups/sunny-nfagent-acr-HostedResources-4CDE264A/providers/Microsoft.ContainerRegistry/registries/SunnyclipubSunnyNfagentAcre00abc1832"
+    },
     "helm_packages": [
         {
             "name": "nf-agent-cnf",

--- a/src/aosm/azext_aosm/tests/latest/mock_cnf/input-nfconfigchart.json
+++ b/src/aosm/azext_aosm/tests/latest/mock_cnf/input-nfconfigchart.json
@@ -5,7 +5,10 @@
     "version": "0.1.0",
     "acr_artifact_store_name": "sunny-nfagent-acr-2",
     "location": "uksouth",
-    "source_registry_id": "this was nonsense just put something in to stop CLI complaining. The image was manually uploaded. /subscriptions/c7bd9d96-70dd-4f61-af56-6e0abd8d80b5/resourceGroups/SIMPLVM-team-CI/providers/Microsoft.ContainerRegistry/registries/a4oSIMPL",
+    "images":
+    {
+        "source_registry": "this was nonsense just put something in to stop CLI complaining. The image was manually uploaded. /subscriptions/c7bd9d96-70dd-4f61-af56-6e0abd8d80b5/resourceGroups/SIMPLVM-team-CI/providers/Microsoft.ContainerRegistry/registries/a4oSIMPL"
+    },
     "helm_packages": [
         {
             "name": "nfconfigchart",

--- a/src/aosm/azext_aosm/tests/latest/mock_nsd/input.json
+++ b/src/aosm/azext_aosm/tests/latest/mock_nsd/input.json
@@ -11,7 +11,8 @@
             "type": "vnf",
             "multiple_instances": false,
             "publisher": "jamie-mobile-publisher",
-            "publisher_resource_group": "Jamie-publisher"
+            "publisher_resource_group": "Jamie-publisher",
+            "publisher_scope": "private"
         }
     ],
     "nsdg_name": "ubuntu",

--- a/src/aosm/azext_aosm/tests/latest/mock_nsd/input_multi_nf_nsd.json
+++ b/src/aosm/azext_aosm/tests/latest/mock_nsd/input_multi_nf_nsd.json
@@ -7,6 +7,7 @@
         {
             "publisher": "reference-publisher",
             "publisher_resource_group": "Reference-publisher",
+            "publisher_scope": "private",
             "name": "nginx-nfdg",
             "version": "1.0.0",
             "publisher_offering_location": "eastus",
@@ -16,6 +17,7 @@
         {
             "publisher": "reference-publisher",
             "publisher_resource_group": "Reference-publisher",
+            "publisher_scope": "private",
             "name": "ubuntu-nfdg",
             "version": "1.0.0",
             "publisher_offering_location": "eastus",

--- a/src/aosm/azext_aosm/tests/latest/mock_nsd/input_multiple_instances.json
+++ b/src/aosm/azext_aosm/tests/latest/mock_nsd/input_multiple_instances.json
@@ -10,6 +10,7 @@
             "publisher_offering_location": "eastus",
             "type": "vnf",
             "multiple_instances": true,
+            "publisher_scope": "private",
             "publisher": "jamie-mobile-publisher",
             "publisher_resource_group": "Jamie-publisher"
         }

--- a/src/aosm/azext_aosm/tests/latest/recording_processors.py
+++ b/src/aosm/azext_aosm/tests/latest/recording_processors.py
@@ -7,9 +7,7 @@
 # the recordings so that we can avoid checking in secrets to the repo.
 # --------------------------------------------------------------------------------------------
 
-from azure.cli.testsdk.scenario_tests import (
-    RecordingProcessor
-)
+from azure.cli.testsdk.scenario_tests import RecordingProcessor
 from azure.cli.testsdk.scenario_tests.utilities import is_text_payload
 import json
 import re
@@ -55,8 +53,16 @@ class SasUriReplacer(RecordingProcessor):
 
             for credential in credentials_list:
                 if CONTAINER_SAS_URI in credential:
-                    credential[CONTAINER_SAS_URI] = re.sub(BLOB_STORE_URI_REGEX, MOCK_SAS_URI, credential[CONTAINER_SAS_URI])
-                    credential[CONTAINER_SAS_URI] = re.sub(STORAGE_ACCOUNT_SR_REGEX, MOCK_STORAGE_ACCOUNT_SR, credential[CONTAINER_SAS_URI])
+                    credential[CONTAINER_SAS_URI] = re.sub(
+                        BLOB_STORE_URI_REGEX,
+                        MOCK_SAS_URI,
+                        credential[CONTAINER_SAS_URI],
+                    )
+                    credential[CONTAINER_SAS_URI] = re.sub(
+                        STORAGE_ACCOUNT_SR_REGEX,
+                        MOCK_STORAGE_ACCOUNT_SR,
+                        credential[CONTAINER_SAS_URI],
+                    )
                 new_credentials_list.append(credential)
 
             response_body[CONTAINER_CREDENTIALS] = new_credentials_list
@@ -71,7 +77,9 @@ class BlobStoreUriReplacer(RecordingProcessor):
     def process_request(self, request):
         try:
             request.uri = re.sub(BLOB_STORE_URI_REGEX, MOCK_SAS_URI, request.uri)
-            request.uri = re.sub(STORAGE_ACCOUNT_SR_REGEX, MOCK_STORAGE_ACCOUNT_SR, request.uri)
+            request.uri = re.sub(
+                STORAGE_ACCOUNT_SR_REGEX, MOCK_STORAGE_ACCOUNT_SR, request.uri
+            )
 
         except TypeError:
             pass

--- a/src/aosm/azext_aosm/tests/latest/recordings/test_vnf_nsd_publish_and_delete.yaml
+++ b/src/aosm/azext_aosm/tests/latest/recordings/test_vnf_nsd_publish_and_delete.yaml
@@ -3,6 +3,186 @@ interactions:
     body: null
     headers:
       Accept:
+      - application/json, text/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aosm nfd publish
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -f --definition-type
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/Allow-2023-09-01?api-version=2021-07-01
+  response:
+    body:
+      string: '{"properties": {"state": "Registered"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/Allow-2023-09-01",
+        "type": "Microsoft.Features/providers/features", "name": "Microsoft.HybridNetwork/Allow-2023-09-01"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '290'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 29 Aug 2023 15:46:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json, text/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aosm nfd publish
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -f --definition-type
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/AllowPreReleaseFeatures?api-version=2021-07-01
+  response:
+    body:
+      string: '{"properties": {"state": "Registered"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/AllowPreReleaseFeatures",
+        "type": "Microsoft.Features/providers/features", "name": "Microsoft.HybridNetwork/AllowPreReleaseFeatures"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 29 Aug 2023 15:46:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json, text/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aosm nfd publish
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -f --definition-type
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/Allow-2023-04-01-preview?api-version=2021-07-01
+  response:
+    body:
+      string: '{"properties": {"state": "Registered"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/Allow-2023-04-01-preview",
+        "type": "Microsoft.Features/providers/features", "name": "Microsoft.HybridNetwork/Allow-2023-04-01-preview"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '306'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 29 Aug 2023 15:46:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json, text/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aosm nfd publish
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -f --definition-type
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/MsiForResourceEnabled?api-version=2021-07-01
+  response:
+    body:
+      string: '{"properties": {"state": "Registered"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/MsiForResourceEnabled",
+        "type": "Microsoft.Features/providers/features", "name": "Microsoft.HybridNetwork/MsiForResourceEnabled"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '300'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 29 Aug 2023 15:46:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
       - application/json
       Accept-Encoding:
       - gzip, deflate
@@ -25,7 +205,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 24 Aug 2023 15:51:59 GMT
+      - Tue, 29 Aug 2023 15:46:33 GMT
       expires:
       - '-1'
       pragma:
@@ -59,8 +239,8 @@ interactions:
       string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001",
         "name": "cli_test_vnf_nsd_000001", "type": "Microsoft.Resources/resourceGroups",
         "location": "westcentralus", "tags": {"product": "azurecli", "cause": "automation",
-        "test": "test_vnf_nsd_publish_and_delete", "date": "2023-08-24T15:51:56Z",
-        "module": "aosm", "autoDelete": "true", "expiresOn": "2023-09-23T15:51:58.4231943Z"},
+        "test": "test_vnf_nsd_publish_and_delete", "date": "2023-08-29T15:46:31Z",
+        "module": "aosm", "autoDelete": "true", "expiresOn": "2023-09-28T15:46:31.4504856Z"},
         "properties": {"provisioningState": "Succeeded"}}'
     headers:
       cache-control:
@@ -70,7 +250,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 15:51:59 GMT
+      - Tue, 29 Aug 2023 15:46:34 GMT
       expires:
       - '-1'
       pragma:
@@ -115,7 +295,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 15:51:59 GMT
+      - Tue, 29 Aug 2023 15:46:34 GMT
       expires:
       - '-1'
       pragma:
@@ -156,23 +336,23 @@ interactions:
       string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher",
         "name": "ubuntuPublisher", "type": "microsoft.hybridnetwork/publishers", "location":
         "westcentralus", "systemData": {"createdBy": "sunnycarter@microsoft.com",
-        "createdByType": "User", "createdAt": "2023-08-24T15:52:00.8042955Z", "lastModifiedBy":
+        "createdByType": "User", "createdAt": "2023-08-29T15:46:35.343537Z", "lastModifiedBy":
         "sunnycarter@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2023-08-24T15:52:00.8042955Z"}, "properties": {"scope": "Private", "provisioningState":
+        "2023-08-29T15:46:35.343537Z"}, "properties": {"scope": "Private", "provisioningState":
         "Accepted"}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/b7bea456-7565-4a4a-96e7-06bce133e82c*61386E9D475D356830EFD4E736C811580B85F4B40B3E931DE66755A06CD89012?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d432786f-2bb0-4ab6-a110-8c838d02c669*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
-      - '587'
+      - '585'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 15:52:01 GMT
+      - Tue, 29 Aug 2023 15:46:36 GMT
       etag:
-      - '"2000d9d6-0000-0600-0000-64e77ca20000"'
+      - '"00003a03-0000-0600-0000-64ee12dc0000"'
       expires:
       - '-1'
       pragma:
@@ -207,13 +387,13 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/b7bea456-7565-4a4a-96e7-06bce133e82c*61386E9D475D356830EFD4E736C811580B85F4B40B3E931DE66755A06CD89012?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d432786f-2bb0-4ab6-a110-8c838d02c669*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/b7bea456-7565-4a4a-96e7-06bce133e82c*61386E9D475D356830EFD4E736C811580B85F4B40B3E931DE66755A06CD89012",
-        "name": "b7bea456-7565-4a4a-96e7-06bce133e82c*61386E9D475D356830EFD4E736C811580B85F4B40B3E931DE66755A06CD89012",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d432786f-2bb0-4ab6-a110-8c838d02c669*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E",
+        "name": "d432786f-2bb0-4ab6-a110-8c838d02c669*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher",
-        "status": "Accepted", "startTime": "2023-08-24T15:52:01.8771894Z"}'
+        "status": "Accepted", "startTime": "2023-08-29T15:46:36.3703473Z"}'
     headers:
       cache-control:
       - no-cache
@@ -222,9 +402,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 15:52:01 GMT
+      - Tue, 29 Aug 2023 15:46:36 GMT
       etag:
-      - '"680064db-0000-0600-0000-64e77ca10000"'
+      - '"0300f9b2-0000-0600-0000-64ee12dc0000"'
       expires:
       - '-1'
       pragma:
@@ -257,13 +437,13 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/b7bea456-7565-4a4a-96e7-06bce133e82c*61386E9D475D356830EFD4E736C811580B85F4B40B3E931DE66755A06CD89012?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d432786f-2bb0-4ab6-a110-8c838d02c669*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/b7bea456-7565-4a4a-96e7-06bce133e82c*61386E9D475D356830EFD4E736C811580B85F4B40B3E931DE66755A06CD89012",
-        "name": "b7bea456-7565-4a4a-96e7-06bce133e82c*61386E9D475D356830EFD4E736C811580B85F4B40B3E931DE66755A06CD89012",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d432786f-2bb0-4ab6-a110-8c838d02c669*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E",
+        "name": "d432786f-2bb0-4ab6-a110-8c838d02c669*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher",
-        "status": "Accepted", "startTime": "2023-08-24T15:52:01.8771894Z"}'
+        "status": "Accepted", "startTime": "2023-08-29T15:46:36.3703473Z"}'
     headers:
       cache-control:
       - no-cache
@@ -272,9 +452,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 15:52:32 GMT
+      - Tue, 29 Aug 2023 15:47:07 GMT
       etag:
-      - '"680064db-0000-0600-0000-64e77ca10000"'
+      - '"0300f9b2-0000-0600-0000-64ee12dc0000"'
       expires:
       - '-1'
       pragma:
@@ -307,13 +487,13 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/b7bea456-7565-4a4a-96e7-06bce133e82c*61386E9D475D356830EFD4E736C811580B85F4B40B3E931DE66755A06CD89012?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d432786f-2bb0-4ab6-a110-8c838d02c669*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/b7bea456-7565-4a4a-96e7-06bce133e82c*61386E9D475D356830EFD4E736C811580B85F4B40B3E931DE66755A06CD89012",
-        "name": "b7bea456-7565-4a4a-96e7-06bce133e82c*61386E9D475D356830EFD4E736C811580B85F4B40B3E931DE66755A06CD89012",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d432786f-2bb0-4ab6-a110-8c838d02c669*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E",
+        "name": "d432786f-2bb0-4ab6-a110-8c838d02c669*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher",
-        "status": "Accepted", "startTime": "2023-08-24T15:52:01.8771894Z"}'
+        "status": "Accepted", "startTime": "2023-08-29T15:46:36.3703473Z"}'
     headers:
       cache-control:
       - no-cache
@@ -322,9 +502,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 15:53:02 GMT
+      - Tue, 29 Aug 2023 15:47:36 GMT
       etag:
-      - '"680064db-0000-0600-0000-64e77ca10000"'
+      - '"0300f9b2-0000-0600-0000-64ee12dc0000"'
       expires:
       - '-1'
       pragma:
@@ -357,13 +537,13 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/b7bea456-7565-4a4a-96e7-06bce133e82c*61386E9D475D356830EFD4E736C811580B85F4B40B3E931DE66755A06CD89012?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d432786f-2bb0-4ab6-a110-8c838d02c669*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/b7bea456-7565-4a4a-96e7-06bce133e82c*61386E9D475D356830EFD4E736C811580B85F4B40B3E931DE66755A06CD89012",
-        "name": "b7bea456-7565-4a4a-96e7-06bce133e82c*61386E9D475D356830EFD4E736C811580B85F4B40B3E931DE66755A06CD89012",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d432786f-2bb0-4ab6-a110-8c838d02c669*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E",
+        "name": "d432786f-2bb0-4ab6-a110-8c838d02c669*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher",
-        "status": "Succeeded", "startTime": "2023-08-24T15:52:01.8771894Z", "properties":
+        "status": "Succeeded", "startTime": "2023-08-29T15:46:36.3703473Z", "properties":
         null}'
     headers:
       cache-control:
@@ -373,9 +553,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 15:53:31 GMT
+      - Tue, 29 Aug 2023 15:48:06 GMT
       etag:
-      - '"680030dc-0000-0600-0000-64e77ce50000"'
+      - '"3a017121-0000-0700-0000-64ee131f0000"'
       expires:
       - '-1'
       pragma:
@@ -414,21 +594,21 @@ interactions:
       string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher",
         "name": "ubuntuPublisher", "type": "microsoft.hybridnetwork/publishers", "location":
         "westcentralus", "systemData": {"createdBy": "sunnycarter@microsoft.com",
-        "createdByType": "User", "createdAt": "2023-08-24T15:52:00.8042955Z", "lastModifiedBy":
+        "createdByType": "User", "createdAt": "2023-08-29T15:46:35.343537Z", "lastModifiedBy":
         "sunnycarter@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2023-08-24T15:52:00.8042955Z"}, "properties": {"scope": "Private", "provisioningState":
+        "2023-08-29T15:46:35.343537Z"}, "properties": {"scope": "Private", "provisioningState":
         "Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '588'
+      - '586'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 15:53:31 GMT
+      - Tue, 29 Aug 2023 15:48:07 GMT
       etag:
-      - '"20000fd7-0000-0600-0000-64e77cad0000"'
+      - '"00003c03-0000-0600-0000-64ee12e60000"'
       expires:
       - '-1'
       pragma:
@@ -477,7 +657,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 15:53:32 GMT
+      - Tue, 29 Aug 2023 15:48:07 GMT
       expires:
       - '-1'
       pragma:
@@ -518,14 +698,14 @@ interactions:
       string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr",
         "name": "ubuntu-acr", "type": "microsoft.hybridnetwork/publishers/artifactstores",
         "location": "westcentralus", "systemData": {"createdBy": "sunnycarter@microsoft.com",
-        "createdByType": "User", "createdAt": "2023-08-24T15:53:33.3686433Z", "lastModifiedBy":
+        "createdByType": "User", "createdAt": "2023-08-29T15:48:08.8909773Z", "lastModifiedBy":
         "sunnycarter@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2023-08-24T15:53:33.3686433Z"}, "properties": {"storeType": "AzureContainerRegistry",
+        "2023-08-29T15:48:08.8909773Z"}, "properties": {"storeType": "AzureContainerRegistry",
         "managedResourceGroupConfiguration": {"location": "westcentralus", "name":
-        "ubuntu-acr-HostedResources-59B033BE"}, "provisioningState": "Accepted"}}'
+        "ubuntu-acr-HostedResources-663B284E"}, "provisioningState": "Accepted"}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/8d2be368-ac01-4589-b357-3ca3852cf648*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ea36bfeb-7c82-4a37-846c-5ec81e0807ad*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -533,9 +713,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 15:53:34 GMT
+      - Tue, 29 Aug 2023 15:48:22 GMT
       etag:
-      - '"1700c225-0000-0600-0000-64e77cfe0000"'
+      - '"0000422c-0000-0600-0000-64ee13470000"'
       expires:
       - '-1'
       pragma:
@@ -570,24 +750,24 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/8d2be368-ac01-4589-b357-3ca3852cf648*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ea36bfeb-7c82-4a37-846c-5ec81e0807ad*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/8d2be368-ac01-4589-b357-3ca3852cf648*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9",
-        "name": "8d2be368-ac01-4589-b357-3ca3852cf648*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ea36bfeb-7c82-4a37-846c-5ec81e0807ad*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
+        "name": "ea36bfeb-7c82-4a37-846c-5ec81e0807ad*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr",
-        "status": "Accepted", "startTime": "2023-08-24T15:53:34.734957Z"}'
+        "status": "Accepted", "startTime": "2023-08-29T15:48:23.0483823Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '562'
+      - '563'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 15:53:34 GMT
+      - Tue, 29 Aug 2023 15:48:22 GMT
       etag:
-      - '"680049dc-0000-0600-0000-64e77cfe0000"'
+      - '"00000d06-0000-0600-0000-64ee13470000"'
       expires:
       - '-1'
       pragma:
@@ -620,24 +800,24 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/8d2be368-ac01-4589-b357-3ca3852cf648*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ea36bfeb-7c82-4a37-846c-5ec81e0807ad*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/8d2be368-ac01-4589-b357-3ca3852cf648*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9",
-        "name": "8d2be368-ac01-4589-b357-3ca3852cf648*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ea36bfeb-7c82-4a37-846c-5ec81e0807ad*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
+        "name": "ea36bfeb-7c82-4a37-846c-5ec81e0807ad*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr",
-        "status": "Accepted", "startTime": "2023-08-24T15:53:34.734957Z"}'
+        "status": "Accepted", "startTime": "2023-08-29T15:48:23.0483823Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '562'
+      - '563'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 15:54:05 GMT
+      - Tue, 29 Aug 2023 15:48:52 GMT
       etag:
-      - '"680049dc-0000-0600-0000-64e77cfe0000"'
+      - '"00000d06-0000-0600-0000-64ee13470000"'
       expires:
       - '-1'
       pragma:
@@ -670,24 +850,24 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/8d2be368-ac01-4589-b357-3ca3852cf648*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ea36bfeb-7c82-4a37-846c-5ec81e0807ad*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/8d2be368-ac01-4589-b357-3ca3852cf648*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9",
-        "name": "8d2be368-ac01-4589-b357-3ca3852cf648*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ea36bfeb-7c82-4a37-846c-5ec81e0807ad*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
+        "name": "ea36bfeb-7c82-4a37-846c-5ec81e0807ad*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr",
-        "status": "Accepted", "startTime": "2023-08-24T15:53:34.734957Z"}'
+        "status": "Accepted", "startTime": "2023-08-29T15:48:23.0483823Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '562'
+      - '563'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 15:54:35 GMT
+      - Tue, 29 Aug 2023 15:49:23 GMT
       etag:
-      - '"680049dc-0000-0600-0000-64e77cfe0000"'
+      - '"00000d06-0000-0600-0000-64ee13470000"'
       expires:
       - '-1'
       pragma:
@@ -720,24 +900,24 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/8d2be368-ac01-4589-b357-3ca3852cf648*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ea36bfeb-7c82-4a37-846c-5ec81e0807ad*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/8d2be368-ac01-4589-b357-3ca3852cf648*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9",
-        "name": "8d2be368-ac01-4589-b357-3ca3852cf648*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ea36bfeb-7c82-4a37-846c-5ec81e0807ad*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
+        "name": "ea36bfeb-7c82-4a37-846c-5ec81e0807ad*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr",
-        "status": "Accepted", "startTime": "2023-08-24T15:53:34.734957Z"}'
+        "status": "Accepted", "startTime": "2023-08-29T15:48:23.0483823Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '562'
+      - '563'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 15:55:05 GMT
+      - Tue, 29 Aug 2023 15:49:53 GMT
       etag:
-      - '"680049dc-0000-0600-0000-64e77cfe0000"'
+      - '"00000d06-0000-0600-0000-64ee13470000"'
       expires:
       - '-1'
       pragma:
@@ -770,24 +950,24 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/8d2be368-ac01-4589-b357-3ca3852cf648*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ea36bfeb-7c82-4a37-846c-5ec81e0807ad*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/8d2be368-ac01-4589-b357-3ca3852cf648*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9",
-        "name": "8d2be368-ac01-4589-b357-3ca3852cf648*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ea36bfeb-7c82-4a37-846c-5ec81e0807ad*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
+        "name": "ea36bfeb-7c82-4a37-846c-5ec81e0807ad*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr",
-        "status": "Accepted", "startTime": "2023-08-24T15:53:34.734957Z"}'
+        "status": "Accepted", "startTime": "2023-08-29T15:48:23.0483823Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '562'
+      - '563'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 15:55:37 GMT
+      - Tue, 29 Aug 2023 15:50:24 GMT
       etag:
-      - '"680049dc-0000-0600-0000-64e77cfe0000"'
+      - '"00000d06-0000-0600-0000-64ee13470000"'
       expires:
       - '-1'
       pragma:
@@ -820,25 +1000,25 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/8d2be368-ac01-4589-b357-3ca3852cf648*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ea36bfeb-7c82-4a37-846c-5ec81e0807ad*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/8d2be368-ac01-4589-b357-3ca3852cf648*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9",
-        "name": "8d2be368-ac01-4589-b357-3ca3852cf648*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ea36bfeb-7c82-4a37-846c-5ec81e0807ad*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
+        "name": "ea36bfeb-7c82-4a37-846c-5ec81e0807ad*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr",
-        "status": "Succeeded", "startTime": "2023-08-24T15:53:34.734957Z", "properties":
+        "status": "Succeeded", "startTime": "2023-08-29T15:48:23.0483823Z", "properties":
         null}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '583'
+      - '584'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 15:56:08 GMT
+      - Tue, 29 Aug 2023 15:50:54 GMT
       etag:
-      - '"6800bbe2-0000-0600-0000-64e77d7e0000"'
+      - '"2602caa8-0000-0100-0000-64ee13c70000"'
       expires:
       - '-1'
       pragma:
@@ -877,12 +1057,12 @@ interactions:
       string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr",
         "name": "ubuntu-acr", "type": "microsoft.hybridnetwork/publishers/artifactstores",
         "location": "westcentralus", "systemData": {"createdBy": "sunnycarter@microsoft.com",
-        "createdByType": "User", "createdAt": "2023-08-24T15:53:33.3686433Z", "lastModifiedBy":
+        "createdByType": "User", "createdAt": "2023-08-29T15:48:08.8909773Z", "lastModifiedBy":
         "sunnycarter@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2023-08-24T15:53:33.3686433Z"}, "properties": {"storeType": "AzureContainerRegistry",
+        "2023-08-29T15:48:08.8909773Z"}, "properties": {"storeType": "AzureContainerRegistry",
         "replicationStrategy": "SingleReplication", "managedResourceGroupConfiguration":
-        {"name": "ubuntu-acr-HostedResources-59B033BE", "location": "westcentralus"},
-        "provisioningState": "Succeeded", "storageResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/ubuntu-acr-HostedResources-59B033BE/providers/Microsoft.ContainerRegistry/registries/UbuntupublisherUbuntuAcrd18ac8e07e"}}'
+        {"name": "ubuntu-acr-HostedResources-663B284E", "location": "westcentralus"},
+        "provisioningState": "Succeeded", "storageResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/ubuntu-acr-HostedResources-663B284E/providers/Microsoft.ContainerRegistry/registries/UbuntupublisherUbuntuAcr8e894d23e6"}}'
     headers:
       cache-control:
       - no-cache
@@ -891,9 +1071,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 15:56:09 GMT
+      - Tue, 29 Aug 2023 15:50:54 GMT
       etag:
-      - '"17003526-0000-0600-0000-64e77d510000"'
+      - '"0000e22c-0000-0600-0000-64ee139a0000"'
       expires:
       - '-1'
       pragma:
@@ -942,7 +1122,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 15:56:09 GMT
+      - Tue, 29 Aug 2023 15:50:55 GMT
       expires:
       - '-1'
       pragma:
@@ -983,14 +1163,14 @@ interactions:
       string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store",
         "name": "ubuntu-blob-store", "type": "microsoft.hybridnetwork/publishers/artifactstores",
         "location": "westcentralus", "systemData": {"createdBy": "sunnycarter@microsoft.com",
-        "createdByType": "User", "createdAt": "2023-08-24T15:56:11.0743249Z", "lastModifiedBy":
+        "createdByType": "User", "createdAt": "2023-08-29T15:50:56.2512265Z", "lastModifiedBy":
         "sunnycarter@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2023-08-24T15:56:11.0743249Z"}, "properties": {"storeType": "AzureStorageAccount",
+        "2023-08-29T15:50:56.2512265Z"}, "properties": {"storeType": "AzureStorageAccount",
         "managedResourceGroupConfiguration": {"location": "westcentralus", "name":
-        "ubuntu-blob-store-HostedResources-4F638472"}, "provisioningState": "Accepted"}}'
+        "ubuntu-blob-store-HostedResources-0C8DFD0E"}, "provisioningState": "Accepted"}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/4fc48ca0-f8aa-4304-8632-308494328919*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d3a33817-9106-4a6e-a2f3-10462ca5c7ae*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -998,9 +1178,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 15:56:11 GMT
+      - Tue, 29 Aug 2023 15:50:57 GMT
       etag:
-      - '"1700a226-0000-0600-0000-64e77d9c0000"'
+      - '"0000652d-0000-0600-0000-64ee13e10000"'
       expires:
       - '-1'
       pragma:
@@ -1035,13 +1215,13 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/4fc48ca0-f8aa-4304-8632-308494328919*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d3a33817-9106-4a6e-a2f3-10462ca5c7ae*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/4fc48ca0-f8aa-4304-8632-308494328919*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0",
-        "name": "4fc48ca0-f8aa-4304-8632-308494328919*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d3a33817-9106-4a6e-a2f3-10462ca5c7ae*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
+        "name": "d3a33817-9106-4a6e-a2f3-10462ca5c7ae*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store",
-        "status": "Accepted", "startTime": "2023-08-24T15:56:12.1348749Z"}'
+        "status": "Accepted", "startTime": "2023-08-29T15:50:57.2229314Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1050,9 +1230,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 15:56:11 GMT
+      - Tue, 29 Aug 2023 15:50:57 GMT
       etag:
-      - '"6800c9e2-0000-0600-0000-64e77d9c0000"'
+      - '"00001b06-0000-0600-0000-64ee13e10000"'
       expires:
       - '-1'
       pragma:
@@ -1085,13 +1265,13 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/4fc48ca0-f8aa-4304-8632-308494328919*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d3a33817-9106-4a6e-a2f3-10462ca5c7ae*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/4fc48ca0-f8aa-4304-8632-308494328919*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0",
-        "name": "4fc48ca0-f8aa-4304-8632-308494328919*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d3a33817-9106-4a6e-a2f3-10462ca5c7ae*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
+        "name": "d3a33817-9106-4a6e-a2f3-10462ca5c7ae*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store",
-        "status": "Accepted", "startTime": "2023-08-24T15:56:12.1348749Z"}'
+        "status": "Accepted", "startTime": "2023-08-29T15:50:57.2229314Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1100,9 +1280,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 15:56:42 GMT
+      - Tue, 29 Aug 2023 15:51:27 GMT
       etag:
-      - '"6800c9e2-0000-0600-0000-64e77d9c0000"'
+      - '"00001b06-0000-0600-0000-64ee13e10000"'
       expires:
       - '-1'
       pragma:
@@ -1135,13 +1315,13 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/4fc48ca0-f8aa-4304-8632-308494328919*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d3a33817-9106-4a6e-a2f3-10462ca5c7ae*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/4fc48ca0-f8aa-4304-8632-308494328919*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0",
-        "name": "4fc48ca0-f8aa-4304-8632-308494328919*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d3a33817-9106-4a6e-a2f3-10462ca5c7ae*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
+        "name": "d3a33817-9106-4a6e-a2f3-10462ca5c7ae*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store",
-        "status": "Accepted", "startTime": "2023-08-24T15:56:12.1348749Z"}'
+        "status": "Accepted", "startTime": "2023-08-29T15:50:57.2229314Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1150,9 +1330,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 15:57:12 GMT
+      - Tue, 29 Aug 2023 15:51:56 GMT
       etag:
-      - '"6800c9e2-0000-0600-0000-64e77d9c0000"'
+      - '"00001b06-0000-0600-0000-64ee13e10000"'
       expires:
       - '-1'
       pragma:
@@ -1185,13 +1365,13 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/4fc48ca0-f8aa-4304-8632-308494328919*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d3a33817-9106-4a6e-a2f3-10462ca5c7ae*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/4fc48ca0-f8aa-4304-8632-308494328919*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0",
-        "name": "4fc48ca0-f8aa-4304-8632-308494328919*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d3a33817-9106-4a6e-a2f3-10462ca5c7ae*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
+        "name": "d3a33817-9106-4a6e-a2f3-10462ca5c7ae*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store",
-        "status": "Accepted", "startTime": "2023-08-24T15:56:12.1348749Z"}'
+        "status": "Accepted", "startTime": "2023-08-29T15:50:57.2229314Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1200,9 +1380,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 15:57:45 GMT
+      - Tue, 29 Aug 2023 15:52:28 GMT
       etag:
-      - '"6800c9e2-0000-0600-0000-64e77d9c0000"'
+      - '"00001b06-0000-0600-0000-64ee13e10000"'
       expires:
       - '-1'
       pragma:
@@ -1235,13 +1415,13 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/4fc48ca0-f8aa-4304-8632-308494328919*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d3a33817-9106-4a6e-a2f3-10462ca5c7ae*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/4fc48ca0-f8aa-4304-8632-308494328919*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0",
-        "name": "4fc48ca0-f8aa-4304-8632-308494328919*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d3a33817-9106-4a6e-a2f3-10462ca5c7ae*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
+        "name": "d3a33817-9106-4a6e-a2f3-10462ca5c7ae*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store",
-        "status": "Accepted", "startTime": "2023-08-24T15:56:12.1348749Z"}'
+        "status": "Accepted", "startTime": "2023-08-29T15:50:57.2229314Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1250,9 +1430,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 15:58:15 GMT
+      - Tue, 29 Aug 2023 15:52:58 GMT
       etag:
-      - '"6800c9e2-0000-0600-0000-64e77d9c0000"'
+      - '"00001b06-0000-0600-0000-64ee13e10000"'
       expires:
       - '-1'
       pragma:
@@ -1285,13 +1465,13 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/4fc48ca0-f8aa-4304-8632-308494328919*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d3a33817-9106-4a6e-a2f3-10462ca5c7ae*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/4fc48ca0-f8aa-4304-8632-308494328919*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0",
-        "name": "4fc48ca0-f8aa-4304-8632-308494328919*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d3a33817-9106-4a6e-a2f3-10462ca5c7ae*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
+        "name": "d3a33817-9106-4a6e-a2f3-10462ca5c7ae*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store",
-        "status": "Succeeded", "startTime": "2023-08-24T15:56:12.1348749Z", "properties":
+        "status": "Succeeded", "startTime": "2023-08-29T15:50:57.2229314Z", "properties":
         null}'
     headers:
       cache-control:
@@ -1301,9 +1481,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 15:58:46 GMT
+      - Tue, 29 Aug 2023 15:53:28 GMT
       etag:
-      - '"63008117-0000-0100-0000-64e77e1c0000"'
+      - '"00002106-0000-0600-0000-64ee14610000"'
       expires:
       - '-1'
       pragma:
@@ -1342,12 +1522,12 @@ interactions:
       string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store",
         "name": "ubuntu-blob-store", "type": "microsoft.hybridnetwork/publishers/artifactstores",
         "location": "westcentralus", "systemData": {"createdBy": "sunnycarter@microsoft.com",
-        "createdByType": "User", "createdAt": "2023-08-24T15:56:11.0743249Z", "lastModifiedBy":
+        "createdByType": "User", "createdAt": "2023-08-29T15:50:56.2512265Z", "lastModifiedBy":
         "sunnycarter@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2023-08-24T15:56:11.0743249Z"}, "properties": {"storeType": "AzureStorageAccount",
+        "2023-08-29T15:50:56.2512265Z"}, "properties": {"storeType": "AzureStorageAccount",
         "replicationStrategy": "SingleReplication", "managedResourceGroupConfiguration":
-        {"name": "ubuntu-blob-store-HostedResources-4F638472", "location": "westcentralus"},
-        "provisioningState": "Succeeded", "storageResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/ubuntu-blob-store-HostedResources-4F638472/providers/Microsoft.Storage/storageAccounts/4f638472ubuntublobstoreb"}}'
+        {"name": "ubuntu-blob-store-HostedResources-0C8DFD0E", "location": "westcentralus"},
+        "provisioningState": "Succeeded", "storageResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/ubuntu-blob-store-HostedResources-0C8DFD0E/providers/Microsoft.Storage/storageAccounts/0c8dfd0eubuntublobstored"}}'
     headers:
       cache-control:
       - no-cache
@@ -1356,9 +1536,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 15:58:46 GMT
+      - Tue, 29 Aug 2023 15:53:28 GMT
       etag:
-      - '"17002e27-0000-0600-0000-64e77df80000"'
+      - '"0000b92d-0000-0600-0000-64ee14400000"'
       expires:
       - '-1'
       pragma:
@@ -1407,7 +1587,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 15:58:47 GMT
+      - Tue, 29 Aug 2023 15:53:28 GMT
       expires:
       - '-1'
       pragma:
@@ -1448,12 +1628,12 @@ interactions:
       string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg",
         "name": "ubuntu-vm-nfdg", "type": "microsoft.hybridnetwork/publishers/networkfunctiondefinitiongroups",
         "location": "westcentralus", "systemData": {"createdBy": "sunnycarter@microsoft.com",
-        "createdByType": "User", "createdAt": "2023-08-24T15:58:48.4200797Z", "lastModifiedBy":
+        "createdByType": "User", "createdAt": "2023-08-29T15:53:30.5177253Z", "lastModifiedBy":
         "sunnycarter@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2023-08-24T15:58:48.4200797Z"}, "properties": {"provisioningState": "Accepted"}}'
+        "2023-08-29T15:53:30.5177253Z"}, "properties": {"provisioningState": "Accepted"}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c66de8a0-f296-47f6-9aee-6217d9bcb6a3*84C4ECA09469BBDA75EE23B0C96AD5D368A53F08FAF2B9701A3C6CBC6EA3616A?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/f6282936-0229-4f1d-a3a2-f24f421970f1*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -1461,9 +1641,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 15:58:50 GMT
+      - Tue, 29 Aug 2023 15:53:31 GMT
       etag:
-      - '"09004aee-0000-0600-0000-64e77e3b0000"'
+      - '"00003c04-0000-0600-0000-64ee147b0000"'
       expires:
       - '-1'
       pragma:
@@ -1498,24 +1678,24 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c66de8a0-f296-47f6-9aee-6217d9bcb6a3*84C4ECA09469BBDA75EE23B0C96AD5D368A53F08FAF2B9701A3C6CBC6EA3616A?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/f6282936-0229-4f1d-a3a2-f24f421970f1*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c66de8a0-f296-47f6-9aee-6217d9bcb6a3*84C4ECA09469BBDA75EE23B0C96AD5D368A53F08FAF2B9701A3C6CBC6EA3616A",
-        "name": "c66de8a0-f296-47f6-9aee-6217d9bcb6a3*84C4ECA09469BBDA75EE23B0C96AD5D368A53F08FAF2B9701A3C6CBC6EA3616A",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/f6282936-0229-4f1d-a3a2-f24f421970f1*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890",
+        "name": "f6282936-0229-4f1d-a3a2-f24f421970f1*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg",
-        "status": "Accepted", "startTime": "2023-08-24T15:58:50.9729566Z"}'
+        "status": "Accepted", "startTime": "2023-08-29T15:53:31.672989Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '584'
+      - '583'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 15:58:50 GMT
+      - Tue, 29 Aug 2023 15:53:31 GMT
       etag:
-      - '"680010e6-0000-0600-0000-64e77e3a0000"'
+      - '"0300bbc5-0000-0600-0000-64ee147b0000"'
       expires:
       - '-1'
       pragma:
@@ -1548,24 +1728,24 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c66de8a0-f296-47f6-9aee-6217d9bcb6a3*84C4ECA09469BBDA75EE23B0C96AD5D368A53F08FAF2B9701A3C6CBC6EA3616A?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/f6282936-0229-4f1d-a3a2-f24f421970f1*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c66de8a0-f296-47f6-9aee-6217d9bcb6a3*84C4ECA09469BBDA75EE23B0C96AD5D368A53F08FAF2B9701A3C6CBC6EA3616A",
-        "name": "c66de8a0-f296-47f6-9aee-6217d9bcb6a3*84C4ECA09469BBDA75EE23B0C96AD5D368A53F08FAF2B9701A3C6CBC6EA3616A",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/f6282936-0229-4f1d-a3a2-f24f421970f1*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890",
+        "name": "f6282936-0229-4f1d-a3a2-f24f421970f1*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg",
-        "status": "Accepted", "startTime": "2023-08-24T15:58:50.9729566Z"}'
+        "status": "Accepted", "startTime": "2023-08-29T15:53:31.672989Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '584'
+      - '583'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 15:59:21 GMT
+      - Tue, 29 Aug 2023 15:54:01 GMT
       etag:
-      - '"680010e6-0000-0600-0000-64e77e3a0000"'
+      - '"0300bbc5-0000-0600-0000-64ee147b0000"'
       expires:
       - '-1'
       pragma:
@@ -1598,24 +1778,24 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c66de8a0-f296-47f6-9aee-6217d9bcb6a3*84C4ECA09469BBDA75EE23B0C96AD5D368A53F08FAF2B9701A3C6CBC6EA3616A?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/f6282936-0229-4f1d-a3a2-f24f421970f1*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c66de8a0-f296-47f6-9aee-6217d9bcb6a3*84C4ECA09469BBDA75EE23B0C96AD5D368A53F08FAF2B9701A3C6CBC6EA3616A",
-        "name": "c66de8a0-f296-47f6-9aee-6217d9bcb6a3*84C4ECA09469BBDA75EE23B0C96AD5D368A53F08FAF2B9701A3C6CBC6EA3616A",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/f6282936-0229-4f1d-a3a2-f24f421970f1*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890",
+        "name": "f6282936-0229-4f1d-a3a2-f24f421970f1*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg",
-        "status": "Accepted", "startTime": "2023-08-24T15:58:50.9729566Z"}'
+        "status": "Accepted", "startTime": "2023-08-29T15:53:31.672989Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '584'
+      - '583'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 15:59:51 GMT
+      - Tue, 29 Aug 2023 15:54:32 GMT
       etag:
-      - '"680010e6-0000-0600-0000-64e77e3a0000"'
+      - '"0300bbc5-0000-0600-0000-64ee147b0000"'
       expires:
       - '-1'
       pragma:
@@ -1648,25 +1828,25 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c66de8a0-f296-47f6-9aee-6217d9bcb6a3*84C4ECA09469BBDA75EE23B0C96AD5D368A53F08FAF2B9701A3C6CBC6EA3616A?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/f6282936-0229-4f1d-a3a2-f24f421970f1*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c66de8a0-f296-47f6-9aee-6217d9bcb6a3*84C4ECA09469BBDA75EE23B0C96AD5D368A53F08FAF2B9701A3C6CBC6EA3616A",
-        "name": "c66de8a0-f296-47f6-9aee-6217d9bcb6a3*84C4ECA09469BBDA75EE23B0C96AD5D368A53F08FAF2B9701A3C6CBC6EA3616A",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/f6282936-0229-4f1d-a3a2-f24f421970f1*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890",
+        "name": "f6282936-0229-4f1d-a3a2-f24f421970f1*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg",
-        "status": "Succeeded", "startTime": "2023-08-24T15:58:50.9729566Z", "properties":
+        "status": "Succeeded", "startTime": "2023-08-29T15:53:31.672989Z", "properties":
         null}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '605'
+      - '604'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:00:21 GMT
+      - Tue, 29 Aug 2023 15:55:01 GMT
       etag:
-      - '"57005324-0000-0700-0000-64e77e7d0000"'
+      - '"9701c20a-0000-0800-0000-64ee14bf0000"'
       expires:
       - '-1'
       pragma:
@@ -1705,9 +1885,9 @@ interactions:
       string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg",
         "name": "ubuntu-vm-nfdg", "type": "microsoft.hybridnetwork/publishers/networkfunctiondefinitiongroups",
         "location": "westcentralus", "systemData": {"createdBy": "sunnycarter@microsoft.com",
-        "createdByType": "User", "createdAt": "2023-08-24T15:58:48.4200797Z", "lastModifiedBy":
+        "createdByType": "User", "createdAt": "2023-08-29T15:53:30.5177253Z", "lastModifiedBy":
         "sunnycarter@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2023-08-24T15:58:48.4200797Z"}, "properties": {"description": null, "provisioningState":
+        "2023-08-29T15:53:30.5177253Z"}, "properties": {"description": null, "provisioningState":
         "Succeeded"}}'
     headers:
       cache-control:
@@ -1717,9 +1897,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:00:21 GMT
+      - Tue, 29 Aug 2023 15:55:02 GMT
       etag:
-      - '"090052ee-0000-0600-0000-64e77e440000"'
+      - '"00003e04-0000-0600-0000-64ee14860000"'
       expires:
       - '-1'
       pragma:
@@ -1768,7 +1948,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:00:22 GMT
+      - Tue, 29 Aug 2023 15:55:02 GMT
       expires:
       - '-1'
       pragma:
@@ -1813,7 +1993,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:00:22 GMT
+      - Tue, 29 Aug 2023 15:55:02 GMT
       expires:
       - '-1'
       pragma:
@@ -1884,8 +2064,8 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/validate?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1692892827",
-        "name": "AOSM_CLI_deployment_1692892827", "type": "Microsoft.Resources/deployments",
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693324506",
+        "name": "AOSM_CLI_deployment_1693324506", "type": "Microsoft.Resources/deployments",
         "properties": {"templateHash": "15169602856414121474", "parameters": {"location":
         {"type": "String", "value": "westcentralus"}, "publisherName": {"type": "String",
         "value": "ubuntuPublisher"}, "acrArtifactStoreName": {"type": "String", "value":
@@ -1895,7 +2075,7 @@ interactions:
         "nfName": {"type": "String", "value": "ubuntu-vm"}, "vhdVersion": {"type":
         "String", "value": "1-0-0"}, "armTemplateVersion": {"type": "String", "value":
         "1.0.0"}}, "mode": "Incremental", "provisioningState": "Succeeded", "timestamp":
-        "0001-01-01T00:00:00Z", "duration": "PT0S", "correlationId": "58c1c55e-105f-4068-ab6d-9548da2c19a6",
+        "0001-01-01T00:00:00Z", "duration": "PT0S", "correlationId": "3feaa34a-f426-4216-905a-f489fff3160d",
         "providers": [{"namespace": "Microsoft.Hybridnetwork", "resourceTypes": [{"resourceType":
         "publishers/artifactStores/artifactManifests", "locations": ["westcentralus"]}]}],
         "dependencies": [], "validatedResources": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store/artifactManifests/ubuntu-vm-sa-manifest-1-0-0"},
@@ -1908,7 +2088,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:00:30 GMT
+      - Tue, 29 Aug 2023 15:55:08 GMT
       expires:
       - '-1'
       pragma:
@@ -1983,8 +2163,8 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1692892827",
-        "name": "AOSM_CLI_deployment_1692892827", "type": "Microsoft.Resources/deployments",
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693324506",
+        "name": "AOSM_CLI_deployment_1693324506", "type": "Microsoft.Resources/deployments",
         "properties": {"templateHash": "15169602856414121474", "parameters": {"location":
         {"type": "String", "value": "westcentralus"}, "publisherName": {"type": "String",
         "value": "ubuntuPublisher"}, "acrArtifactStoreName": {"type": "String", "value":
@@ -1994,13 +2174,13 @@ interactions:
         "nfName": {"type": "String", "value": "ubuntu-vm"}, "vhdVersion": {"type":
         "String", "value": "1-0-0"}, "armTemplateVersion": {"type": "String", "value":
         "1.0.0"}}, "mode": "Incremental", "provisioningState": "Accepted", "timestamp":
-        "2023-08-24T16:00:33.5555778Z", "duration": "PT0.0005862S", "correlationId":
-        "63ecc845-bf8b-4388-82dc-ce742adc14d7", "providers": [{"namespace": "Microsoft.Hybridnetwork",
+        "2023-08-29T15:55:11.7583889Z", "duration": "PT0.0002148S", "correlationId":
+        "f964cef3-3041-45ad-81ac-c11eaaae08b7", "providers": [{"namespace": "Microsoft.Hybridnetwork",
         "resourceTypes": [{"resourceType": "publishers/artifactStores/artifactManifests",
         "locations": ["westcentralus"]}]}], "dependencies": []}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1692892827/operationStatuses/08585087140536565080?api-version=2022-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693324506/operationStatuses/08585082823751958274?api-version=2022-09-01
       cache-control:
       - no-cache
       content-length:
@@ -2008,7 +2188,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:00:34 GMT
+      - Tue, 29 Aug 2023 15:55:11 GMT
       expires:
       - '-1'
       pragma:
@@ -2038,7 +2218,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585087140536565080?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585082823751958274?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Accepted"}'
@@ -2050,7 +2230,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:00:34 GMT
+      - Tue, 29 Aug 2023 15:55:12 GMT
       expires:
       - '-1'
       pragma:
@@ -2080,7 +2260,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585087140536565080?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585082823751958274?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Succeeded"}'
@@ -2092,7 +2272,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:01:05 GMT
+      - Tue, 29 Aug 2023 15:55:43 GMT
       expires:
       - '-1'
       pragma:
@@ -2125,8 +2305,8 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1692892827",
-        "name": "AOSM_CLI_deployment_1692892827", "type": "Microsoft.Resources/deployments",
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693324506",
+        "name": "AOSM_CLI_deployment_1693324506", "type": "Microsoft.Resources/deployments",
         "properties": {"templateHash": "15169602856414121474", "parameters": {"location":
         {"type": "String", "value": "westcentralus"}, "publisherName": {"type": "String",
         "value": "ubuntuPublisher"}, "acrArtifactStoreName": {"type": "String", "value":
@@ -2136,8 +2316,8 @@ interactions:
         "nfName": {"type": "String", "value": "ubuntu-vm"}, "vhdVersion": {"type":
         "String", "value": "1-0-0"}, "armTemplateVersion": {"type": "String", "value":
         "1.0.0"}}, "mode": "Incremental", "provisioningState": "Succeeded", "timestamp":
-        "2023-08-24T16:01:02.0374569Z", "duration": "PT28.4824653S", "correlationId":
-        "63ecc845-bf8b-4388-82dc-ce742adc14d7", "providers": [{"namespace": "Microsoft.Hybridnetwork",
+        "2023-08-29T15:55:42.3955798Z", "duration": "PT30.6374057S", "correlationId":
+        "f964cef3-3041-45ad-81ac-c11eaaae08b7", "providers": [{"namespace": "Microsoft.Hybridnetwork",
         "resourceTypes": [{"resourceType": "publishers/artifactStores/artifactManifests",
         "locations": ["westcentralus"]}]}], "dependencies": [], "outputResources":
         [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-acr-manifest-1-0-0"},
@@ -2150,7 +2330,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:01:05 GMT
+      - Tue, 29 Aug 2023 15:55:43 GMT
       expires:
       - '-1'
       pragma:
@@ -2187,9 +2367,9 @@ interactions:
       string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store/artifactManifests/ubuntu-vm-sa-manifest-1-0-0",
         "name": "ubuntu-vm-sa-manifest-1-0-0", "type": "microsoft.hybridnetwork/publishers/artifactstores/artifactmanifests",
         "location": "westcentralus", "systemData": {"createdBy": "sunnycarter@microsoft.com",
-        "createdByType": "User", "createdAt": "2023-08-24T16:00:37.8080167Z", "lastModifiedBy":
+        "createdByType": "User", "createdAt": "2023-08-29T15:55:16.1701519Z", "lastModifiedBy":
         "sunnycarter@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2023-08-24T16:00:37.8080167Z"}, "properties": {"artifacts": [{"artifactName":
+        "2023-08-29T15:55:16.1701519Z"}, "properties": {"artifacts": [{"artifactName":
         "ubuntu-vm-vhd", "artifactType": "VhdImageFile", "artifactVersion": "1-0-0"}],
         "artifactManifestState": "Uploading", "provisioningState": "Succeeded"}}'
     headers:
@@ -2200,9 +2380,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:01:06 GMT
+      - Tue, 29 Aug 2023 15:55:43 GMT
       etag:
-      - '"20002fac-0000-0600-0000-64e77ead0000"'
+      - '"0000160f-0000-0600-0000-64ee14ea0000"'
       expires:
       - '-1'
       pragma:
@@ -2242,10 +2422,10 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store/artifactManifests/ubuntu-vm-sa-manifest-1-0-0/listCredential?api-version=2023-04-01-preview
   response:
     body:
-      string: '{"storageAccountId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/ubuntu-blob-store-HostedResources-4F638472/providers/Microsoft.Storage/storageAccounts/4f638472ubuntublobstoreb",
+      string: '{"storageAccountId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/ubuntu-blob-store-HostedResources-0C8DFD0E/providers/Microsoft.Storage/storageAccounts/0c8dfd0eubuntublobstored",
         "containerCredentials": [{"containerName": "ubuntuvmvhd-1-0-0", "containerSasUri":
         "https://xxxxxxxxxxxxxxx.blob.core.windows.net/ubuntuvmvhd-1-0-0?sv=2021-08-06&si=StorageAccountAccessPolicy&sr=xxxxxxxxxxxxxxxxxxxx"}],
-        "expiry": "2023-08-25T16:01:08.8582418+00:00", "credentialType": "AzureStorageAccountToken"}'
+        "expiry": "2023-08-30T15:55:45.6103964+00:00", "credentialType": "AzureStorageAccountToken"}'
     headers:
       cache-control:
       - no-cache
@@ -2254,7 +2434,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:01:08 GMT
+      - Tue, 29 Aug 2023 15:55:44 GMT
       expires:
       - '-1'
       pragma:
@@ -2299,9 +2479,9 @@ interactions:
       string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-acr-manifest-1-0-0",
         "name": "ubuntu-vm-acr-manifest-1-0-0", "type": "microsoft.hybridnetwork/publishers/artifactstores/artifactmanifests",
         "location": "westcentralus", "systemData": {"createdBy": "sunnycarter@microsoft.com",
-        "createdByType": "User", "createdAt": "2023-08-24T16:00:37.7924048Z", "lastModifiedBy":
+        "createdByType": "User", "createdAt": "2023-08-29T15:55:16.1232743Z", "lastModifiedBy":
         "sunnycarter@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2023-08-24T16:00:37.7924048Z"}, "properties": {"artifacts": [{"artifactName":
+        "2023-08-29T15:55:16.1232743Z"}, "properties": {"artifacts": [{"artifactName":
         "ubuntu-vm-arm-template", "artifactType": "ArmTemplate", "artifactVersion":
         "1.0.0"}], "artifactManifestState": "Uploading", "provisioningState": "Succeeded"}}'
     headers:
@@ -2312,9 +2492,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:01:08 GMT
+      - Tue, 29 Aug 2023 15:55:54 GMT
       etag:
-      - '"200040ac-0000-0600-0000-64e77eb80000"'
+      - '"0000180f-0000-0600-0000-64ee14f90000"'
       expires:
       - '-1'
       pragma:
@@ -2355,8 +2535,8 @@ interactions:
   response:
     body:
       string: '{"username": "ubuntu-vm-acr-manifest-1-0-0", "acrToken": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-        "acrServerUrl": "https://ubuntupublisherubuntuacrd18ac8e07e.azurecr.io", "repositories":
-        ["ubuntu-vm-arm-template"], "expiry": "2023-08-25T16:01:10.3248733+00:00",
+        "acrServerUrl": "https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io", "repositories":
+        ["ubuntu-vm-arm-template"], "expiry": "2023-08-30T15:55:55.9964501+00:00",
         "credentialType": "AzureContainerRegistryScopedToken"}'
     headers:
       cache-control:
@@ -2366,7 +2546,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:01:11 GMT
+      - Tue, 29 Aug 2023 15:55:56 GMT
       expires:
       - '-1'
       pragma:
@@ -2406,7 +2586,7 @@ interactions:
       x-ms-blob-type:
       - PageBlob
       x-ms-date:
-      - Thu, 24 Aug 2023 16:01:09 GMT
+      - Tue, 29 Aug 2023 15:55:56 GMT
       x-ms-version:
       - '2023-01-03'
     method: PUT
@@ -2418,11 +2598,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 24 Aug 2023 16:01:11 GMT
+      - Tue, 29 Aug 2023 15:55:56 GMT
       etag:
-      - '"0x8DBA4BB568B63CB"'
+      - '"0x8DBA8A86EE207F7"'
       last-modified:
-      - Thu, 24 Aug 2023 16:01:12 GMT
+      - Tue, 29 Aug 2023 15:55:57 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
@@ -2452,11 +2632,11 @@ interactions:
       Content-Type:
       - application/octet-stream
       If-Match:
-      - '"0x8DBA4BB568B63CB"'
+      - '"0x8DBA8A86EE207F7"'
       User-Agent:
       - azsdk-python-storage-blob/12.17.0 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
       x-ms-date:
-      - Thu, 24 Aug 2023 16:01:10 GMT
+      - Tue, 29 Aug 2023 15:55:57 GMT
       x-ms-page-write:
       - update
       x-ms-range:
@@ -2472,11 +2652,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 24 Aug 2023 16:01:12 GMT
+      - Tue, 29 Aug 2023 15:55:57 GMT
       etag:
-      - '"0x8DBA4BB56A41849"'
+      - '"0x8DBA8A86EFD541F"'
       last-modified:
-      - Thu, 24 Aug 2023 16:01:12 GMT
+      - Tue, 29 Aug 2023 15:55:57 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-sequence-number:
@@ -2506,7 +2686,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: POST
-    uri: https://ubuntupublisherubuntuacrd18ac8e07e.azurecr.io/v2/ubuntu-vm-arm-template/blobs/uploads/
+    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/v2/ubuntu-vm-arm-template/blobs/uploads/
   response:
     body:
       string: '{"errors": [{"code": "UNAUTHORIZED", "message": "authentication required,
@@ -2526,7 +2706,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:01:12 GMT
+      - Tue, 29 Aug 2023 15:55:58 GMT
       docker-distribution-api-version:
       - registry/2.0
       server:
@@ -2535,7 +2715,7 @@ interactions:
       - max-age=31536000; includeSubDomains
       - max-age=31536000; includeSubDomains
       www-authenticate:
-      - Bearer realm="https://ubuntupublisherubuntuacrd18ac8e07e.azurecr.io/oauth2/token",service="ubuntupublisherubuntuacrd18ac8e07e.azurecr.io",scope="repository:ubuntu-vm-arm-template:pull,push"
+      - Bearer realm="https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/oauth2/token",service="ubuntupublisherubuntuacr8e894d23e6.azurecr.io",scope="repository:ubuntu-vm-arm-template:pull,push"
       x-content-type-options:
       - nosniff
     status:
@@ -2551,11 +2731,11 @@ interactions:
       Connection:
       - keep-alive
       Service:
-      - ubuntupublisherubuntuacrd18ac8e07e.azurecr.io
+      - ubuntupublisherubuntuacr8e894d23e6.azurecr.io
       User-Agent:
       - oras-py
     method: GET
-    uri: https://ubuntupublisherubuntuacrd18ac8e07e.azurecr.io/oauth2/token?service=ubuntupublisherubuntuacrd18ac8e07e.azurecr.io&scope=repository%3Aubuntu-vm-arm-template%3Apull%2Cpush
+    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/oauth2/token?service=ubuntupublisherubuntuacr8e894d23e6.azurecr.io&scope=repository%3Aubuntu-vm-arm-template%3Apull%2Cpush
   response:
     body:
       string: '{"access_token": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}'
@@ -2565,7 +2745,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:01:13 GMT
+      - Tue, 29 Aug 2023 15:55:58 GMT
       server:
       - openresty
       strict-transport-security:
@@ -2593,7 +2773,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: POST
-    uri: https://ubuntupublisherubuntuacrd18ac8e07e.azurecr.io/v2/ubuntu-vm-arm-template/blobs/uploads/
+    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/v2/ubuntu-vm-arm-template/blobs/uploads/
   response:
     body:
       string: ''
@@ -2608,13 +2788,13 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 24 Aug 2023 16:01:13 GMT
+      - Tue, 29 Aug 2023 15:55:58 GMT
       docker-distribution-api-version:
       - registry/2.0
       docker-upload-uuid:
-      - 318bd0c2-5f8b-4447-b03c-f5609fb06ded
+      - 5fadc8f5-b3d6-40d1-8668-3e4af73befb7
       location:
-      - /v2/ubuntu-vm-arm-template/blobs/uploads/318bd0c2-5f8b-4447-b03c-f5609fb06ded?_nouploadcache=false&_state=yua3eMmBqFsoh1C2o6dfh6QMukkV28S5EIRr1fKCuJt7Ik5hbWUiOiJ1YnVudHUtdm0tYXJtLXRlbXBsYXRlIiwiVVVJRCI6IjMxOGJkMGMyLTVmOGItNDQ0Ny1iMDNjLWY1NjA5ZmIwNmRlZCIsIk9mZnNldCI6MCwiU3RhcnRlZEF0IjoiMjAyMy0wOC0yNFQxNjowMToxMy4yODUyNDQwNVoifQ%3D%3D
+      - /v2/ubuntu-vm-arm-template/blobs/uploads/5fadc8f5-b3d6-40d1-8668-3e4af73befb7?_nouploadcache=false&_state=4Fo-lXSoT6fpl62615Nxz5oPtqNHHDwXHb3REoA7pbx7Ik5hbWUiOiJ1YnVudHUtdm0tYXJtLXRlbXBsYXRlIiwiVVVJRCI6IjVmYWRjOGY1LWIzZDYtNDBkMS04NjY4LTNlNGFmNzNiZWZiNyIsIk9mZnNldCI6MCwiU3RhcnRlZEF0IjoiMjAyMy0wOC0yOVQxNTo1NTo1OC41MzEzMDc3NTVaIn0%3D
       range:
       - 0-0
       server:
@@ -2687,7 +2867,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: PUT
-    uri: https://ubuntupublisherubuntuacrd18ac8e07e.azurecr.io/v2/ubuntu-vm-arm-template/blobs/uploads/318bd0c2-5f8b-4447-b03c-f5609fb06ded?_nouploadcache=false&_state=yua3eMmBqFsoh1C2o6dfh6QMukkV28S5EIRr1fKCuJt7Ik5hbWUiOiJ1YnVudHUtdm0tYXJtLXRlbXBsYXRlIiwiVVVJRCI6IjMxOGJkMGMyLTVmOGItNDQ0Ny1iMDNjLWY1NjA5ZmIwNmRlZCIsIk9mZnNldCI6MCwiU3RhcnRlZEF0IjoiMjAyMy0wOC0yNFQxNjowMToxMy4yODUyNDQwNVoifQ%3D%3D&digest=sha256%3Ae71bf56543dc33dc8e550a0c574efe9a4875754a4ddf74347e448dec2462798b
+    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/v2/ubuntu-vm-arm-template/blobs/uploads/5fadc8f5-b3d6-40d1-8668-3e4af73befb7?_nouploadcache=false&_state=4Fo-lXSoT6fpl62615Nxz5oPtqNHHDwXHb3REoA7pbx7Ik5hbWUiOiJ1YnVudHUtdm0tYXJtLXRlbXBsYXRlIiwiVVVJRCI6IjVmYWRjOGY1LWIzZDYtNDBkMS04NjY4LTNlNGFmNzNiZWZiNyIsIk9mZnNldCI6MCwiU3RhcnRlZEF0IjoiMjAyMy0wOC0yOVQxNTo1NTo1OC41MzEzMDc3NTVaIn0%3D&digest=sha256%3Ae71bf56543dc33dc8e550a0c574efe9a4875754a4ddf74347e448dec2462798b
   response:
     body:
       string: ''
@@ -2702,7 +2882,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 24 Aug 2023 16:01:13 GMT
+      - Tue, 29 Aug 2023 15:55:58 GMT
       docker-content-digest:
       - sha256:e71bf56543dc33dc8e550a0c574efe9a4875754a4ddf74347e448dec2462798b
       docker-distribution-api-version:
@@ -2735,7 +2915,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: POST
-    uri: https://ubuntupublisherubuntuacrd18ac8e07e.azurecr.io/v2/ubuntu-vm-arm-template/blobs/uploads/
+    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/v2/ubuntu-vm-arm-template/blobs/uploads/
   response:
     body:
       string: '{"errors": [{"code": "UNAUTHORIZED", "message": "authentication required,
@@ -2755,7 +2935,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:01:13 GMT
+      - Tue, 29 Aug 2023 15:55:58 GMT
       docker-distribution-api-version:
       - registry/2.0
       server:
@@ -2764,7 +2944,7 @@ interactions:
       - max-age=31536000; includeSubDomains
       - max-age=31536000; includeSubDomains
       www-authenticate:
-      - Bearer realm="https://ubuntupublisherubuntuacrd18ac8e07e.azurecr.io/oauth2/token",service="ubuntupublisherubuntuacrd18ac8e07e.azurecr.io",scope="repository:ubuntu-vm-arm-template:pull,push"
+      - Bearer realm="https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/oauth2/token",service="ubuntupublisherubuntuacr8e894d23e6.azurecr.io",scope="repository:ubuntu-vm-arm-template:pull,push"
       x-content-type-options:
       - nosniff
     status:
@@ -2780,11 +2960,11 @@ interactions:
       Connection:
       - keep-alive
       Service:
-      - ubuntupublisherubuntuacrd18ac8e07e.azurecr.io
+      - ubuntupublisherubuntuacr8e894d23e6.azurecr.io
       User-Agent:
       - oras-py
     method: GET
-    uri: https://ubuntupublisherubuntuacrd18ac8e07e.azurecr.io/oauth2/token?service=ubuntupublisherubuntuacrd18ac8e07e.azurecr.io&scope=repository%3Aubuntu-vm-arm-template%3Apull%2Cpush
+    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/oauth2/token?service=ubuntupublisherubuntuacr8e894d23e6.azurecr.io&scope=repository%3Aubuntu-vm-arm-template%3Apull%2Cpush
   response:
     body:
       string: '{"access_token": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}'
@@ -2794,7 +2974,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:01:14 GMT
+      - Tue, 29 Aug 2023 15:55:59 GMT
       server:
       - openresty
       strict-transport-security:
@@ -2822,7 +3002,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: POST
-    uri: https://ubuntupublisherubuntuacrd18ac8e07e.azurecr.io/v2/ubuntu-vm-arm-template/blobs/uploads/
+    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/v2/ubuntu-vm-arm-template/blobs/uploads/
   response:
     body:
       string: ''
@@ -2837,13 +3017,13 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 24 Aug 2023 16:01:14 GMT
+      - Tue, 29 Aug 2023 15:55:59 GMT
       docker-distribution-api-version:
       - registry/2.0
       docker-upload-uuid:
-      - c733ba94-4aa0-4db7-8194-798e0a015dde
+      - a4753e4b-54a9-4fc6-8e84-99359fdf505f
       location:
-      - /v2/ubuntu-vm-arm-template/blobs/uploads/c733ba94-4aa0-4db7-8194-798e0a015dde?_nouploadcache=false&_state=_eLGyAG_Buj8oQSC8ZMELwlVo3B6PYur8ugIhkdl85J7Ik5hbWUiOiJ1YnVudHUtdm0tYXJtLXRlbXBsYXRlIiwiVVVJRCI6ImM3MzNiYTk0LTRhYTAtNGRiNy04MTk0LTc5OGUwYTAxNWRkZSIsIk9mZnNldCI6MCwiU3RhcnRlZEF0IjoiMjAyMy0wOC0yNFQxNjowMToxNC4yMzgwNjg4NDFaIn0%3D
+      - /v2/ubuntu-vm-arm-template/blobs/uploads/a4753e4b-54a9-4fc6-8e84-99359fdf505f?_nouploadcache=false&_state=brpszlUaMZlcgHIXdbdAImcdrg0zRwo_CWknisOSRap7Ik5hbWUiOiJ1YnVudHUtdm0tYXJtLXRlbXBsYXRlIiwiVVVJRCI6ImE0NzUzZTRiLTU0YTktNGZjNi04ZTg0LTk5MzU5ZmRmNTA1ZiIsIk9mZnNldCI6MCwiU3RhcnRlZEF0IjoiMjAyMy0wOC0yOVQxNTo1NTo1OS4zMTA2MTY1OTVaIn0%3D
       range:
       - 0-0
       server:
@@ -2872,7 +3052,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: PUT
-    uri: https://ubuntupublisherubuntuacrd18ac8e07e.azurecr.io/v2/ubuntu-vm-arm-template/blobs/uploads/c733ba94-4aa0-4db7-8194-798e0a015dde?_nouploadcache=false&_state=_eLGyAG_Buj8oQSC8ZMELwlVo3B6PYur8ugIhkdl85J7Ik5hbWUiOiJ1YnVudHUtdm0tYXJtLXRlbXBsYXRlIiwiVVVJRCI6ImM3MzNiYTk0LTRhYTAtNGRiNy04MTk0LTc5OGUwYTAxNWRkZSIsIk9mZnNldCI6MCwiU3RhcnRlZEF0IjoiMjAyMy0wOC0yNFQxNjowMToxNC4yMzgwNjg4NDFaIn0%3D&digest=sha256%3Ae3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/v2/ubuntu-vm-arm-template/blobs/uploads/a4753e4b-54a9-4fc6-8e84-99359fdf505f?_nouploadcache=false&_state=brpszlUaMZlcgHIXdbdAImcdrg0zRwo_CWknisOSRap7Ik5hbWUiOiJ1YnVudHUtdm0tYXJtLXRlbXBsYXRlIiwiVVVJRCI6ImE0NzUzZTRiLTU0YTktNGZjNi04ZTg0LTk5MzU5ZmRmNTA1ZiIsIk9mZnNldCI6MCwiU3RhcnRlZEF0IjoiMjAyMy0wOC0yOVQxNTo1NTo1OS4zMTA2MTY1OTVaIn0%3D&digest=sha256%3Ae3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   response:
     body:
       string: ''
@@ -2887,7 +3067,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 24 Aug 2023 16:01:14 GMT
+      - Tue, 29 Aug 2023 15:55:59 GMT
       docker-content-digest:
       - sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       docker-distribution-api-version:
@@ -2926,7 +3106,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: PUT
-    uri: https://ubuntupublisherubuntuacrd18ac8e07e.azurecr.io/v2/ubuntu-vm-arm-template/manifests/1.0.0
+    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/v2/ubuntu-vm-arm-template/manifests/1.0.0
   response:
     body:
       string: '{"errors": [{"code": "UNAUTHORIZED", "message": "authentication required,
@@ -2946,7 +3126,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:01:14 GMT
+      - Tue, 29 Aug 2023 15:55:59 GMT
       docker-distribution-api-version:
       - registry/2.0
       server:
@@ -2955,7 +3135,7 @@ interactions:
       - max-age=31536000; includeSubDomains
       - max-age=31536000; includeSubDomains
       www-authenticate:
-      - Bearer realm="https://ubuntupublisherubuntuacrd18ac8e07e.azurecr.io/oauth2/token",service="ubuntupublisherubuntuacrd18ac8e07e.azurecr.io",scope="repository:ubuntu-vm-arm-template:pull,push"
+      - Bearer realm="https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/oauth2/token",service="ubuntupublisherubuntuacr8e894d23e6.azurecr.io",scope="repository:ubuntu-vm-arm-template:pull,push"
       x-content-type-options:
       - nosniff
     status:
@@ -2971,11 +3151,11 @@ interactions:
       Connection:
       - keep-alive
       Service:
-      - ubuntupublisherubuntuacrd18ac8e07e.azurecr.io
+      - ubuntupublisherubuntuacr8e894d23e6.azurecr.io
       User-Agent:
       - oras-py
     method: GET
-    uri: https://ubuntupublisherubuntuacrd18ac8e07e.azurecr.io/oauth2/token?service=ubuntupublisherubuntuacrd18ac8e07e.azurecr.io&scope=repository%3Aubuntu-vm-arm-template%3Apull%2Cpush
+    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/oauth2/token?service=ubuntupublisherubuntuacr8e894d23e6.azurecr.io&scope=repository%3Aubuntu-vm-arm-template%3Apull%2Cpush
   response:
     body:
       string: '{"access_token": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}'
@@ -2985,7 +3165,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:01:14 GMT
+      - Tue, 29 Aug 2023 15:55:59 GMT
       server:
       - openresty
       strict-transport-security:
@@ -3019,7 +3199,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: PUT
-    uri: https://ubuntupublisherubuntuacrd18ac8e07e.azurecr.io/v2/ubuntu-vm-arm-template/manifests/1.0.0
+    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/v2/ubuntu-vm-arm-template/manifests/1.0.0
   response:
     body:
       string: ''
@@ -3034,7 +3214,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 24 Aug 2023 16:01:15 GMT
+      - Tue, 29 Aug 2023 15:56:00 GMT
       docker-content-digest:
       - sha256:8923fa544da97914212bc9173ec512741d331940e4a2c7b6fbad979657a5c507
       docker-distribution-api-version:
@@ -3125,8 +3305,8 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/validate?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1692892875",
-        "name": "AOSM_CLI_deployment_1692892875", "type": "Microsoft.Resources/deployments",
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693324562",
+        "name": "AOSM_CLI_deployment_1693324562", "type": "Microsoft.Resources/deployments",
         "properties": {"templateHash": "1926705401567781373", "parameters": {"location":
         {"type": "String", "value": "westcentralus"}, "publisherName": {"type": "String",
         "value": "ubuntuPublisher"}, "acrArtifactStoreName": {"type": "String", "value":
@@ -3136,7 +3316,7 @@ interactions:
         "value": "1.0.0"}, "vhdVersion": {"type": "String", "value": "1-0-0"}, "armTemplateVersion":
         {"type": "String", "value": "1.0.0"}}, "mode": "Incremental", "provisioningState":
         "Succeeded", "timestamp": "0001-01-01T00:00:00Z", "duration": "PT0S", "correlationId":
-        "8d120c37-9714-4a7e-a5c6-9e948899fb6a", "providers": [{"namespace": "Microsoft.Hybridnetwork",
+        "358fefb4-997e-4764-93ee-8dce6e41f410", "providers": [{"namespace": "Microsoft.Hybridnetwork",
         "resourceTypes": [{"resourceType": "publishers/networkfunctiondefinitiongroups/networkfunctiondefinitionversions",
         "locations": ["westcentralus"]}]}], "dependencies": [], "validatedResources":
         [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/ubuntuPublisher/networkfunctiondefinitiongroups/ubuntu-vm-nfdg/networkfunctiondefinitionversions/1.0.0"}]}}'
@@ -3148,7 +3328,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:01:18 GMT
+      - Tue, 29 Aug 2023 15:56:03 GMT
       expires:
       - '-1'
       pragma:
@@ -3240,8 +3420,8 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1692892875",
-        "name": "AOSM_CLI_deployment_1692892875", "type": "Microsoft.Resources/deployments",
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693324562",
+        "name": "AOSM_CLI_deployment_1693324562", "type": "Microsoft.Resources/deployments",
         "properties": {"templateHash": "1926705401567781373", "parameters": {"location":
         {"type": "String", "value": "westcentralus"}, "publisherName": {"type": "String",
         "value": "ubuntuPublisher"}, "acrArtifactStoreName": {"type": "String", "value":
@@ -3250,21 +3430,21 @@ interactions:
         "String", "value": "ubuntu-vm-nfdg"}, "nfDefinitionVersion": {"type": "String",
         "value": "1.0.0"}, "vhdVersion": {"type": "String", "value": "1-0-0"}, "armTemplateVersion":
         {"type": "String", "value": "1.0.0"}}, "mode": "Incremental", "provisioningState":
-        "Accepted", "timestamp": "2023-08-24T16:01:20.881841Z", "duration": "PT0.0006239S",
-        "correlationId": "8f411ae7-1d8e-4d24-8abf-69a39a3a0c27", "providers": [{"namespace":
+        "Accepted", "timestamp": "2023-08-29T15:56:07.0620969Z", "duration": "PT0.0001316S",
+        "correlationId": "c12ea2f4-c906-4529-961f-4faf217719d0", "providers": [{"namespace":
         "Microsoft.Hybridnetwork", "resourceTypes": [{"resourceType": "publishers/networkfunctiondefinitiongroups/networkfunctiondefinitionversions",
         "locations": ["westcentralus"]}]}], "dependencies": []}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1692892875/operationStatuses/08585087140052578905?api-version=2022-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693324562/operationStatuses/08585082823207719763?api-version=2022-09-01
       cache-control:
       - no-cache
       content-length:
-      - '1296'
+      - '1297'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:01:20 GMT
+      - Tue, 29 Aug 2023 15:56:07 GMT
       expires:
       - '-1'
       pragma:
@@ -3294,7 +3474,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585087140052578905?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585082823207719763?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Accepted"}'
@@ -3306,7 +3486,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:01:20 GMT
+      - Tue, 29 Aug 2023 15:56:08 GMT
       expires:
       - '-1'
       pragma:
@@ -3336,7 +3516,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585087140052578905?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585082823207719763?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Running"}'
@@ -3348,7 +3528,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:01:51 GMT
+      - Tue, 29 Aug 2023 15:56:38 GMT
       expires:
       - '-1'
       pragma:
@@ -3378,7 +3558,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585087140052578905?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585082823207719763?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Running"}'
@@ -3390,7 +3570,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:02:36 GMT
+      - Tue, 29 Aug 2023 15:57:09 GMT
       expires:
       - '-1'
       pragma:
@@ -3420,7 +3600,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585087140052578905?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585082823207719763?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Succeeded"}'
@@ -3432,7 +3612,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:03:07 GMT
+      - Tue, 29 Aug 2023 15:57:39 GMT
       expires:
       - '-1'
       pragma:
@@ -3465,8 +3645,8 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1692892875",
-        "name": "AOSM_CLI_deployment_1692892875", "type": "Microsoft.Resources/deployments",
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693324562",
+        "name": "AOSM_CLI_deployment_1693324562", "type": "Microsoft.Resources/deployments",
         "properties": {"templateHash": "1926705401567781373", "parameters": {"location":
         {"type": "String", "value": "westcentralus"}, "publisherName": {"type": "String",
         "value": "ubuntuPublisher"}, "acrArtifactStoreName": {"type": "String", "value":
@@ -3475,22 +3655,20 @@ interactions:
         "String", "value": "ubuntu-vm-nfdg"}, "nfDefinitionVersion": {"type": "String",
         "value": "1.0.0"}, "vhdVersion": {"type": "String", "value": "1-0-0"}, "armTemplateVersion":
         {"type": "String", "value": "1.0.0"}}, "mode": "Incremental", "provisioningState":
-        "Succeeded", "timestamp": "2023-08-24T16:02:39.2124156Z", "duration": "PT1M18.3311985S",
-        "correlationId": "8f411ae7-1d8e-4d24-8abf-69a39a3a0c27", "providers": [{"namespace":
+        "Succeeded", "timestamp": "2023-08-29T15:57:28.5850113Z", "duration": "PT1M21.523046S",
+        "correlationId": "c12ea2f4-c906-4529-961f-4faf217719d0", "providers": [{"namespace":
         "Microsoft.Hybridnetwork", "resourceTypes": [{"resourceType": "publishers/networkfunctiondefinitiongroups/networkfunctiondefinitionversions",
         "locations": ["westcentralus"]}]}], "dependencies": [], "outputResources":
         [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/ubuntuPublisher/networkfunctiondefinitiongroups/ubuntu-vm-nfdg/networkfunctiondefinitionversions/1.0.0"}]}}'
     headers:
       cache-control:
       - no-cache
-      connection:
-      - close
       content-length:
-      - '1572'
+      - '1571'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:03:07 GMT
+      - Tue, 29 Aug 2023 15:57:39 GMT
       expires:
       - '-1'
       pragma:
@@ -3527,9 +3705,9 @@ interactions:
       string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/ubuntuPublisher/networkfunctiondefinitiongroups/ubuntu-vm-nfdg/networkfunctiondefinitionversions/1.0.0",
         "name": "1.0.0", "type": "microsoft.hybridnetwork/publishers/networkfunctiondefinitiongroups/networkfunctiondefinitionversions",
         "location": "westcentralus", "systemData": {"createdBy": "sunnycarter@microsoft.com",
-        "createdByType": "User", "createdAt": "2023-08-24T16:01:25.1475401Z", "lastModifiedBy":
+        "createdByType": "User", "createdAt": "2023-08-29T15:56:10.8293417Z", "lastModifiedBy":
         "sunnycarter@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2023-08-24T16:01:25.1475401Z"}, "properties": {"networkFunctionTemplate":
+        "2023-08-29T15:56:10.8293417Z"}, "properties": {"networkFunctionTemplate":
         {"networkFunctionApplications": [{"artifactProfile": {"vhdArtifactProfile":
         {"vhdName": "ubuntu-vm-vhd", "vhdVersion": "1-0-0"}, "artifactStore": {"id":
         "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store"}},
@@ -3553,9 +3731,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:03:08 GMT
+      - Tue, 29 Aug 2023 15:57:40 GMT
       etag:
-      - '"000095d9-0000-0600-0000-64e77ee30000"'
+      - '"00003600-0000-0600-0000-64ee152a0000"'
       expires:
       - '-1'
       pragma:
@@ -3570,6 +3748,186 @@ interactions:
       - nosniff
       x-ms-providerhub-traffic:
       - 'True'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json, text/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aosm nsd publish
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -f
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/Allow-2023-09-01?api-version=2021-07-01
+  response:
+    body:
+      string: '{"properties": {"state": "Registered"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/Allow-2023-09-01",
+        "type": "Microsoft.Features/providers/features", "name": "Microsoft.HybridNetwork/Allow-2023-09-01"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '290'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 29 Aug 2023 15:57:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json, text/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aosm nsd publish
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -f
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/AllowPreReleaseFeatures?api-version=2021-07-01
+  response:
+    body:
+      string: '{"properties": {"state": "Registered"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/AllowPreReleaseFeatures",
+        "type": "Microsoft.Features/providers/features", "name": "Microsoft.HybridNetwork/AllowPreReleaseFeatures"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 29 Aug 2023 15:57:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json, text/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aosm nsd publish
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -f
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/Allow-2023-04-01-preview?api-version=2021-07-01
+  response:
+    body:
+      string: '{"properties": {"state": "Registered"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/Allow-2023-04-01-preview",
+        "type": "Microsoft.Features/providers/features", "name": "Microsoft.HybridNetwork/Allow-2023-04-01-preview"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '306'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 29 Aug 2023 15:57:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json, text/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aosm nsd publish
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -f
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/MsiForResourceEnabled?api-version=2021-07-01
+  response:
+    body:
+      string: '{"properties": {"state": "Registered"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/MsiForResourceEnabled",
+        "type": "Microsoft.Features/providers/features", "name": "Microsoft.HybridNetwork/MsiForResourceEnabled"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '300'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 29 Aug 2023 15:57:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
     status:
       code: 200
       message: OK
@@ -3599,7 +3957,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 24 Aug 2023 16:03:08 GMT
+      - Tue, 29 Aug 2023 15:57:41 GMT
       expires:
       - '-1'
       pragma:
@@ -3633,8 +3991,8 @@ interactions:
       string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001",
         "name": "cli_test_vnf_nsd_000001", "type": "Microsoft.Resources/resourceGroups",
         "location": "westcentralus", "tags": {"product": "azurecli", "cause": "automation",
-        "test": "test_vnf_nsd_publish_and_delete", "date": "2023-08-24T15:51:56Z",
-        "module": "aosm", "autoDelete": "true", "expiresOn": "2023-09-23T15:51:58.4231943Z"},
+        "test": "test_vnf_nsd_publish_and_delete", "date": "2023-08-29T15:46:31Z",
+        "module": "aosm", "autoDelete": "true", "expiresOn": "2023-09-28T15:46:31.4504856Z"},
         "properties": {"provisioningState": "Succeeded"}}'
     headers:
       cache-control:
@@ -3644,7 +4002,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:03:08 GMT
+      - Tue, 29 Aug 2023 15:57:41 GMT
       expires:
       - '-1'
       pragma:
@@ -3681,21 +4039,21 @@ interactions:
       string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher",
         "name": "ubuntuPublisher", "type": "microsoft.hybridnetwork/publishers", "location":
         "westcentralus", "systemData": {"createdBy": "sunnycarter@microsoft.com",
-        "createdByType": "User", "createdAt": "2023-08-24T15:52:00.8042955Z", "lastModifiedBy":
+        "createdByType": "User", "createdAt": "2023-08-29T15:46:35.343537Z", "lastModifiedBy":
         "sunnycarter@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2023-08-24T15:52:00.8042955Z"}, "properties": {"scope": "Private", "provisioningState":
+        "2023-08-29T15:46:35.343537Z"}, "properties": {"scope": "Private", "provisioningState":
         "Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '588'
+      - '586'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:03:08 GMT
+      - Tue, 29 Aug 2023 15:57:42 GMT
       etag:
-      - '"20000fd7-0000-0600-0000-64e77cad0000"'
+      - '"00003c03-0000-0600-0000-64ee12e60000"'
       expires:
       - '-1'
       pragma:
@@ -3736,12 +4094,12 @@ interactions:
       string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr",
         "name": "ubuntu-acr", "type": "microsoft.hybridnetwork/publishers/artifactstores",
         "location": "westcentralus", "systemData": {"createdBy": "sunnycarter@microsoft.com",
-        "createdByType": "User", "createdAt": "2023-08-24T15:53:33.3686433Z", "lastModifiedBy":
+        "createdByType": "User", "createdAt": "2023-08-29T15:48:08.8909773Z", "lastModifiedBy":
         "b8ed041c-aa91-418e-8f47-20c70abc2de1", "lastModifiedByType": "Application",
-        "lastModifiedAt": "2023-08-24T16:01:38.4961035Z"}, "properties": {"storeType":
+        "lastModifiedAt": "2023-08-29T15:56:25.5771605Z"}, "properties": {"storeType":
         "AzureContainerRegistry", "replicationStrategy": "SingleReplication", "managedResourceGroupConfiguration":
-        {"name": "ubuntu-acr-HostedResources-59B033BE", "location": "westcentralus"},
-        "provisioningState": "Succeeded", "storageResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/ubuntu-acr-HostedResources-59B033BE/providers/Microsoft.ContainerRegistry/registries/UbuntupublisherUbuntuAcrd18ac8e07e"}}'
+        {"name": "ubuntu-acr-HostedResources-663B284E", "location": "westcentralus"},
+        "provisioningState": "Succeeded", "storageResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/ubuntu-acr-HostedResources-663B284E/providers/Microsoft.ContainerRegistry/registries/UbuntupublisherUbuntuAcr8e894d23e6"}}'
     headers:
       cache-control:
       - no-cache
@@ -3750,9 +4108,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:03:09 GMT
+      - Tue, 29 Aug 2023 15:57:42 GMT
       etag:
-      - '"17009c28-0000-0600-0000-64e77ee20000"'
+      - '"0000ec2e-0000-0600-0000-64ee152a0000"'
       expires:
       - '-1'
       pragma:
@@ -3797,13 +4155,13 @@ interactions:
       string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkServiceDesignGroups/ubuntu",
         "name": "ubuntu", "type": "microsoft.hybridnetwork/publishers/networkservicedesigngroups",
         "location": "westcentralus", "systemData": {"createdBy": "sunnycarter@microsoft.com",
-        "createdByType": "User", "createdAt": "2023-08-24T16:03:10.7668139Z", "lastModifiedBy":
+        "createdByType": "User", "createdAt": "2023-08-29T15:57:43.9163403Z", "lastModifiedBy":
         "sunnycarter@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2023-08-24T16:03:10.7668139Z"}, "properties": {"description": null, "provisioningState":
+        "2023-08-29T15:57:43.9163403Z"}, "properties": {"description": null, "provisioningState":
         "Accepted"}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/82069ad7-f304-484a-a9fe-a9fff161c55b*53C8DC39476B596E433AF2FA0B23E756482A041129272170226926D9542C88A2?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/8e5f8d49-efa6-47d9-8cdd-6ed90c40c51f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -3811,9 +4169,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:03:12 GMT
+      - Tue, 29 Aug 2023 15:57:53 GMT
       etag:
-      - '"02005298-0000-0600-0000-64e77f410000"'
+      - '"00003901-0000-0600-0000-64ee15810000"'
       expires:
       - '-1'
       pragma:
@@ -3848,24 +4206,24 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/82069ad7-f304-484a-a9fe-a9fff161c55b*53C8DC39476B596E433AF2FA0B23E756482A041129272170226926D9542C88A2?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/8e5f8d49-efa6-47d9-8cdd-6ed90c40c51f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/82069ad7-f304-484a-a9fe-a9fff161c55b*53C8DC39476B596E433AF2FA0B23E756482A041129272170226926D9542C88A2",
-        "name": "82069ad7-f304-484a-a9fe-a9fff161c55b*53C8DC39476B596E433AF2FA0B23E756482A041129272170226926D9542C88A2",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/8e5f8d49-efa6-47d9-8cdd-6ed90c40c51f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B",
+        "name": "8e5f8d49-efa6-47d9-8cdd-6ed90c40c51f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkServiceDesignGroups/ubuntu",
-        "status": "Accepted", "startTime": "2023-08-24T16:03:12.8156983Z"}'
+        "status": "Accepted", "startTime": "2023-08-29T15:57:53.242231Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '571'
+      - '570'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:03:12 GMT
+      - Tue, 29 Aug 2023 15:57:53 GMT
       etag:
-      - '"0d00a438-0000-0600-0000-64e77f400000"'
+      - '"00002606-0000-0600-0000-64ee15810000"'
       expires:
       - '-1'
       pragma:
@@ -3898,25 +4256,25 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/82069ad7-f304-484a-a9fe-a9fff161c55b*53C8DC39476B596E433AF2FA0B23E756482A041129272170226926D9542C88A2?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/8e5f8d49-efa6-47d9-8cdd-6ed90c40c51f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/82069ad7-f304-484a-a9fe-a9fff161c55b*53C8DC39476B596E433AF2FA0B23E756482A041129272170226926D9542C88A2",
-        "name": "82069ad7-f304-484a-a9fe-a9fff161c55b*53C8DC39476B596E433AF2FA0B23E756482A041129272170226926D9542C88A2",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/8e5f8d49-efa6-47d9-8cdd-6ed90c40c51f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B",
+        "name": "8e5f8d49-efa6-47d9-8cdd-6ed90c40c51f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkServiceDesignGroups/ubuntu",
-        "status": "Succeeded", "startTime": "2023-08-24T16:03:12.8156983Z", "endTime":
-        "2023-08-24T16:03:17.7056886Z", "properties": null}'
+        "status": "Succeeded", "startTime": "2023-08-29T15:57:53.242231Z", "endTime":
+        "2023-08-29T15:58:01.2586688Z", "properties": null}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '635'
+      - '634'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:03:43 GMT
+      - Tue, 29 Aug 2023 15:58:24 GMT
       etag:
-      - '"0d00a638-0000-0600-0000-64e77f450000"'
+      - '"00002706-0000-0600-0000-64ee15890000"'
       expires:
       - '-1'
       pragma:
@@ -3955,9 +4313,9 @@ interactions:
       string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkServiceDesignGroups/ubuntu",
         "name": "ubuntu", "type": "microsoft.hybridnetwork/publishers/networkservicedesigngroups",
         "location": "westcentralus", "systemData": {"createdBy": "sunnycarter@microsoft.com",
-        "createdByType": "User", "createdAt": "2023-08-24T16:03:10.7668139Z", "lastModifiedBy":
+        "createdByType": "User", "createdAt": "2023-08-29T15:57:43.9163403Z", "lastModifiedBy":
         "sunnycarter@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2023-08-24T16:03:10.7668139Z"}, "properties": {"description": null, "provisioningState":
+        "2023-08-29T15:57:43.9163403Z"}, "properties": {"description": null, "provisioningState":
         "Succeeded"}}'
     headers:
       cache-control:
@@ -3967,9 +4325,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:03:43 GMT
+      - Tue, 29 Aug 2023 15:58:24 GMT
       etag:
-      - '"02005398-0000-0600-0000-64e77f450000"'
+      - '"00003a01-0000-0600-0000-64ee15890000"'
       expires:
       - '-1'
       pragma:
@@ -4018,7 +4376,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:03:44 GMT
+      - Tue, 29 Aug 2023 15:58:25 GMT
       expires:
       - '-1'
       pragma:
@@ -4078,8 +4436,8 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/validate?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1692893028",
-        "name": "AOSM_CLI_deployment_1692893028", "type": "Microsoft.Resources/deployments",
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693324707",
+        "name": "AOSM_CLI_deployment_1693324707", "type": "Microsoft.Resources/deployments",
         "properties": {"templateHash": "2851085707422332070", "parameters": {"location":
         {"type": "String", "value": "westcentralus"}, "publisherName": {"type": "String",
         "value": "ubuntuPublisher"}, "acrArtifactStoreName": {"type": "String", "value":
@@ -4087,7 +4445,7 @@ interactions:
         "armTemplateNames": {"type": "Array", "value": ["ubuntu-vm-nfdg_nf_artifact"]},
         "armTemplateVersion": {"type": "String", "value": "1.0.0"}}, "mode": "Incremental",
         "provisioningState": "Succeeded", "timestamp": "0001-01-01T00:00:00Z", "duration":
-        "PT0S", "correlationId": "07a53220-6f0d-42af-894e-16e9234fbaf9", "providers":
+        "PT0S", "correlationId": "c7001363-001e-40fd-957e-3e8d9eec8f78", "providers":
         [{"namespace": "Microsoft.Hybridnetwork", "resourceTypes": [{"resourceType":
         "publishers/artifactStores/artifactManifests", "locations": ["westcentralus"]}]}],
         "dependencies": [], "validatedResources": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-nfdg-nf-acr-manifest-1-0-0"}]}}'
@@ -4099,7 +4457,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:03:49 GMT
+      - Tue, 29 Aug 2023 15:58:29 GMT
       expires:
       - '-1'
       pragma:
@@ -4163,30 +4521,30 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1692893028",
-        "name": "AOSM_CLI_deployment_1692893028", "type": "Microsoft.Resources/deployments",
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693324707",
+        "name": "AOSM_CLI_deployment_1693324707", "type": "Microsoft.Resources/deployments",
         "properties": {"templateHash": "2851085707422332070", "parameters": {"location":
         {"type": "String", "value": "westcentralus"}, "publisherName": {"type": "String",
         "value": "ubuntuPublisher"}, "acrArtifactStoreName": {"type": "String", "value":
         "ubuntu-acr"}, "acrManifestNames": {"type": "Array", "value": ["ubuntu-vm-nfdg-nf-acr-manifest-1-0-0"]},
         "armTemplateNames": {"type": "Array", "value": ["ubuntu-vm-nfdg_nf_artifact"]},
         "armTemplateVersion": {"type": "String", "value": "1.0.0"}}, "mode": "Incremental",
-        "provisioningState": "Accepted", "timestamp": "2023-08-24T16:03:52.144488Z",
-        "duration": "PT0.0001188S", "correlationId": "4eccbc67-0868-45b8-9bbe-cd5b24067d41",
+        "provisioningState": "Accepted", "timestamp": "2023-08-29T15:58:32.6763857Z",
+        "duration": "PT0.0002267S", "correlationId": "09cc96a3-cdc7-44c1-bb35-9d1fbb6828c7",
         "providers": [{"namespace": "Microsoft.Hybridnetwork", "resourceTypes": [{"resourceType":
         "publishers/artifactStores/artifactManifests", "locations": ["westcentralus"]}]}],
         "dependencies": []}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1692893028/operationStatuses/08585087138547804458?api-version=2022-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693324707/operationStatuses/08585082821741459869?api-version=2022-09-01
       cache-control:
       - no-cache
       content-length:
-      - '1127'
+      - '1128'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:03:52 GMT
+      - Tue, 29 Aug 2023 15:58:33 GMT
       expires:
       - '-1'
       pragma:
@@ -4216,7 +4574,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585087138547804458?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585082821741459869?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Accepted"}'
@@ -4228,7 +4586,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:03:53 GMT
+      - Tue, 29 Aug 2023 15:58:33 GMT
       expires:
       - '-1'
       pragma:
@@ -4258,7 +4616,49 @@ interactions:
       User-Agent:
       - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585087138547804458?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585082821741459869?api-version=2022-09-01
+  response:
+    body:
+      string: '{"status": "Running"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 29 Aug 2023 15:59:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aosm nsd publish
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -f
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585082821741459869?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Succeeded"}'
@@ -4270,7 +4670,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:04:25 GMT
+      - Tue, 29 Aug 2023 15:59:33 GMT
       expires:
       - '-1'
       pragma:
@@ -4303,16 +4703,16 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1692893028",
-        "name": "AOSM_CLI_deployment_1692893028", "type": "Microsoft.Resources/deployments",
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693324707",
+        "name": "AOSM_CLI_deployment_1693324707", "type": "Microsoft.Resources/deployments",
         "properties": {"templateHash": "2851085707422332070", "parameters": {"location":
         {"type": "String", "value": "westcentralus"}, "publisherName": {"type": "String",
         "value": "ubuntuPublisher"}, "acrArtifactStoreName": {"type": "String", "value":
         "ubuntu-acr"}, "acrManifestNames": {"type": "Array", "value": ["ubuntu-vm-nfdg-nf-acr-manifest-1-0-0"]},
         "armTemplateNames": {"type": "Array", "value": ["ubuntu-vm-nfdg_nf_artifact"]},
         "armTemplateVersion": {"type": "String", "value": "1.0.0"}}, "mode": "Incremental",
-        "provisioningState": "Succeeded", "timestamp": "2023-08-24T16:04:20.6449064Z",
-        "duration": "PT28.5005372S", "correlationId": "4eccbc67-0868-45b8-9bbe-cd5b24067d41",
+        "provisioningState": "Succeeded", "timestamp": "2023-08-29T15:59:16.4310587Z",
+        "duration": "PT43.7548997S", "correlationId": "09cc96a3-cdc7-44c1-bb35-9d1fbb6828c7",
         "providers": [{"namespace": "Microsoft.Hybridnetwork", "resourceTypes": [{"resourceType":
         "publishers/artifactStores/artifactManifests", "locations": ["westcentralus"]}]}],
         "dependencies": [], "outputResources": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-nfdg-nf-acr-manifest-1-0-0"}]}}'
@@ -4324,7 +4724,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:04:25 GMT
+      - Tue, 29 Aug 2023 15:59:33 GMT
       expires:
       - '-1'
       pragma:
@@ -4361,9 +4761,9 @@ interactions:
       string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-nfdg-nf-acr-manifest-1-0-0",
         "name": "ubuntu-vm-nfdg-nf-acr-manifest-1-0-0", "type": "microsoft.hybridnetwork/publishers/artifactstores/artifactmanifests",
         "location": "westcentralus", "systemData": {"createdBy": "sunnycarter@microsoft.com",
-        "createdByType": "User", "createdAt": "2023-08-24T16:03:56.0771383Z", "lastModifiedBy":
+        "createdByType": "User", "createdAt": "2023-08-29T15:58:36.6237908Z", "lastModifiedBy":
         "sunnycarter@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2023-08-24T16:03:56.0771383Z"}, "properties": {"artifacts": [{"artifactName":
+        "2023-08-29T15:58:36.6237908Z"}, "properties": {"artifacts": [{"artifactName":
         "ubuntu-vm-nfdg_nf_artifact", "artifactType": "ArmTemplate", "artifactVersion":
         "1.0.0"}], "artifactManifestState": "Uploading", "provisioningState": "Succeeded"}}'
     headers:
@@ -4374,9 +4774,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:04:25 GMT
+      - Tue, 29 Aug 2023 15:59:35 GMT
       etag:
-      - '"2000a3ad-0000-0600-0000-64e77f7c0000"'
+      - '"00002e0f-0000-0600-0000-64ee15c20000"'
       expires:
       - '-1'
       pragma:
@@ -4417,8 +4817,8 @@ interactions:
   response:
     body:
       string: '{"username": "ubuntu-vm-nfdg-nf-acr-manifest-1-0-0", "acrToken": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-        "acrServerUrl": "https://ubuntupublisherubuntuacrd18ac8e07e.azurecr.io", "repositories":
-        ["ubuntu-vm-nfdg_nf_artifact"], "expiry": "2023-08-25T16:04:26.8180227+00:00",
+        "acrServerUrl": "https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io", "repositories":
+        ["ubuntu-vm-nfdg_nf_artifact"], "expiry": "2023-08-30T15:59:36.9854136+00:00",
         "credentialType": "AzureContainerRegistryScopedToken"}'
     headers:
       cache-control:
@@ -4428,7 +4828,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:04:27 GMT
+      - Tue, 29 Aug 2023 15:59:37 GMT
       expires:
       - '-1'
       pragma:
@@ -4466,7 +4866,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: POST
-    uri: https://ubuntupublisherubuntuacrd18ac8e07e.azurecr.io/v2/ubuntu-vm-nfdg_nf_artifact/blobs/uploads/
+    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/v2/ubuntu-vm-nfdg_nf_artifact/blobs/uploads/
   response:
     body:
       string: '{"errors": [{"code": "UNAUTHORIZED", "message": "authentication required,
@@ -4486,7 +4886,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:04:31 GMT
+      - Tue, 29 Aug 2023 15:59:40 GMT
       docker-distribution-api-version:
       - registry/2.0
       server:
@@ -4495,7 +4895,7 @@ interactions:
       - max-age=31536000; includeSubDomains
       - max-age=31536000; includeSubDomains
       www-authenticate:
-      - Bearer realm="https://ubuntupublisherubuntuacrd18ac8e07e.azurecr.io/oauth2/token",service="ubuntupublisherubuntuacrd18ac8e07e.azurecr.io",scope="repository:ubuntu-vm-nfdg_nf_artifact:pull,push"
+      - Bearer realm="https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/oauth2/token",service="ubuntupublisherubuntuacr8e894d23e6.azurecr.io",scope="repository:ubuntu-vm-nfdg_nf_artifact:pull,push"
       x-content-type-options:
       - nosniff
     status:
@@ -4511,11 +4911,11 @@ interactions:
       Connection:
       - keep-alive
       Service:
-      - ubuntupublisherubuntuacrd18ac8e07e.azurecr.io
+      - ubuntupublisherubuntuacr8e894d23e6.azurecr.io
       User-Agent:
       - oras-py
     method: GET
-    uri: https://ubuntupublisherubuntuacrd18ac8e07e.azurecr.io/oauth2/token?service=ubuntupublisherubuntuacrd18ac8e07e.azurecr.io&scope=repository%3Aubuntu-vm-nfdg_nf_artifact%3Apull%2Cpush
+    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/oauth2/token?service=ubuntupublisherubuntuacr8e894d23e6.azurecr.io&scope=repository%3Aubuntu-vm-nfdg_nf_artifact%3Apull%2Cpush
   response:
     body:
       string: '{"access_token": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}'
@@ -4525,7 +4925,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:04:31 GMT
+      - Tue, 29 Aug 2023 15:59:41 GMT
       server:
       - openresty
       strict-transport-security:
@@ -4553,7 +4953,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: POST
-    uri: https://ubuntupublisherubuntuacrd18ac8e07e.azurecr.io/v2/ubuntu-vm-nfdg_nf_artifact/blobs/uploads/
+    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/v2/ubuntu-vm-nfdg_nf_artifact/blobs/uploads/
   response:
     body:
       string: ''
@@ -4568,13 +4968,13 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 24 Aug 2023 16:04:32 GMT
+      - Tue, 29 Aug 2023 15:59:41 GMT
       docker-distribution-api-version:
       - registry/2.0
       docker-upload-uuid:
-      - fbc77141-8bc1-45b8-90b3-e36836fc2775
+      - 616589d9-557e-4af4-871d-f280e01b03a0
       location:
-      - /v2/ubuntu-vm-nfdg_nf_artifact/blobs/uploads/fbc77141-8bc1-45b8-90b3-e36836fc2775?_nouploadcache=false&_state=F7eDLjyvqwajCoX8cgmXk_BluQl1UgUObzDGjLPddR17Ik5hbWUiOiJ1YnVudHUtdm0tbmZkZ19uZl9hcnRpZmFjdCIsIlVVSUQiOiJmYmM3NzE0MS04YmMxLTQ1YjgtOTBiMy1lMzY4MzZmYzI3NzUiLCJPZmZzZXQiOjAsIlN0YXJ0ZWRBdCI6IjIwMjMtMDgtMjRUMTY6MDQ6MzEuOTAxODI0Mjg5WiJ9
+      - /v2/ubuntu-vm-nfdg_nf_artifact/blobs/uploads/616589d9-557e-4af4-871d-f280e01b03a0?_nouploadcache=false&_state=ITMtpjWT0X3FyZxRkfW8TSCsQEgfPobzsxGv3RD2amh7Ik5hbWUiOiJ1YnVudHUtdm0tbmZkZ19uZl9hcnRpZmFjdCIsIlVVSUQiOiI2MTY1ODlkOS01NTdlLTRhZjQtODcxZC1mMjgwZTAxYjAzYTAiLCJPZmZzZXQiOjAsIlN0YXJ0ZWRBdCI6IjIwMjMtMDgtMjlUMTU6NTk6NDEuMzI1OTkwNjQyWiJ9
       range:
       - 0-0
       server:
@@ -4641,7 +5041,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: PUT
-    uri: https://ubuntupublisherubuntuacrd18ac8e07e.azurecr.io/v2/ubuntu-vm-nfdg_nf_artifact/blobs/uploads/fbc77141-8bc1-45b8-90b3-e36836fc2775?_nouploadcache=false&_state=F7eDLjyvqwajCoX8cgmXk_BluQl1UgUObzDGjLPddR17Ik5hbWUiOiJ1YnVudHUtdm0tbmZkZ19uZl9hcnRpZmFjdCIsIlVVSUQiOiJmYmM3NzE0MS04YmMxLTQ1YjgtOTBiMy1lMzY4MzZmYzI3NzUiLCJPZmZzZXQiOjAsIlN0YXJ0ZWRBdCI6IjIwMjMtMDgtMjRUMTY6MDQ6MzEuOTAxODI0Mjg5WiJ9&digest=sha256%3Acda1bbb871260a2c7624e8adc401dec0667351f923fe545647b887e9f5271aad
+    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/v2/ubuntu-vm-nfdg_nf_artifact/blobs/uploads/616589d9-557e-4af4-871d-f280e01b03a0?_nouploadcache=false&_state=ITMtpjWT0X3FyZxRkfW8TSCsQEgfPobzsxGv3RD2amh7Ik5hbWUiOiJ1YnVudHUtdm0tbmZkZ19uZl9hcnRpZmFjdCIsIlVVSUQiOiI2MTY1ODlkOS01NTdlLTRhZjQtODcxZC1mMjgwZTAxYjAzYTAiLCJPZmZzZXQiOjAsIlN0YXJ0ZWRBdCI6IjIwMjMtMDgtMjlUMTU6NTk6NDEuMzI1OTkwNjQyWiJ9&digest=sha256%3Acda1bbb871260a2c7624e8adc401dec0667351f923fe545647b887e9f5271aad
   response:
     body:
       string: ''
@@ -4656,7 +5056,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 24 Aug 2023 16:04:32 GMT
+      - Tue, 29 Aug 2023 15:59:41 GMT
       docker-content-digest:
       - sha256:cda1bbb871260a2c7624e8adc401dec0667351f923fe545647b887e9f5271aad
       docker-distribution-api-version:
@@ -4689,7 +5089,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: POST
-    uri: https://ubuntupublisherubuntuacrd18ac8e07e.azurecr.io/v2/ubuntu-vm-nfdg_nf_artifact/blobs/uploads/
+    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/v2/ubuntu-vm-nfdg_nf_artifact/blobs/uploads/
   response:
     body:
       string: '{"errors": [{"code": "UNAUTHORIZED", "message": "authentication required,
@@ -4709,7 +5109,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:04:32 GMT
+      - Tue, 29 Aug 2023 15:59:41 GMT
       docker-distribution-api-version:
       - registry/2.0
       server:
@@ -4718,7 +5118,7 @@ interactions:
       - max-age=31536000; includeSubDomains
       - max-age=31536000; includeSubDomains
       www-authenticate:
-      - Bearer realm="https://ubuntupublisherubuntuacrd18ac8e07e.azurecr.io/oauth2/token",service="ubuntupublisherubuntuacrd18ac8e07e.azurecr.io",scope="repository:ubuntu-vm-nfdg_nf_artifact:pull,push"
+      - Bearer realm="https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/oauth2/token",service="ubuntupublisherubuntuacr8e894d23e6.azurecr.io",scope="repository:ubuntu-vm-nfdg_nf_artifact:push,pull"
       x-content-type-options:
       - nosniff
     status:
@@ -4734,11 +5134,11 @@ interactions:
       Connection:
       - keep-alive
       Service:
-      - ubuntupublisherubuntuacrd18ac8e07e.azurecr.io
+      - ubuntupublisherubuntuacr8e894d23e6.azurecr.io
       User-Agent:
       - oras-py
     method: GET
-    uri: https://ubuntupublisherubuntuacrd18ac8e07e.azurecr.io/oauth2/token?service=ubuntupublisherubuntuacrd18ac8e07e.azurecr.io&scope=repository%3Aubuntu-vm-nfdg_nf_artifact%3Apull%2Cpush
+    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/oauth2/token?service=ubuntupublisherubuntuacr8e894d23e6.azurecr.io&scope=repository%3Aubuntu-vm-nfdg_nf_artifact%3Apush%2Cpull
   response:
     body:
       string: '{"access_token": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}'
@@ -4748,7 +5148,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:04:32 GMT
+      - Tue, 29 Aug 2023 15:59:41 GMT
       server:
       - openresty
       strict-transport-security:
@@ -4776,7 +5176,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: POST
-    uri: https://ubuntupublisherubuntuacrd18ac8e07e.azurecr.io/v2/ubuntu-vm-nfdg_nf_artifact/blobs/uploads/
+    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/v2/ubuntu-vm-nfdg_nf_artifact/blobs/uploads/
   response:
     body:
       string: ''
@@ -4791,13 +5191,13 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 24 Aug 2023 16:04:32 GMT
+      - Tue, 29 Aug 2023 15:59:42 GMT
       docker-distribution-api-version:
       - registry/2.0
       docker-upload-uuid:
-      - 97b04ea6-33e0-485a-a93e-a47aa589a9b2
+      - 7e7be12d-db35-4887-b41a-2114682c1037
       location:
-      - /v2/ubuntu-vm-nfdg_nf_artifact/blobs/uploads/97b04ea6-33e0-485a-a93e-a47aa589a9b2?_nouploadcache=false&_state=lzegn4qYjkNrBuwm54aujoFLjnBV0r7T9STa6a7_URh7Ik5hbWUiOiJ1YnVudHUtdm0tbmZkZ19uZl9hcnRpZmFjdCIsIlVVSUQiOiI5N2IwNGVhNi0zM2UwLTQ4NWEtYTkzZS1hNDdhYTU4OWE5YjIiLCJPZmZzZXQiOjAsIlN0YXJ0ZWRBdCI6IjIwMjMtMDgtMjRUMTY6MDQ6MzIuOTM1MjYwMjA1WiJ9
+      - /v2/ubuntu-vm-nfdg_nf_artifact/blobs/uploads/7e7be12d-db35-4887-b41a-2114682c1037?_nouploadcache=false&_state=GVN-YkeTyht6G_aBax7zYcamgtM7JtwGtvNV0AOv9tV7Ik5hbWUiOiJ1YnVudHUtdm0tbmZkZ19uZl9hcnRpZmFjdCIsIlVVSUQiOiI3ZTdiZTEyZC1kYjM1LTQ4ODctYjQxYS0yMTE0NjgyYzEwMzciLCJPZmZzZXQiOjAsIlN0YXJ0ZWRBdCI6IjIwMjMtMDgtMjlUMTU6NTk6NDIuMTE3NDg5ODQ4WiJ9
       range:
       - 0-0
       server:
@@ -4826,7 +5226,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: PUT
-    uri: https://ubuntupublisherubuntuacrd18ac8e07e.azurecr.io/v2/ubuntu-vm-nfdg_nf_artifact/blobs/uploads/97b04ea6-33e0-485a-a93e-a47aa589a9b2?_nouploadcache=false&_state=lzegn4qYjkNrBuwm54aujoFLjnBV0r7T9STa6a7_URh7Ik5hbWUiOiJ1YnVudHUtdm0tbmZkZ19uZl9hcnRpZmFjdCIsIlVVSUQiOiI5N2IwNGVhNi0zM2UwLTQ4NWEtYTkzZS1hNDdhYTU4OWE5YjIiLCJPZmZzZXQiOjAsIlN0YXJ0ZWRBdCI6IjIwMjMtMDgtMjRUMTY6MDQ6MzIuOTM1MjYwMjA1WiJ9&digest=sha256%3Ae3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/v2/ubuntu-vm-nfdg_nf_artifact/blobs/uploads/7e7be12d-db35-4887-b41a-2114682c1037?_nouploadcache=false&_state=GVN-YkeTyht6G_aBax7zYcamgtM7JtwGtvNV0AOv9tV7Ik5hbWUiOiJ1YnVudHUtdm0tbmZkZ19uZl9hcnRpZmFjdCIsIlVVSUQiOiI3ZTdiZTEyZC1kYjM1LTQ4ODctYjQxYS0yMTE0NjgyYzEwMzciLCJPZmZzZXQiOjAsIlN0YXJ0ZWRBdCI6IjIwMjMtMDgtMjlUMTU6NTk6NDIuMTE3NDg5ODQ4WiJ9&digest=sha256%3Ae3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   response:
     body:
       string: ''
@@ -4841,7 +5241,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 24 Aug 2023 16:04:33 GMT
+      - Tue, 29 Aug 2023 15:59:42 GMT
       docker-content-digest:
       - sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       docker-distribution-api-version:
@@ -4880,7 +5280,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: PUT
-    uri: https://ubuntupublisherubuntuacrd18ac8e07e.azurecr.io/v2/ubuntu-vm-nfdg_nf_artifact/manifests/1.0.0
+    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/v2/ubuntu-vm-nfdg_nf_artifact/manifests/1.0.0
   response:
     body:
       string: '{"errors": [{"code": "UNAUTHORIZED", "message": "authentication required,
@@ -4900,7 +5300,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:04:33 GMT
+      - Tue, 29 Aug 2023 15:59:42 GMT
       docker-distribution-api-version:
       - registry/2.0
       server:
@@ -4909,7 +5309,7 @@ interactions:
       - max-age=31536000; includeSubDomains
       - max-age=31536000; includeSubDomains
       www-authenticate:
-      - Bearer realm="https://ubuntupublisherubuntuacrd18ac8e07e.azurecr.io/oauth2/token",service="ubuntupublisherubuntuacrd18ac8e07e.azurecr.io",scope="repository:ubuntu-vm-nfdg_nf_artifact:pull,push"
+      - Bearer realm="https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/oauth2/token",service="ubuntupublisherubuntuacr8e894d23e6.azurecr.io",scope="repository:ubuntu-vm-nfdg_nf_artifact:pull,push"
       x-content-type-options:
       - nosniff
     status:
@@ -4925,11 +5325,11 @@ interactions:
       Connection:
       - keep-alive
       Service:
-      - ubuntupublisherubuntuacrd18ac8e07e.azurecr.io
+      - ubuntupublisherubuntuacr8e894d23e6.azurecr.io
       User-Agent:
       - oras-py
     method: GET
-    uri: https://ubuntupublisherubuntuacrd18ac8e07e.azurecr.io/oauth2/token?service=ubuntupublisherubuntuacrd18ac8e07e.azurecr.io&scope=repository%3Aubuntu-vm-nfdg_nf_artifact%3Apull%2Cpush
+    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/oauth2/token?service=ubuntupublisherubuntuacr8e894d23e6.azurecr.io&scope=repository%3Aubuntu-vm-nfdg_nf_artifact%3Apull%2Cpush
   response:
     body:
       string: '{"access_token": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}'
@@ -4939,7 +5339,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:04:33 GMT
+      - Tue, 29 Aug 2023 15:59:42 GMT
       server:
       - openresty
       strict-transport-security:
@@ -4973,7 +5373,7 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: PUT
-    uri: https://ubuntupublisherubuntuacrd18ac8e07e.azurecr.io/v2/ubuntu-vm-nfdg_nf_artifact/manifests/1.0.0
+    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/v2/ubuntu-vm-nfdg_nf_artifact/manifests/1.0.0
   response:
     body:
       string: ''
@@ -4988,7 +5388,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 24 Aug 2023 16:04:34 GMT
+      - Tue, 29 Aug 2023 15:59:43 GMT
       docker-content-digest:
       - sha256:7b3db21b27fb97e6d1c92f21747cf67e213ae2360c4a63a390b859a7b5e17b77
       docker-distribution-api-version:
@@ -5078,8 +5478,8 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/validate?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1692893075",
-        "name": "AOSM_CLI_deployment_1692893075", "type": "Microsoft.Resources/deployments",
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693324785",
+        "name": "AOSM_CLI_deployment_1693324785", "type": "Microsoft.Resources/deployments",
         "properties": {"templateHash": "18201962655924189778", "parameters": {"location":
         {"type": "String", "value": "westcentralus"}, "publisherName": {"type": "String",
         "value": "ubuntuPublisher"}, "acrArtifactStoreName": {"type": "String", "value":
@@ -5087,7 +5487,7 @@ interactions:
         {"type": "String", "value": "1.0.0"}, "nfviSiteName": {"type": "String", "value":
         "ubuntu_NFVI"}}, "mode": "Incremental", "provisioningState": "Succeeded",
         "timestamp": "0001-01-01T00:00:00Z", "duration": "PT0S", "correlationId":
-        "4a6663bc-d197-46eb-9b30-1c2bbf46c1ed", "providers": [{"namespace": "Microsoft.Hybridnetwork",
+        "0df9ebe1-6935-4823-ab6f-9a0a8a099640", "providers": [{"namespace": "Microsoft.Hybridnetwork",
         "resourceTypes": [{"resourceType": "publishers/configurationGroupSchemas",
         "locations": ["westcentralus"]}, {"resourceType": "publishers/networkservicedesigngroups/networkservicedesignversions",
         "locations": ["westcentralus"]}]}], "dependencies": [{"dependsOn": [{"id":
@@ -5106,7 +5506,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:04:38 GMT
+      - Tue, 29 Aug 2023 15:59:46 GMT
       expires:
       - '-1'
       pragma:
@@ -5197,16 +5597,16 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1692893075",
-        "name": "AOSM_CLI_deployment_1692893075", "type": "Microsoft.Resources/deployments",
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693324785",
+        "name": "AOSM_CLI_deployment_1693324785", "type": "Microsoft.Resources/deployments",
         "properties": {"templateHash": "18201962655924189778", "parameters": {"location":
         {"type": "String", "value": "westcentralus"}, "publisherName": {"type": "String",
         "value": "ubuntuPublisher"}, "acrArtifactStoreName": {"type": "String", "value":
         "ubuntu-acr"}, "nsDesignGroup": {"type": "String", "value": "ubuntu"}, "nsDesignVersion":
         {"type": "String", "value": "1.0.0"}, "nfviSiteName": {"type": "String", "value":
         "ubuntu_NFVI"}}, "mode": "Incremental", "provisioningState": "Accepted", "timestamp":
-        "2023-08-24T16:04:40.5057579Z", "duration": "PT0.0007955S", "correlationId":
-        "5622d3ca-bc00-46ba-a56a-b90fca292487", "providers": [{"namespace": "Microsoft.Hybridnetwork",
+        "2023-08-29T15:59:49.2140578Z", "duration": "PT0.0007847S", "correlationId":
+        "ebc2b215-e495-4423-9438-efe28eb3d0d4", "providers": [{"namespace": "Microsoft.Hybridnetwork",
         "resourceTypes": [{"resourceType": "publishers/configurationGroupSchemas",
         "locations": ["westcentralus"]}, {"resourceType": "publishers/networkservicedesigngroups/networkservicedesignversions",
         "locations": ["westcentralus"]}]}], "dependencies": [{"dependsOn": [{"id":
@@ -5217,7 +5617,7 @@ interactions:
         "resourceName": "ubuntuPublisher/ubuntu/1.0.0"}]}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1692893075/operationStatuses/08585087138057025190?api-version=2022-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693324785/operationStatuses/08585082820977388054?api-version=2022-09-01
       cache-control:
       - no-cache
       content-length:
@@ -5225,7 +5625,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:04:40 GMT
+      - Tue, 29 Aug 2023 15:59:50 GMT
       expires:
       - '-1'
       pragma:
@@ -5255,7 +5655,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585087138057025190?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585082820977388054?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Accepted"}'
@@ -5267,7 +5667,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:04:40 GMT
+      - Tue, 29 Aug 2023 15:59:50 GMT
       expires:
       - '-1'
       pragma:
@@ -5297,7 +5697,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585087138057025190?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585082820977388054?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Running"}'
@@ -5309,7 +5709,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:05:12 GMT
+      - Tue, 29 Aug 2023 16:00:19 GMT
       expires:
       - '-1'
       pragma:
@@ -5339,7 +5739,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585087138057025190?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585082820977388054?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Succeeded"}'
@@ -5351,7 +5751,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:05:43 GMT
+      - Tue, 29 Aug 2023 16:00:50 GMT
       expires:
       - '-1'
       pragma:
@@ -5384,16 +5784,16 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1692893075",
-        "name": "AOSM_CLI_deployment_1692893075", "type": "Microsoft.Resources/deployments",
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693324785",
+        "name": "AOSM_CLI_deployment_1693324785", "type": "Microsoft.Resources/deployments",
         "properties": {"templateHash": "18201962655924189778", "parameters": {"location":
         {"type": "String", "value": "westcentralus"}, "publisherName": {"type": "String",
         "value": "ubuntuPublisher"}, "acrArtifactStoreName": {"type": "String", "value":
         "ubuntu-acr"}, "nsDesignGroup": {"type": "String", "value": "ubuntu"}, "nsDesignVersion":
         {"type": "String", "value": "1.0.0"}, "nfviSiteName": {"type": "String", "value":
         "ubuntu_NFVI"}}, "mode": "Incremental", "provisioningState": "Succeeded",
-        "timestamp": "2023-08-24T16:05:42.6610816Z", "duration": "PT1M2.1561192S",
-        "correlationId": "5622d3ca-bc00-46ba-a56a-b90fca292487", "providers": [{"namespace":
+        "timestamp": "2023-08-29T16:00:42.7888709Z", "duration": "PT53.5755978S",
+        "correlationId": "ebc2b215-e495-4423-9438-efe28eb3d0d4", "providers": [{"namespace":
         "Microsoft.Hybridnetwork", "resourceTypes": [{"resourceType": "publishers/configurationGroupSchemas",
         "locations": ["westcentralus"]}, {"resourceType": "publishers/networkservicedesigngroups/networkservicedesignversions",
         "locations": ["westcentralus"]}]}], "dependencies": [{"dependsOn": [{"id":
@@ -5408,11 +5808,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '2412'
+      - '2411'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:05:43 GMT
+      - Tue, 29 Aug 2023 16:00:51 GMT
       expires:
       - '-1'
       pragma:
@@ -5421,6 +5821,186 @@ interactions:
       - max-age=31536000; includeSubDomains
       vary:
       - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json, text/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aosm nsd delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -f --clean --force
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/Allow-2023-09-01?api-version=2021-07-01
+  response:
+    body:
+      string: '{"properties": {"state": "Registered"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/Allow-2023-09-01",
+        "type": "Microsoft.Features/providers/features", "name": "Microsoft.HybridNetwork/Allow-2023-09-01"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '290'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 29 Aug 2023 16:00:51 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json, text/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aosm nsd delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -f --clean --force
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/AllowPreReleaseFeatures?api-version=2021-07-01
+  response:
+    body:
+      string: '{"properties": {"state": "Registered"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/AllowPreReleaseFeatures",
+        "type": "Microsoft.Features/providers/features", "name": "Microsoft.HybridNetwork/AllowPreReleaseFeatures"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 29 Aug 2023 16:00:51 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json, text/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aosm nsd delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -f --clean --force
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/Allow-2023-04-01-preview?api-version=2021-07-01
+  response:
+    body:
+      string: '{"properties": {"state": "Registered"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/Allow-2023-04-01-preview",
+        "type": "Microsoft.Features/providers/features", "name": "Microsoft.HybridNetwork/Allow-2023-04-01-preview"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '306'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 29 Aug 2023 16:00:51 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json, text/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aosm nsd delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -f --clean --force
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/MsiForResourceEnabled?api-version=2021-07-01
+  response:
+    body:
+      string: '{"properties": {"state": "Registered"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/MsiForResourceEnabled",
+        "type": "Microsoft.Features/providers/features", "name": "Microsoft.HybridNetwork/MsiForResourceEnabled"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '300'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 29 Aug 2023 16:00:51 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
       x-content-type-options:
       - nosniff
     status:
@@ -5451,7 +6031,7 @@ interactions:
       string: 'null'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a46c4064-2c71-4917-8a77-f86a92b86205*C72A0125C1B0D0569A82E29901B39DD48772792BAF591B0D1C59883B086CFA65?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/0c741975-66e4-4a20-9250-8b4286973587*7F8DC5BF7193E63CB1613E8CF9959AAF6FF43D206B9468ABA965B313544E20E7?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -5459,13 +6039,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:05:46 GMT
+      - Tue, 29 Aug 2023 16:00:54 GMT
       etag:
-      - '"f003a303-0000-0600-0000-64e77fda0000"'
+      - '"00002a00-0000-0600-0000-64ee16360000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a46c4064-2c71-4917-8a77-f86a92b86205*C72A0125C1B0D0569A82E29901B39DD48772792BAF591B0D1C59883B086CFA65?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/0c741975-66e4-4a20-9250-8b4286973587*7F8DC5BF7193E63CB1613E8CF9959AAF6FF43D206B9468ABA965B313544E20E7?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -5498,16 +6078,16 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a46c4064-2c71-4917-8a77-f86a92b86205*C72A0125C1B0D0569A82E29901B39DD48772792BAF591B0D1C59883B086CFA65?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/0c741975-66e4-4a20-9250-8b4286973587*7F8DC5BF7193E63CB1613E8CF9959AAF6FF43D206B9468ABA965B313544E20E7?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a46c4064-2c71-4917-8a77-f86a92b86205*C72A0125C1B0D0569A82E29901B39DD48772792BAF591B0D1C59883B086CFA65",
-        "name": "a46c4064-2c71-4917-8a77-f86a92b86205*C72A0125C1B0D0569A82E29901B39DD48772792BAF591B0D1C59883B086CFA65",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/0c741975-66e4-4a20-9250-8b4286973587*7F8DC5BF7193E63CB1613E8CF9959AAF6FF43D206B9468ABA965B313544E20E7",
+        "name": "0c741975-66e4-4a20-9250-8b4286973587*7F8DC5BF7193E63CB1613E8CF9959AAF6FF43D206B9468ABA965B313544E20E7",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkServiceDesignGroups/ubuntu/networkServiceDesignVersions/1.0.0",
-        "status": "Deleting", "startTime": "2023-08-24T16:05:45.7779924Z"}'
+        "status": "Deleting", "startTime": "2023-08-29T16:00:53.6598892Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/a46c4064-2c71-4917-8a77-f86a92b86205*C72A0125C1B0D0569A82E29901B39DD48772792BAF591B0D1C59883B086CFA65?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/0c741975-66e4-4a20-9250-8b4286973587*7F8DC5BF7193E63CB1613E8CF9959AAF6FF43D206B9468ABA965B313544E20E7?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -5515,13 +6095,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:05:46 GMT
+      - Tue, 29 Aug 2023 16:00:54 GMT
       etag:
-      - '"680085f6-0000-0600-0000-64e77fd90000"'
+      - '"00002b06-0000-0600-0000-64ee16350000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/a46c4064-2c71-4917-8a77-f86a92b86205*C72A0125C1B0D0569A82E29901B39DD48772792BAF591B0D1C59883B086CFA65?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/0c741975-66e4-4a20-9250-8b4286973587*7F8DC5BF7193E63CB1613E8CF9959AAF6FF43D206B9468ABA965B313544E20E7?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -5548,14 +6128,14 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a46c4064-2c71-4917-8a77-f86a92b86205*C72A0125C1B0D0569A82E29901B39DD48772792BAF591B0D1C59883B086CFA65?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/0c741975-66e4-4a20-9250-8b4286973587*7F8DC5BF7193E63CB1613E8CF9959AAF6FF43D206B9468ABA965B313544E20E7?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a46c4064-2c71-4917-8a77-f86a92b86205*C72A0125C1B0D0569A82E29901B39DD48772792BAF591B0D1C59883B086CFA65",
-        "name": "a46c4064-2c71-4917-8a77-f86a92b86205*C72A0125C1B0D0569A82E29901B39DD48772792BAF591B0D1C59883B086CFA65",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/0c741975-66e4-4a20-9250-8b4286973587*7F8DC5BF7193E63CB1613E8CF9959AAF6FF43D206B9468ABA965B313544E20E7",
+        "name": "0c741975-66e4-4a20-9250-8b4286973587*7F8DC5BF7193E63CB1613E8CF9959AAF6FF43D206B9468ABA965B313544E20E7",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkServiceDesignGroups/ubuntu/networkServiceDesignVersions/1.0.0",
-        "status": "Succeeded", "startTime": "2023-08-24T16:05:45.7779924Z", "endTime":
-        "2023-08-24T16:05:52.5924501Z", "properties": null}'
+        "status": "Succeeded", "startTime": "2023-08-29T16:00:53.6598892Z", "endTime":
+        "2023-08-29T16:01:03.2956106Z", "properties": null}'
     headers:
       cache-control:
       - no-cache
@@ -5564,9 +6144,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:06:16 GMT
+      - Tue, 29 Aug 2023 16:01:24 GMT
       etag:
-      - '"68008af6-0000-0600-0000-64e77fe00000"'
+      - '"00002c06-0000-0600-0000-64ee163f0000"'
       expires:
       - '-1'
       pragma:
@@ -5599,14 +6179,14 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a46c4064-2c71-4917-8a77-f86a92b86205*C72A0125C1B0D0569A82E29901B39DD48772792BAF591B0D1C59883B086CFA65?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/0c741975-66e4-4a20-9250-8b4286973587*7F8DC5BF7193E63CB1613E8CF9959AAF6FF43D206B9468ABA965B313544E20E7?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a46c4064-2c71-4917-8a77-f86a92b86205*C72A0125C1B0D0569A82E29901B39DD48772792BAF591B0D1C59883B086CFA65",
-        "name": "a46c4064-2c71-4917-8a77-f86a92b86205*C72A0125C1B0D0569A82E29901B39DD48772792BAF591B0D1C59883B086CFA65",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/0c741975-66e4-4a20-9250-8b4286973587*7F8DC5BF7193E63CB1613E8CF9959AAF6FF43D206B9468ABA965B313544E20E7",
+        "name": "0c741975-66e4-4a20-9250-8b4286973587*7F8DC5BF7193E63CB1613E8CF9959AAF6FF43D206B9468ABA965B313544E20E7",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkServiceDesignGroups/ubuntu/networkServiceDesignVersions/1.0.0",
-        "status": "Succeeded", "startTime": "2023-08-24T16:05:45.7779924Z", "endTime":
-        "2023-08-24T16:05:52.5924501Z", "properties": null}'
+        "status": "Succeeded", "startTime": "2023-08-29T16:00:53.6598892Z", "endTime":
+        "2023-08-29T16:01:03.2956106Z", "properties": null}'
     headers:
       cache-control:
       - no-cache
@@ -5615,9 +6195,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:06:16 GMT
+      - Tue, 29 Aug 2023 16:01:24 GMT
       etag:
-      - '"68008af6-0000-0600-0000-64e77fe00000"'
+      - '"00002c06-0000-0600-0000-64ee163f0000"'
       expires:
       - '-1'
       pragma:
@@ -5658,7 +6238,7 @@ interactions:
       string: 'null'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/553d7aa2-7978-4ed0-a8c6-f443353c27bc*8C319F845FB1C8E9B5C65A082E388EDAE8415C7CD4DC39D5EF7147D5ABF13634?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/9d4c799a-87a2-46a4-8835-ba55a6b403f0*DB692E0A0A4C5AD9CA3492FE4C39590F7AE07FBADAB5C39D246972FD64B25CCF?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -5666,13 +6246,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:06:19 GMT
+      - Tue, 29 Aug 2023 16:01:26 GMT
       etag:
-      - '"200087ae-0000-0600-0000-64e77ffb0000"'
+      - '"0000de0f-0000-0600-0000-64ee16570000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/553d7aa2-7978-4ed0-a8c6-f443353c27bc*8C319F845FB1C8E9B5C65A082E388EDAE8415C7CD4DC39D5EF7147D5ABF13634?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/9d4c799a-87a2-46a4-8835-ba55a6b403f0*DB692E0A0A4C5AD9CA3492FE4C39590F7AE07FBADAB5C39D246972FD64B25CCF?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -5705,16 +6285,16 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/553d7aa2-7978-4ed0-a8c6-f443353c27bc*8C319F845FB1C8E9B5C65A082E388EDAE8415C7CD4DC39D5EF7147D5ABF13634?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/9d4c799a-87a2-46a4-8835-ba55a6b403f0*DB692E0A0A4C5AD9CA3492FE4C39590F7AE07FBADAB5C39D246972FD64B25CCF?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/553d7aa2-7978-4ed0-a8c6-f443353c27bc*8C319F845FB1C8E9B5C65A082E388EDAE8415C7CD4DC39D5EF7147D5ABF13634",
-        "name": "553d7aa2-7978-4ed0-a8c6-f443353c27bc*8C319F845FB1C8E9B5C65A082E388EDAE8415C7CD4DC39D5EF7147D5ABF13634",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/9d4c799a-87a2-46a4-8835-ba55a6b403f0*DB692E0A0A4C5AD9CA3492FE4C39590F7AE07FBADAB5C39D246972FD64B25CCF",
+        "name": "9d4c799a-87a2-46a4-8835-ba55a6b403f0*DB692E0A0A4C5AD9CA3492FE4C39590F7AE07FBADAB5C39D246972FD64B25CCF",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-nfdg-nf-acr-manifest-1-0-0",
-        "status": "Deleting", "startTime": "2023-08-24T16:06:18.6941862Z"}'
+        "status": "Deleting", "startTime": "2023-08-29T16:01:26.2822183Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/553d7aa2-7978-4ed0-a8c6-f443353c27bc*8C319F845FB1C8E9B5C65A082E388EDAE8415C7CD4DC39D5EF7147D5ABF13634?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/9d4c799a-87a2-46a4-8835-ba55a6b403f0*DB692E0A0A4C5AD9CA3492FE4C39590F7AE07FBADAB5C39D246972FD64B25CCF?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -5722,13 +6302,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:06:19 GMT
+      - Tue, 29 Aug 2023 16:01:27 GMT
       etag:
-      - '"0d000539-0000-0600-0000-64e77ffa0000"'
+      - '"030003db-0000-0600-0000-64ee16560000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/553d7aa2-7978-4ed0-a8c6-f443353c27bc*8C319F845FB1C8E9B5C65A082E388EDAE8415C7CD4DC39D5EF7147D5ABF13634?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/9d4c799a-87a2-46a4-8835-ba55a6b403f0*DB692E0A0A4C5AD9CA3492FE4C39590F7AE07FBADAB5C39D246972FD64B25CCF?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -5755,64 +6335,14 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/553d7aa2-7978-4ed0-a8c6-f443353c27bc*8C319F845FB1C8E9B5C65A082E388EDAE8415C7CD4DC39D5EF7147D5ABF13634?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/9d4c799a-87a2-46a4-8835-ba55a6b403f0*DB692E0A0A4C5AD9CA3492FE4C39590F7AE07FBADAB5C39D246972FD64B25CCF?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/553d7aa2-7978-4ed0-a8c6-f443353c27bc*8C319F845FB1C8E9B5C65A082E388EDAE8415C7CD4DC39D5EF7147D5ABF13634",
-        "name": "553d7aa2-7978-4ed0-a8c6-f443353c27bc*8C319F845FB1C8E9B5C65A082E388EDAE8415C7CD4DC39D5EF7147D5ABF13634",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/9d4c799a-87a2-46a4-8835-ba55a6b403f0*DB692E0A0A4C5AD9CA3492FE4C39590F7AE07FBADAB5C39D246972FD64B25CCF",
+        "name": "9d4c799a-87a2-46a4-8835-ba55a6b403f0*DB692E0A0A4C5AD9CA3492FE4C39590F7AE07FBADAB5C39D246972FD64B25CCF",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-nfdg-nf-acr-manifest-1-0-0",
-        "status": "Deleting", "startTime": "2023-08-24T16:06:18.6941862Z"}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/553d7aa2-7978-4ed0-a8c6-f443353c27bc*8C319F845FB1C8E9B5C65A082E388EDAE8415C7CD4DC39D5EF7147D5ABF13634?api-version=2020-01-01-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '618'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Thu, 24 Aug 2023 16:06:49 GMT
-      etag:
-      - '"0d000539-0000-0600-0000-64e77ffa0000"'
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/553d7aa2-7978-4ed0-a8c6-f443353c27bc*8C319F845FB1C8E9B5C65A082E388EDAE8415C7CD4DC39D5EF7147D5ABF13634?api-version=2020-01-01-preview
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aosm nsd delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -f --clean --force
-      User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/553d7aa2-7978-4ed0-a8c6-f443353c27bc*8C319F845FB1C8E9B5C65A082E388EDAE8415C7CD4DC39D5EF7147D5ABF13634?api-version=2020-01-01-preview
-  response:
-    body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/553d7aa2-7978-4ed0-a8c6-f443353c27bc*8C319F845FB1C8E9B5C65A082E388EDAE8415C7CD4DC39D5EF7147D5ABF13634",
-        "name": "553d7aa2-7978-4ed0-a8c6-f443353c27bc*8C319F845FB1C8E9B5C65A082E388EDAE8415C7CD4DC39D5EF7147D5ABF13634",
-        "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-nfdg-nf-acr-manifest-1-0-0",
-        "status": "Succeeded", "startTime": "2023-08-24T16:06:18.6941862Z", "endTime":
-        "2023-08-24T16:06:52.9622606Z", "properties": null}'
+        "status": "Succeeded", "startTime": "2023-08-29T16:01:26.2822183Z", "endTime":
+        "2023-08-29T16:01:55.1417126Z", "properties": null}'
     headers:
       cache-control:
       - no-cache
@@ -5821,9 +6351,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:07:20 GMT
+      - Tue, 29 Aug 2023 16:01:56 GMT
       etag:
-      - '"0d001f39-0000-0600-0000-64e7801c0000"'
+      - '"030048dc-0000-0600-0000-64ee16730000"'
       expires:
       - '-1'
       pragma:
@@ -5856,14 +6386,14 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/553d7aa2-7978-4ed0-a8c6-f443353c27bc*8C319F845FB1C8E9B5C65A082E388EDAE8415C7CD4DC39D5EF7147D5ABF13634?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/9d4c799a-87a2-46a4-8835-ba55a6b403f0*DB692E0A0A4C5AD9CA3492FE4C39590F7AE07FBADAB5C39D246972FD64B25CCF?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/553d7aa2-7978-4ed0-a8c6-f443353c27bc*8C319F845FB1C8E9B5C65A082E388EDAE8415C7CD4DC39D5EF7147D5ABF13634",
-        "name": "553d7aa2-7978-4ed0-a8c6-f443353c27bc*8C319F845FB1C8E9B5C65A082E388EDAE8415C7CD4DC39D5EF7147D5ABF13634",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/9d4c799a-87a2-46a4-8835-ba55a6b403f0*DB692E0A0A4C5AD9CA3492FE4C39590F7AE07FBADAB5C39D246972FD64B25CCF",
+        "name": "9d4c799a-87a2-46a4-8835-ba55a6b403f0*DB692E0A0A4C5AD9CA3492FE4C39590F7AE07FBADAB5C39D246972FD64B25CCF",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-nfdg-nf-acr-manifest-1-0-0",
-        "status": "Succeeded", "startTime": "2023-08-24T16:06:18.6941862Z", "endTime":
-        "2023-08-24T16:06:52.9622606Z", "properties": null}'
+        "status": "Succeeded", "startTime": "2023-08-29T16:01:26.2822183Z", "endTime":
+        "2023-08-29T16:01:55.1417126Z", "properties": null}'
     headers:
       cache-control:
       - no-cache
@@ -5872,9 +6402,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:07:20 GMT
+      - Tue, 29 Aug 2023 16:01:57 GMT
       etag:
-      - '"0d001f39-0000-0600-0000-64e7801c0000"'
+      - '"030048dc-0000-0600-0000-64ee16730000"'
       expires:
       - '-1'
       pragma:
@@ -5915,7 +6445,7 @@ interactions:
       string: 'null'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/e115f48c-b0b0-4337-8029-fc6f26b480c6*3605ADF8F8E01DF805E73863AE1394001CC63D4F5B8D3C59898CBC5F9A83AF51?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/608cd2f1-59d6-43a0-98ee-4b7bdb22e100*ECDDF7375EFCF3921DDCEFC854B2890F0514C1081A8FA77D7EDAA293F3B7E7FA?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -5923,13 +6453,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:07:22 GMT
+      - Tue, 29 Aug 2023 16:02:00 GMT
       etag:
-      - '"b2009e96-0000-0600-0000-64e7803b0000"'
+      - '"00009201-0000-0600-0000-64ee16780000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/e115f48c-b0b0-4337-8029-fc6f26b480c6*3605ADF8F8E01DF805E73863AE1394001CC63D4F5B8D3C59898CBC5F9A83AF51?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/608cd2f1-59d6-43a0-98ee-4b7bdb22e100*ECDDF7375EFCF3921DDCEFC854B2890F0514C1081A8FA77D7EDAA293F3B7E7FA?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -5962,16 +6492,16 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/e115f48c-b0b0-4337-8029-fc6f26b480c6*3605ADF8F8E01DF805E73863AE1394001CC63D4F5B8D3C59898CBC5F9A83AF51?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/608cd2f1-59d6-43a0-98ee-4b7bdb22e100*ECDDF7375EFCF3921DDCEFC854B2890F0514C1081A8FA77D7EDAA293F3B7E7FA?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/e115f48c-b0b0-4337-8029-fc6f26b480c6*3605ADF8F8E01DF805E73863AE1394001CC63D4F5B8D3C59898CBC5F9A83AF51",
-        "name": "e115f48c-b0b0-4337-8029-fc6f26b480c6*3605ADF8F8E01DF805E73863AE1394001CC63D4F5B8D3C59898CBC5F9A83AF51",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/608cd2f1-59d6-43a0-98ee-4b7bdb22e100*ECDDF7375EFCF3921DDCEFC854B2890F0514C1081A8FA77D7EDAA293F3B7E7FA",
+        "name": "608cd2f1-59d6-43a0-98ee-4b7bdb22e100*ECDDF7375EFCF3921DDCEFC854B2890F0514C1081A8FA77D7EDAA293F3B7E7FA",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/configurationGroupSchemas/ubuntu_ConfigGroupSchema",
-        "status": "Deleting", "startTime": "2023-08-24T16:07:22.254059Z"}'
+        "status": "Deleting", "startTime": "2023-08-29T16:01:59.477457Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/e115f48c-b0b0-4337-8029-fc6f26b480c6*3605ADF8F8E01DF805E73863AE1394001CC63D4F5B8D3C59898CBC5F9A83AF51?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/608cd2f1-59d6-43a0-98ee-4b7bdb22e100*ECDDF7375EFCF3921DDCEFC854B2890F0514C1081A8FA77D7EDAA293F3B7E7FA?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -5979,13 +6509,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:07:23 GMT
+      - Tue, 29 Aug 2023 16:02:00 GMT
       etag:
-      - '"6800a5ff-0000-0600-0000-64e7803a0000"'
+      - '"030078dc-0000-0600-0000-64ee16770000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/e115f48c-b0b0-4337-8029-fc6f26b480c6*3605ADF8F8E01DF805E73863AE1394001CC63D4F5B8D3C59898CBC5F9A83AF51?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/608cd2f1-59d6-43a0-98ee-4b7bdb22e100*ECDDF7375EFCF3921DDCEFC854B2890F0514C1081A8FA77D7EDAA293F3B7E7FA?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -6012,25 +6542,25 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/e115f48c-b0b0-4337-8029-fc6f26b480c6*3605ADF8F8E01DF805E73863AE1394001CC63D4F5B8D3C59898CBC5F9A83AF51?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/608cd2f1-59d6-43a0-98ee-4b7bdb22e100*ECDDF7375EFCF3921DDCEFC854B2890F0514C1081A8FA77D7EDAA293F3B7E7FA?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/e115f48c-b0b0-4337-8029-fc6f26b480c6*3605ADF8F8E01DF805E73863AE1394001CC63D4F5B8D3C59898CBC5F9A83AF51",
-        "name": "e115f48c-b0b0-4337-8029-fc6f26b480c6*3605ADF8F8E01DF805E73863AE1394001CC63D4F5B8D3C59898CBC5F9A83AF51",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/608cd2f1-59d6-43a0-98ee-4b7bdb22e100*ECDDF7375EFCF3921DDCEFC854B2890F0514C1081A8FA77D7EDAA293F3B7E7FA",
+        "name": "608cd2f1-59d6-43a0-98ee-4b7bdb22e100*ECDDF7375EFCF3921DDCEFC854B2890F0514C1081A8FA77D7EDAA293F3B7E7FA",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/configurationGroupSchemas/ubuntu_ConfigGroupSchema",
-        "status": "Succeeded", "startTime": "2023-08-24T16:07:22.254059Z", "endTime":
-        "2023-08-24T16:07:28.3924704Z", "properties": null}'
+        "status": "Succeeded", "startTime": "2023-08-29T16:01:59.477457Z", "endTime":
+        "2023-08-29T16:02:03.488937Z", "properties": null}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '651'
+      - '650'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:07:53 GMT
+      - Tue, 29 Aug 2023 16:02:30 GMT
       etag:
-      - '"69004e00-0000-0600-0000-64e780400000"'
+      - '"0300a2dc-0000-0600-0000-64ee167b0000"'
       expires:
       - '-1'
       pragma:
@@ -6063,25 +6593,25 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/e115f48c-b0b0-4337-8029-fc6f26b480c6*3605ADF8F8E01DF805E73863AE1394001CC63D4F5B8D3C59898CBC5F9A83AF51?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/608cd2f1-59d6-43a0-98ee-4b7bdb22e100*ECDDF7375EFCF3921DDCEFC854B2890F0514C1081A8FA77D7EDAA293F3B7E7FA?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/e115f48c-b0b0-4337-8029-fc6f26b480c6*3605ADF8F8E01DF805E73863AE1394001CC63D4F5B8D3C59898CBC5F9A83AF51",
-        "name": "e115f48c-b0b0-4337-8029-fc6f26b480c6*3605ADF8F8E01DF805E73863AE1394001CC63D4F5B8D3C59898CBC5F9A83AF51",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/608cd2f1-59d6-43a0-98ee-4b7bdb22e100*ECDDF7375EFCF3921DDCEFC854B2890F0514C1081A8FA77D7EDAA293F3B7E7FA",
+        "name": "608cd2f1-59d6-43a0-98ee-4b7bdb22e100*ECDDF7375EFCF3921DDCEFC854B2890F0514C1081A8FA77D7EDAA293F3B7E7FA",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/configurationGroupSchemas/ubuntu_ConfigGroupSchema",
-        "status": "Succeeded", "startTime": "2023-08-24T16:07:22.254059Z", "endTime":
-        "2023-08-24T16:07:28.3924704Z", "properties": null}'
+        "status": "Succeeded", "startTime": "2023-08-29T16:01:59.477457Z", "endTime":
+        "2023-08-29T16:02:03.488937Z", "properties": null}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '651'
+      - '650'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:07:53 GMT
+      - Tue, 29 Aug 2023 16:02:30 GMT
       etag:
-      - '"69004e00-0000-0600-0000-64e780400000"'
+      - '"0300a2dc-0000-0600-0000-64ee167b0000"'
       expires:
       - '-1'
       pragma:
@@ -6122,7 +6652,7 @@ interactions:
       string: 'null'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/6d23512d-cbb8-4252-9f38-573f747c1149*53C8DC39476B596E433AF2FA0B23E756482A041129272170226926D9542C88A2?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/65c4ef13-5825-4856-baec-0ea93c271b7f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -6130,13 +6660,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:07:55 GMT
+      - Tue, 29 Aug 2023 16:02:32 GMT
       etag:
-      - '"02007d98-0000-0600-0000-64e7805b0000"'
+      - '"00006a01-0000-0600-0000-64ee16980000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/6d23512d-cbb8-4252-9f38-573f747c1149*53C8DC39476B596E433AF2FA0B23E756482A041129272170226926D9542C88A2?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/65c4ef13-5825-4856-baec-0ea93c271b7f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -6169,16 +6699,16 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/6d23512d-cbb8-4252-9f38-573f747c1149*53C8DC39476B596E433AF2FA0B23E756482A041129272170226926D9542C88A2?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/65c4ef13-5825-4856-baec-0ea93c271b7f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/6d23512d-cbb8-4252-9f38-573f747c1149*53C8DC39476B596E433AF2FA0B23E756482A041129272170226926D9542C88A2",
-        "name": "6d23512d-cbb8-4252-9f38-573f747c1149*53C8DC39476B596E433AF2FA0B23E756482A041129272170226926D9542C88A2",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/65c4ef13-5825-4856-baec-0ea93c271b7f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B",
+        "name": "65c4ef13-5825-4856-baec-0ea93c271b7f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkServiceDesignGroups/ubuntu",
-        "status": "Deleting", "startTime": "2023-08-24T16:07:55.2018322Z"}'
+        "status": "Deleting", "startTime": "2023-08-29T16:02:31.6031656Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/6d23512d-cbb8-4252-9f38-573f747c1149*53C8DC39476B596E433AF2FA0B23E756482A041129272170226926D9542C88A2?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/65c4ef13-5825-4856-baec-0ea93c271b7f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -6186,13 +6716,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:07:55 GMT
+      - Tue, 29 Aug 2023 16:02:32 GMT
       etag:
-      - '"0d006839-0000-0600-0000-64e7805b0000"'
+      - '"00002f06-0000-0600-0000-64ee16970000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/6d23512d-cbb8-4252-9f38-573f747c1149*53C8DC39476B596E433AF2FA0B23E756482A041129272170226926D9542C88A2?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/65c4ef13-5825-4856-baec-0ea93c271b7f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -6219,25 +6749,25 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/6d23512d-cbb8-4252-9f38-573f747c1149*53C8DC39476B596E433AF2FA0B23E756482A041129272170226926D9542C88A2?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/65c4ef13-5825-4856-baec-0ea93c271b7f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/6d23512d-cbb8-4252-9f38-573f747c1149*53C8DC39476B596E433AF2FA0B23E756482A041129272170226926D9542C88A2",
-        "name": "6d23512d-cbb8-4252-9f38-573f747c1149*53C8DC39476B596E433AF2FA0B23E756482A041129272170226926D9542C88A2",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/65c4ef13-5825-4856-baec-0ea93c271b7f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B",
+        "name": "65c4ef13-5825-4856-baec-0ea93c271b7f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkServiceDesignGroups/ubuntu",
-        "status": "Succeeded", "startTime": "2023-08-24T16:07:55.2018322Z", "endTime":
-        "2023-08-24T16:08:00.7269132Z", "properties": null}'
+        "status": "Succeeded", "startTime": "2023-08-29T16:02:31.6031656Z", "endTime":
+        "2023-08-29T16:02:34.488496Z", "properties": null}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '635'
+      - '634'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:08:25 GMT
+      - Tue, 29 Aug 2023 16:03:02 GMT
       etag:
-      - '"0d006b39-0000-0600-0000-64e780600000"'
+      - '"00003006-0000-0600-0000-64ee169a0000"'
       expires:
       - '-1'
       pragma:
@@ -6270,25 +6800,25 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/6d23512d-cbb8-4252-9f38-573f747c1149*53C8DC39476B596E433AF2FA0B23E756482A041129272170226926D9542C88A2?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/65c4ef13-5825-4856-baec-0ea93c271b7f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/6d23512d-cbb8-4252-9f38-573f747c1149*53C8DC39476B596E433AF2FA0B23E756482A041129272170226926D9542C88A2",
-        "name": "6d23512d-cbb8-4252-9f38-573f747c1149*53C8DC39476B596E433AF2FA0B23E756482A041129272170226926D9542C88A2",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/65c4ef13-5825-4856-baec-0ea93c271b7f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B",
+        "name": "65c4ef13-5825-4856-baec-0ea93c271b7f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkServiceDesignGroups/ubuntu",
-        "status": "Succeeded", "startTime": "2023-08-24T16:07:55.2018322Z", "endTime":
-        "2023-08-24T16:08:00.7269132Z", "properties": null}'
+        "status": "Succeeded", "startTime": "2023-08-29T16:02:31.6031656Z", "endTime":
+        "2023-08-29T16:02:34.488496Z", "properties": null}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '635'
+      - '634'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:08:25 GMT
+      - Tue, 29 Aug 2023 16:03:02 GMT
       etag:
-      - '"0d006b39-0000-0600-0000-64e780600000"'
+      - '"00003006-0000-0600-0000-64ee169a0000"'
       expires:
       - '-1'
       pragma:
@@ -6299,6 +6829,186 @@ interactions:
       - chunked
       vary:
       - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json, text/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aosm nfd delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --definition-type -f --clean --force
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/Allow-2023-09-01?api-version=2021-07-01
+  response:
+    body:
+      string: '{"properties": {"state": "Registered"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/Allow-2023-09-01",
+        "type": "Microsoft.Features/providers/features", "name": "Microsoft.HybridNetwork/Allow-2023-09-01"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '290'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 29 Aug 2023 16:03:02 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json, text/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aosm nfd delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --definition-type -f --clean --force
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/AllowPreReleaseFeatures?api-version=2021-07-01
+  response:
+    body:
+      string: '{"properties": {"state": "Registered"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/AllowPreReleaseFeatures",
+        "type": "Microsoft.Features/providers/features", "name": "Microsoft.HybridNetwork/AllowPreReleaseFeatures"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 29 Aug 2023 16:03:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json, text/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aosm nfd delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --definition-type -f --clean --force
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/Allow-2023-04-01-preview?api-version=2021-07-01
+  response:
+    body:
+      string: '{"properties": {"state": "Registered"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/Allow-2023-04-01-preview",
+        "type": "Microsoft.Features/providers/features", "name": "Microsoft.HybridNetwork/Allow-2023-04-01-preview"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '306'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 29 Aug 2023 16:03:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json, text/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aosm nfd delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --definition-type -f --clean --force
+      User-Agent:
+      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/MsiForResourceEnabled?api-version=2021-07-01
+  response:
+    body:
+      string: '{"properties": {"state": "Registered"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/MsiForResourceEnabled",
+        "type": "Microsoft.Features/providers/features", "name": "Microsoft.HybridNetwork/MsiForResourceEnabled"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '300'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 29 Aug 2023 16:03:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
       x-content-type-options:
       - nosniff
     status:
@@ -6329,7 +7039,7 @@ interactions:
       string: 'null'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ec882454-ff5b-45d9-825f-5a20e8c138d8*7C1AD58E046381AD2ED325F0FDCEA92582216C89E85CC73C222335229B5F3601?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -6337,13 +7047,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:08:27 GMT
+      - Tue, 29 Aug 2023 16:03:05 GMT
       etag:
-      - '"000097d9-0000-0600-0000-64e7807c0000"'
+      - '"00003800-0000-0600-0000-64ee16ba0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ec882454-ff5b-45d9-825f-5a20e8c138d8*7C1AD58E046381AD2ED325F0FDCEA92582216C89E85CC73C222335229B5F3601?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -6376,16 +7086,16 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ec882454-ff5b-45d9-825f-5a20e8c138d8*7C1AD58E046381AD2ED325F0FDCEA92582216C89E85CC73C222335229B5F3601?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ec882454-ff5b-45d9-825f-5a20e8c138d8*7C1AD58E046381AD2ED325F0FDCEA92582216C89E85CC73C222335229B5F3601",
-        "name": "ec882454-ff5b-45d9-825f-5a20e8c138d8*7C1AD58E046381AD2ED325F0FDCEA92582216C89E85CC73C222335229B5F3601",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47",
+        "name": "aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg/networkFunctionDefinitionVersions/1.0.0",
-        "status": "Deleting", "startTime": "2023-08-24T16:08:28.3530907Z"}'
+        "status": "Deleting", "startTime": "2023-08-29T16:03:06.0145598Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/ec882454-ff5b-45d9-825f-5a20e8c138d8*7C1AD58E046381AD2ED325F0FDCEA92582216C89E85CC73C222335229B5F3601?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -6393,13 +7103,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:08:27 GMT
+      - Tue, 29 Aug 2023 16:03:06 GMT
       etag:
-      - '"0d009d39-0000-0600-0000-64e7807c0000"'
+      - '"03008cdf-0000-0600-0000-64ee16ba0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/ec882454-ff5b-45d9-825f-5a20e8c138d8*7C1AD58E046381AD2ED325F0FDCEA92582216C89E85CC73C222335229B5F3601?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -6426,16 +7136,16 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ec882454-ff5b-45d9-825f-5a20e8c138d8*7C1AD58E046381AD2ED325F0FDCEA92582216C89E85CC73C222335229B5F3601?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ec882454-ff5b-45d9-825f-5a20e8c138d8*7C1AD58E046381AD2ED325F0FDCEA92582216C89E85CC73C222335229B5F3601",
-        "name": "ec882454-ff5b-45d9-825f-5a20e8c138d8*7C1AD58E046381AD2ED325F0FDCEA92582216C89E85CC73C222335229B5F3601",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47",
+        "name": "aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg/networkFunctionDefinitionVersions/1.0.0",
-        "status": "Deleting", "startTime": "2023-08-24T16:08:28.3530907Z"}'
+        "status": "Deleting", "startTime": "2023-08-29T16:03:06.0145598Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/ec882454-ff5b-45d9-825f-5a20e8c138d8*7C1AD58E046381AD2ED325F0FDCEA92582216C89E85CC73C222335229B5F3601?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -6443,13 +7153,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:08:58 GMT
+      - Tue, 29 Aug 2023 16:03:35 GMT
       etag:
-      - '"0d009d39-0000-0600-0000-64e7807c0000"'
+      - '"03008cdf-0000-0600-0000-64ee16ba0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/ec882454-ff5b-45d9-825f-5a20e8c138d8*7C1AD58E046381AD2ED325F0FDCEA92582216C89E85CC73C222335229B5F3601?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -6476,16 +7186,16 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ec882454-ff5b-45d9-825f-5a20e8c138d8*7C1AD58E046381AD2ED325F0FDCEA92582216C89E85CC73C222335229B5F3601?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ec882454-ff5b-45d9-825f-5a20e8c138d8*7C1AD58E046381AD2ED325F0FDCEA92582216C89E85CC73C222335229B5F3601",
-        "name": "ec882454-ff5b-45d9-825f-5a20e8c138d8*7C1AD58E046381AD2ED325F0FDCEA92582216C89E85CC73C222335229B5F3601",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47",
+        "name": "aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg/networkFunctionDefinitionVersions/1.0.0",
-        "status": "Deleting", "startTime": "2023-08-24T16:08:28.3530907Z"}'
+        "status": "Deleting", "startTime": "2023-08-29T16:03:06.0145598Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/ec882454-ff5b-45d9-825f-5a20e8c138d8*7C1AD58E046381AD2ED325F0FDCEA92582216C89E85CC73C222335229B5F3601?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -6493,13 +7203,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:09:28 GMT
+      - Tue, 29 Aug 2023 16:04:06 GMT
       etag:
-      - '"0d009d39-0000-0600-0000-64e7807c0000"'
+      - '"03008cdf-0000-0600-0000-64ee16ba0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/ec882454-ff5b-45d9-825f-5a20e8c138d8*7C1AD58E046381AD2ED325F0FDCEA92582216C89E85CC73C222335229B5F3601?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -6526,13 +7236,13 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ec882454-ff5b-45d9-825f-5a20e8c138d8*7C1AD58E046381AD2ED325F0FDCEA92582216C89E85CC73C222335229B5F3601?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ec882454-ff5b-45d9-825f-5a20e8c138d8*7C1AD58E046381AD2ED325F0FDCEA92582216C89E85CC73C222335229B5F3601",
-        "name": "ec882454-ff5b-45d9-825f-5a20e8c138d8*7C1AD58E046381AD2ED325F0FDCEA92582216C89E85CC73C222335229B5F3601",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47",
+        "name": "aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg/networkFunctionDefinitionVersions/1.0.0",
-        "status": "Succeeded", "startTime": "2023-08-24T16:08:28.3530907Z", "properties":
+        "status": "Succeeded", "startTime": "2023-08-29T16:03:06.0145598Z", "properties":
         null}'
     headers:
       cache-control:
@@ -6542,9 +7252,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:09:58 GMT
+      - Tue, 29 Aug 2023 16:04:36 GMT
       etag:
-      - '"70001f6a-0000-0700-0000-64e780bf0000"'
+      - '"0300afe2-0000-0600-0000-64ee16fd0000"'
       expires:
       - '-1'
       pragma:
@@ -6577,13 +7287,13 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ec882454-ff5b-45d9-825f-5a20e8c138d8*7C1AD58E046381AD2ED325F0FDCEA92582216C89E85CC73C222335229B5F3601?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ec882454-ff5b-45d9-825f-5a20e8c138d8*7C1AD58E046381AD2ED325F0FDCEA92582216C89E85CC73C222335229B5F3601",
-        "name": "ec882454-ff5b-45d9-825f-5a20e8c138d8*7C1AD58E046381AD2ED325F0FDCEA92582216C89E85CC73C222335229B5F3601",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47",
+        "name": "aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg/networkFunctionDefinitionVersions/1.0.0",
-        "status": "Succeeded", "startTime": "2023-08-24T16:08:28.3530907Z", "properties":
+        "status": "Succeeded", "startTime": "2023-08-29T16:03:06.0145598Z", "properties":
         null}'
     headers:
       cache-control:
@@ -6593,9 +7303,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:09:58 GMT
+      - Tue, 29 Aug 2023 16:04:36 GMT
       etag:
-      - '"70001f6a-0000-0700-0000-64e780bf0000"'
+      - '"0300afe2-0000-0600-0000-64ee16fd0000"'
       expires:
       - '-1'
       pragma:
@@ -6636,7 +7346,7 @@ interactions:
       string: 'null'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c8496bd0-928d-4e1d-9a5b-3102e7bc2fd1*D1874706236BBE1D3454E8D0BD8BB273C5D0E8A6B32F26A5E3D096F93B79A71D?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/15b4c924-80ca-4e5f-9149-835be9756471*B6943EBA12F10489DAA3AC3D9E77837B54D532FEF60B933E735DA59000AFDE79?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -6644,13 +7354,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:10:00 GMT
+      - Tue, 29 Aug 2023 16:04:38 GMT
       etag:
-      - '"200008b0-0000-0600-0000-64e780d80000"'
+      - '"00003510-0000-0600-0000-64ee17170000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c8496bd0-928d-4e1d-9a5b-3102e7bc2fd1*D1874706236BBE1D3454E8D0BD8BB273C5D0E8A6B32F26A5E3D096F93B79A71D?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/15b4c924-80ca-4e5f-9149-835be9756471*B6943EBA12F10489DAA3AC3D9E77837B54D532FEF60B933E735DA59000AFDE79?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -6683,16 +7393,16 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c8496bd0-928d-4e1d-9a5b-3102e7bc2fd1*D1874706236BBE1D3454E8D0BD8BB273C5D0E8A6B32F26A5E3D096F93B79A71D?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/15b4c924-80ca-4e5f-9149-835be9756471*B6943EBA12F10489DAA3AC3D9E77837B54D532FEF60B933E735DA59000AFDE79?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c8496bd0-928d-4e1d-9a5b-3102e7bc2fd1*D1874706236BBE1D3454E8D0BD8BB273C5D0E8A6B32F26A5E3D096F93B79A71D",
-        "name": "c8496bd0-928d-4e1d-9a5b-3102e7bc2fd1*D1874706236BBE1D3454E8D0BD8BB273C5D0E8A6B32F26A5E3D096F93B79A71D",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/15b4c924-80ca-4e5f-9149-835be9756471*B6943EBA12F10489DAA3AC3D9E77837B54D532FEF60B933E735DA59000AFDE79",
+        "name": "15b4c924-80ca-4e5f-9149-835be9756471*B6943EBA12F10489DAA3AC3D9E77837B54D532FEF60B933E735DA59000AFDE79",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store/artifactManifests/ubuntu-vm-sa-manifest-1-0-0",
-        "status": "Deleting", "startTime": "2023-08-24T16:09:59.9340552Z"}'
+        "status": "Deleting", "startTime": "2023-08-29T16:04:38.5945997Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/c8496bd0-928d-4e1d-9a5b-3102e7bc2fd1*D1874706236BBE1D3454E8D0BD8BB273C5D0E8A6B32F26A5E3D096F93B79A71D?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/15b4c924-80ca-4e5f-9149-835be9756471*B6943EBA12F10489DAA3AC3D9E77837B54D532FEF60B933E735DA59000AFDE79?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -6700,13 +7410,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:10:00 GMT
+      - Tue, 29 Aug 2023 16:04:38 GMT
       etag:
-      - '"0d00273a-0000-0600-0000-64e780d70000"'
+      - '"0300d8e3-0000-0600-0000-64ee17160000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/c8496bd0-928d-4e1d-9a5b-3102e7bc2fd1*D1874706236BBE1D3454E8D0BD8BB273C5D0E8A6B32F26A5E3D096F93B79A71D?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/15b4c924-80ca-4e5f-9149-835be9756471*B6943EBA12F10489DAA3AC3D9E77837B54D532FEF60B933E735DA59000AFDE79?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -6733,14 +7443,14 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c8496bd0-928d-4e1d-9a5b-3102e7bc2fd1*D1874706236BBE1D3454E8D0BD8BB273C5D0E8A6B32F26A5E3D096F93B79A71D?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/15b4c924-80ca-4e5f-9149-835be9756471*B6943EBA12F10489DAA3AC3D9E77837B54D532FEF60B933E735DA59000AFDE79?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c8496bd0-928d-4e1d-9a5b-3102e7bc2fd1*D1874706236BBE1D3454E8D0BD8BB273C5D0E8A6B32F26A5E3D096F93B79A71D",
-        "name": "c8496bd0-928d-4e1d-9a5b-3102e7bc2fd1*D1874706236BBE1D3454E8D0BD8BB273C5D0E8A6B32F26A5E3D096F93B79A71D",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/15b4c924-80ca-4e5f-9149-835be9756471*B6943EBA12F10489DAA3AC3D9E77837B54D532FEF60B933E735DA59000AFDE79",
+        "name": "15b4c924-80ca-4e5f-9149-835be9756471*B6943EBA12F10489DAA3AC3D9E77837B54D532FEF60B933E735DA59000AFDE79",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store/artifactManifests/ubuntu-vm-sa-manifest-1-0-0",
-        "status": "Succeeded", "startTime": "2023-08-24T16:09:59.9340552Z", "endTime":
-        "2023-08-24T16:10:04.3159607Z", "properties": null}'
+        "status": "Succeeded", "startTime": "2023-08-29T16:04:38.5945997Z", "endTime":
+        "2023-08-29T16:04:42.8673091Z", "properties": null}'
     headers:
       cache-control:
       - no-cache
@@ -6749,9 +7459,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:10:30 GMT
+      - Tue, 29 Aug 2023 16:05:09 GMT
       etag:
-      - '"0d002a3a-0000-0600-0000-64e780dc0000"'
+      - '"0300fae3-0000-0600-0000-64ee171a0000"'
       expires:
       - '-1'
       pragma:
@@ -6784,14 +7494,14 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c8496bd0-928d-4e1d-9a5b-3102e7bc2fd1*D1874706236BBE1D3454E8D0BD8BB273C5D0E8A6B32F26A5E3D096F93B79A71D?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/15b4c924-80ca-4e5f-9149-835be9756471*B6943EBA12F10489DAA3AC3D9E77837B54D532FEF60B933E735DA59000AFDE79?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c8496bd0-928d-4e1d-9a5b-3102e7bc2fd1*D1874706236BBE1D3454E8D0BD8BB273C5D0E8A6B32F26A5E3D096F93B79A71D",
-        "name": "c8496bd0-928d-4e1d-9a5b-3102e7bc2fd1*D1874706236BBE1D3454E8D0BD8BB273C5D0E8A6B32F26A5E3D096F93B79A71D",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/15b4c924-80ca-4e5f-9149-835be9756471*B6943EBA12F10489DAA3AC3D9E77837B54D532FEF60B933E735DA59000AFDE79",
+        "name": "15b4c924-80ca-4e5f-9149-835be9756471*B6943EBA12F10489DAA3AC3D9E77837B54D532FEF60B933E735DA59000AFDE79",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store/artifactManifests/ubuntu-vm-sa-manifest-1-0-0",
-        "status": "Succeeded", "startTime": "2023-08-24T16:09:59.9340552Z", "endTime":
-        "2023-08-24T16:10:04.3159607Z", "properties": null}'
+        "status": "Succeeded", "startTime": "2023-08-29T16:04:38.5945997Z", "endTime":
+        "2023-08-29T16:04:42.8673091Z", "properties": null}'
     headers:
       cache-control:
       - no-cache
@@ -6800,9 +7510,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:10:31 GMT
+      - Tue, 29 Aug 2023 16:05:09 GMT
       etag:
-      - '"0d002a3a-0000-0600-0000-64e780dc0000"'
+      - '"0300fae3-0000-0600-0000-64ee171a0000"'
       expires:
       - '-1'
       pragma:
@@ -6843,7 +7553,7 @@ interactions:
       string: 'null'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/bf8df8c7-d231-4122-8542-c850cb1d1855*4936AD9BE9CA11FE54ACFF611EAB3820D8EF3E5E0AB34441FFACC79BE5C26B7E?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/217f9262-1baa-4ead-8d54-ec2bb59887ca*6D4A88C4C492FF795DB9717A6CA26AF2F20572E19A448839FF1467472F8832B8?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -6851,13 +7561,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:10:33 GMT
+      - Tue, 29 Aug 2023 16:05:11 GMT
       etag:
-      - '"20004bb0-0000-0600-0000-64e780f90000"'
+      - '"00003610-0000-0600-0000-64ee17380000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/bf8df8c7-d231-4122-8542-c850cb1d1855*4936AD9BE9CA11FE54ACFF611EAB3820D8EF3E5E0AB34441FFACC79BE5C26B7E?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/217f9262-1baa-4ead-8d54-ec2bb59887ca*6D4A88C4C492FF795DB9717A6CA26AF2F20572E19A448839FF1467472F8832B8?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -6890,16 +7600,16 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/bf8df8c7-d231-4122-8542-c850cb1d1855*4936AD9BE9CA11FE54ACFF611EAB3820D8EF3E5E0AB34441FFACC79BE5C26B7E?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/217f9262-1baa-4ead-8d54-ec2bb59887ca*6D4A88C4C492FF795DB9717A6CA26AF2F20572E19A448839FF1467472F8832B8?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/bf8df8c7-d231-4122-8542-c850cb1d1855*4936AD9BE9CA11FE54ACFF611EAB3820D8EF3E5E0AB34441FFACC79BE5C26B7E",
-        "name": "bf8df8c7-d231-4122-8542-c850cb1d1855*4936AD9BE9CA11FE54ACFF611EAB3820D8EF3E5E0AB34441FFACC79BE5C26B7E",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/217f9262-1baa-4ead-8d54-ec2bb59887ca*6D4A88C4C492FF795DB9717A6CA26AF2F20572E19A448839FF1467472F8832B8",
+        "name": "217f9262-1baa-4ead-8d54-ec2bb59887ca*6D4A88C4C492FF795DB9717A6CA26AF2F20572E19A448839FF1467472F8832B8",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-acr-manifest-1-0-0",
-        "status": "Deleting", "startTime": "2023-08-24T16:10:33.3961553Z"}'
+        "status": "Deleting", "startTime": "2023-08-29T16:05:11.6158607Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/bf8df8c7-d231-4122-8542-c850cb1d1855*4936AD9BE9CA11FE54ACFF611EAB3820D8EF3E5E0AB34441FFACC79BE5C26B7E?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/217f9262-1baa-4ead-8d54-ec2bb59887ca*6D4A88C4C492FF795DB9717A6CA26AF2F20572E19A448839FF1467472F8832B8?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -6907,13 +7617,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:10:33 GMT
+      - Tue, 29 Aug 2023 16:05:11 GMT
       etag:
-      - '"0d005b3a-0000-0600-0000-64e780f90000"'
+      - '"030050e5-0000-0600-0000-64ee17370000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/bf8df8c7-d231-4122-8542-c850cb1d1855*4936AD9BE9CA11FE54ACFF611EAB3820D8EF3E5E0AB34441FFACC79BE5C26B7E?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/217f9262-1baa-4ead-8d54-ec2bb59887ca*6D4A88C4C492FF795DB9717A6CA26AF2F20572E19A448839FF1467472F8832B8?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -6940,14 +7650,14 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/bf8df8c7-d231-4122-8542-c850cb1d1855*4936AD9BE9CA11FE54ACFF611EAB3820D8EF3E5E0AB34441FFACC79BE5C26B7E?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/217f9262-1baa-4ead-8d54-ec2bb59887ca*6D4A88C4C492FF795DB9717A6CA26AF2F20572E19A448839FF1467472F8832B8?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/bf8df8c7-d231-4122-8542-c850cb1d1855*4936AD9BE9CA11FE54ACFF611EAB3820D8EF3E5E0AB34441FFACC79BE5C26B7E",
-        "name": "bf8df8c7-d231-4122-8542-c850cb1d1855*4936AD9BE9CA11FE54ACFF611EAB3820D8EF3E5E0AB34441FFACC79BE5C26B7E",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/217f9262-1baa-4ead-8d54-ec2bb59887ca*6D4A88C4C492FF795DB9717A6CA26AF2F20572E19A448839FF1467472F8832B8",
+        "name": "217f9262-1baa-4ead-8d54-ec2bb59887ca*6D4A88C4C492FF795DB9717A6CA26AF2F20572E19A448839FF1467472F8832B8",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-acr-manifest-1-0-0",
-        "status": "Succeeded", "startTime": "2023-08-24T16:10:33.3961553Z", "endTime":
-        "2023-08-24T16:10:38.2121143Z", "properties": null}'
+        "status": "Succeeded", "startTime": "2023-08-29T16:05:11.6158607Z", "endTime":
+        "2023-08-29T16:05:29.9848076Z", "properties": null}'
     headers:
       cache-control:
       - no-cache
@@ -6956,9 +7666,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:11:05 GMT
+      - Tue, 29 Aug 2023 16:05:41 GMT
       etag:
-      - '"0d006a3a-0000-0600-0000-64e780fe0000"'
+      - '"03001ee6-0000-0600-0000-64ee17490000"'
       expires:
       - '-1'
       pragma:
@@ -6991,14 +7701,14 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/bf8df8c7-d231-4122-8542-c850cb1d1855*4936AD9BE9CA11FE54ACFF611EAB3820D8EF3E5E0AB34441FFACC79BE5C26B7E?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/217f9262-1baa-4ead-8d54-ec2bb59887ca*6D4A88C4C492FF795DB9717A6CA26AF2F20572E19A448839FF1467472F8832B8?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/bf8df8c7-d231-4122-8542-c850cb1d1855*4936AD9BE9CA11FE54ACFF611EAB3820D8EF3E5E0AB34441FFACC79BE5C26B7E",
-        "name": "bf8df8c7-d231-4122-8542-c850cb1d1855*4936AD9BE9CA11FE54ACFF611EAB3820D8EF3E5E0AB34441FFACC79BE5C26B7E",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/217f9262-1baa-4ead-8d54-ec2bb59887ca*6D4A88C4C492FF795DB9717A6CA26AF2F20572E19A448839FF1467472F8832B8",
+        "name": "217f9262-1baa-4ead-8d54-ec2bb59887ca*6D4A88C4C492FF795DB9717A6CA26AF2F20572E19A448839FF1467472F8832B8",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-acr-manifest-1-0-0",
-        "status": "Succeeded", "startTime": "2023-08-24T16:10:33.3961553Z", "endTime":
-        "2023-08-24T16:10:38.2121143Z", "properties": null}'
+        "status": "Succeeded", "startTime": "2023-08-29T16:05:11.6158607Z", "endTime":
+        "2023-08-29T16:05:29.9848076Z", "properties": null}'
     headers:
       cache-control:
       - no-cache
@@ -7007,9 +7717,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:11:06 GMT
+      - Tue, 29 Aug 2023 16:05:41 GMT
       etag:
-      - '"0d006a3a-0000-0600-0000-64e780fe0000"'
+      - '"03001ee6-0000-0600-0000-64ee17490000"'
       expires:
       - '-1'
       pragma:
@@ -7050,7 +7760,7 @@ interactions:
       string: 'null'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c3164c13-e442-4a0c-a2df-e9933b944992*84C4ECA09469BBDA75EE23B0C96AD5D368A53F08FAF2B9701A3C6CBC6EA3616A?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -7058,13 +7768,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:11:09 GMT
+      - Tue, 29 Aug 2023 16:05:46 GMT
       etag:
-      - '"09007aef-0000-0600-0000-64e7811d0000"'
+      - '"00005304-0000-0600-0000-64ee175b0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c3164c13-e442-4a0c-a2df-e9933b944992*84C4ECA09469BBDA75EE23B0C96AD5D368A53F08FAF2B9701A3C6CBC6EA3616A?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -7097,16 +7807,16 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c3164c13-e442-4a0c-a2df-e9933b944992*84C4ECA09469BBDA75EE23B0C96AD5D368A53F08FAF2B9701A3C6CBC6EA3616A?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c3164c13-e442-4a0c-a2df-e9933b944992*84C4ECA09469BBDA75EE23B0C96AD5D368A53F08FAF2B9701A3C6CBC6EA3616A",
-        "name": "c3164c13-e442-4a0c-a2df-e9933b944992*84C4ECA09469BBDA75EE23B0C96AD5D368A53F08FAF2B9701A3C6CBC6EA3616A",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890",
+        "name": "bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg",
-        "status": "Deleting", "startTime": "2023-08-24T16:11:08.9404909Z"}'
+        "status": "Deleting", "startTime": "2023-08-29T16:05:46.9649481Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/c3164c13-e442-4a0c-a2df-e9933b944992*84C4ECA09469BBDA75EE23B0C96AD5D368A53F08FAF2B9701A3C6CBC6EA3616A?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -7114,13 +7824,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:11:09 GMT
+      - Tue, 29 Aug 2023 16:05:46 GMT
       etag:
-      - '"6900cb10-0000-0600-0000-64e7811c0000"'
+      - '"0300f3e6-0000-0600-0000-64ee175a0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/c3164c13-e442-4a0c-a2df-e9933b944992*84C4ECA09469BBDA75EE23B0C96AD5D368A53F08FAF2B9701A3C6CBC6EA3616A?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -7147,16 +7857,16 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c3164c13-e442-4a0c-a2df-e9933b944992*84C4ECA09469BBDA75EE23B0C96AD5D368A53F08FAF2B9701A3C6CBC6EA3616A?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c3164c13-e442-4a0c-a2df-e9933b944992*84C4ECA09469BBDA75EE23B0C96AD5D368A53F08FAF2B9701A3C6CBC6EA3616A",
-        "name": "c3164c13-e442-4a0c-a2df-e9933b944992*84C4ECA09469BBDA75EE23B0C96AD5D368A53F08FAF2B9701A3C6CBC6EA3616A",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890",
+        "name": "bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg",
-        "status": "Deleting", "startTime": "2023-08-24T16:11:08.9404909Z"}'
+        "status": "Deleting", "startTime": "2023-08-29T16:05:46.9649481Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/c3164c13-e442-4a0c-a2df-e9933b944992*84C4ECA09469BBDA75EE23B0C96AD5D368A53F08FAF2B9701A3C6CBC6EA3616A?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -7164,13 +7874,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:11:38 GMT
+      - Tue, 29 Aug 2023 16:06:17 GMT
       etag:
-      - '"6900cb10-0000-0600-0000-64e7811c0000"'
+      - '"0300f3e6-0000-0600-0000-64ee175a0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/c3164c13-e442-4a0c-a2df-e9933b944992*84C4ECA09469BBDA75EE23B0C96AD5D368A53F08FAF2B9701A3C6CBC6EA3616A?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -7197,16 +7907,16 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c3164c13-e442-4a0c-a2df-e9933b944992*84C4ECA09469BBDA75EE23B0C96AD5D368A53F08FAF2B9701A3C6CBC6EA3616A?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c3164c13-e442-4a0c-a2df-e9933b944992*84C4ECA09469BBDA75EE23B0C96AD5D368A53F08FAF2B9701A3C6CBC6EA3616A",
-        "name": "c3164c13-e442-4a0c-a2df-e9933b944992*84C4ECA09469BBDA75EE23B0C96AD5D368A53F08FAF2B9701A3C6CBC6EA3616A",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890",
+        "name": "bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg",
-        "status": "Deleting", "startTime": "2023-08-24T16:11:08.9404909Z"}'
+        "status": "Deleting", "startTime": "2023-08-29T16:05:46.9649481Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/c3164c13-e442-4a0c-a2df-e9933b944992*84C4ECA09469BBDA75EE23B0C96AD5D368A53F08FAF2B9701A3C6CBC6EA3616A?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -7214,13 +7924,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:12:09 GMT
+      - Tue, 29 Aug 2023 16:06:46 GMT
       etag:
-      - '"6900cb10-0000-0600-0000-64e7811c0000"'
+      - '"0300f3e6-0000-0600-0000-64ee175a0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/c3164c13-e442-4a0c-a2df-e9933b944992*84C4ECA09469BBDA75EE23B0C96AD5D368A53F08FAF2B9701A3C6CBC6EA3616A?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -7247,13 +7957,13 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c3164c13-e442-4a0c-a2df-e9933b944992*84C4ECA09469BBDA75EE23B0C96AD5D368A53F08FAF2B9701A3C6CBC6EA3616A?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c3164c13-e442-4a0c-a2df-e9933b944992*84C4ECA09469BBDA75EE23B0C96AD5D368A53F08FAF2B9701A3C6CBC6EA3616A",
-        "name": "c3164c13-e442-4a0c-a2df-e9933b944992*84C4ECA09469BBDA75EE23B0C96AD5D368A53F08FAF2B9701A3C6CBC6EA3616A",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890",
+        "name": "bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg",
-        "status": "Succeeded", "startTime": "2023-08-24T16:11:08.9404909Z", "properties":
+        "status": "Succeeded", "startTime": "2023-08-29T16:05:46.9649481Z", "properties":
         null}'
     headers:
       cache-control:
@@ -7263,9 +7973,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:12:39 GMT
+      - Tue, 29 Aug 2023 16:07:17 GMT
       etag:
-      - '"0b01e332-0000-0800-0000-64e781600000"'
+      - '"3a01a854-0000-0700-0000-64ee179d0000"'
       expires:
       - '-1'
       pragma:
@@ -7298,13 +8008,13 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c3164c13-e442-4a0c-a2df-e9933b944992*84C4ECA09469BBDA75EE23B0C96AD5D368A53F08FAF2B9701A3C6CBC6EA3616A?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c3164c13-e442-4a0c-a2df-e9933b944992*84C4ECA09469BBDA75EE23B0C96AD5D368A53F08FAF2B9701A3C6CBC6EA3616A",
-        "name": "c3164c13-e442-4a0c-a2df-e9933b944992*84C4ECA09469BBDA75EE23B0C96AD5D368A53F08FAF2B9701A3C6CBC6EA3616A",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890",
+        "name": "bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg",
-        "status": "Succeeded", "startTime": "2023-08-24T16:11:08.9404909Z", "properties":
+        "status": "Succeeded", "startTime": "2023-08-29T16:05:46.9649481Z", "properties":
         null}'
     headers:
       cache-control:
@@ -7314,9 +8024,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:12:39 GMT
+      - Tue, 29 Aug 2023 16:07:18 GMT
       etag:
-      - '"0b01e332-0000-0800-0000-64e781600000"'
+      - '"3a01a854-0000-0700-0000-64ee179d0000"'
       expires:
       - '-1'
       pragma:
@@ -7357,7 +8067,7 @@ interactions:
       string: 'null'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -7365,13 +8075,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:12:40 GMT
+      - Tue, 29 Aug 2023 16:07:19 GMT
       etag:
-      - '"1700472c-0000-0600-0000-64e781790000"'
+      - '"00000e32-0000-0600-0000-64ee17b70000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -7404,16 +8114,16 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9",
-        "name": "51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
+        "name": "aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr",
-        "status": "Deleting", "startTime": "2023-08-24T16:12:41.2375373Z"}'
+        "status": "Deleting", "startTime": "2023-08-29T16:07:19.8256543Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -7421,13 +8131,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:12:41 GMT
+      - Tue, 29 Aug 2023 16:07:19 GMT
       etag:
-      - '"69002c15-0000-0600-0000-64e781790000"'
+      - '"00003c06-0000-0600-0000-64ee17b70000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -7454,16 +8164,16 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9",
-        "name": "51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
+        "name": "aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr",
-        "status": "Deleting", "startTime": "2023-08-24T16:12:41.2375373Z"}'
+        "status": "Deleting", "startTime": "2023-08-29T16:07:19.8256543Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -7471,13 +8181,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:13:10 GMT
+      - Tue, 29 Aug 2023 16:07:50 GMT
       etag:
-      - '"69002c15-0000-0600-0000-64e781790000"'
+      - '"00003c06-0000-0600-0000-64ee17b70000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -7504,16 +8214,16 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9",
-        "name": "51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
+        "name": "aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr",
-        "status": "Deleting", "startTime": "2023-08-24T16:12:41.2375373Z"}'
+        "status": "Deleting", "startTime": "2023-08-29T16:07:19.8256543Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -7521,13 +8231,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:13:41 GMT
+      - Tue, 29 Aug 2023 16:08:20 GMT
       etag:
-      - '"69002c15-0000-0600-0000-64e781790000"'
+      - '"00003c06-0000-0600-0000-64ee17b70000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -7554,16 +8264,16 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9",
-        "name": "51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
+        "name": "aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr",
-        "status": "Deleting", "startTime": "2023-08-24T16:12:41.2375373Z"}'
+        "status": "Deleting", "startTime": "2023-08-29T16:07:19.8256543Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -7571,13 +8281,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:14:12 GMT
+      - Tue, 29 Aug 2023 16:08:49 GMT
       etag:
-      - '"69002c15-0000-0600-0000-64e781790000"'
+      - '"00003c06-0000-0600-0000-64ee17b70000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -7604,16 +8314,16 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9",
-        "name": "51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
+        "name": "aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr",
-        "status": "Deleting", "startTime": "2023-08-24T16:12:41.2375373Z"}'
+        "status": "Deleting", "startTime": "2023-08-29T16:07:19.8256543Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -7621,13 +8331,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:14:46 GMT
+      - Tue, 29 Aug 2023 16:09:20 GMT
       etag:
-      - '"69002c15-0000-0600-0000-64e781790000"'
+      - '"00003c06-0000-0600-0000-64ee17b70000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -7654,16 +8364,16 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9",
-        "name": "51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
+        "name": "aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr",
-        "status": "Deleting", "startTime": "2023-08-24T16:12:41.2375373Z"}'
+        "status": "Deleting", "startTime": "2023-08-29T16:07:19.8256543Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -7671,13 +8381,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:15:16 GMT
+      - Tue, 29 Aug 2023 16:09:51 GMT
       etag:
-      - '"69002c15-0000-0600-0000-64e781790000"'
+      - '"00003c06-0000-0600-0000-64ee17b70000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -7704,16 +8414,16 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9",
-        "name": "51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
+        "name": "aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr",
-        "status": "Deleting", "startTime": "2023-08-24T16:12:41.2375373Z"}'
+        "status": "Deleting", "startTime": "2023-08-29T16:07:19.8256543Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -7721,13 +8431,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:15:46 GMT
+      - Tue, 29 Aug 2023 16:10:21 GMT
       etag:
-      - '"69002c15-0000-0600-0000-64e781790000"'
+      - '"00003c06-0000-0600-0000-64ee17b70000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -7754,13 +8464,13 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9",
-        "name": "51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
+        "name": "aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr",
-        "status": "Succeeded", "startTime": "2023-08-24T16:12:41.2375373Z", "properties":
+        "status": "Succeeded", "startTime": "2023-08-29T16:07:19.8256543Z", "properties":
         null}'
     headers:
       cache-control:
@@ -7770,9 +8480,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:16:16 GMT
+      - Tue, 29 Aug 2023 16:10:51 GMT
       etag:
-      - '"57008942-0000-0700-0000-64e782340000"'
+      - '"00004206-0000-0600-0000-64ee18730000"'
       expires:
       - '-1'
       pragma:
@@ -7805,13 +8515,13 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9",
-        "name": "51e99b04-3c26-4c0b-a408-c0a2be0c938d*1F07EC3B84B32EE3331AD7794A88FFCA376AE4194DB5BB18A725E793AB9FB2E9",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
+        "name": "aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr",
-        "status": "Succeeded", "startTime": "2023-08-24T16:12:41.2375373Z", "properties":
+        "status": "Succeeded", "startTime": "2023-08-29T16:07:19.8256543Z", "properties":
         null}'
     headers:
       cache-control:
@@ -7821,9 +8531,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:16:17 GMT
+      - Tue, 29 Aug 2023 16:10:52 GMT
       etag:
-      - '"57008942-0000-0700-0000-64e782340000"'
+      - '"00004206-0000-0600-0000-64ee18730000"'
       expires:
       - '-1'
       pragma:
@@ -7864,7 +8574,7 @@ interactions:
       string: 'null'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -7872,13 +8582,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:16:18 GMT
+      - Tue, 29 Aug 2023 16:10:53 GMT
       etag:
-      - '"17006d2d-0000-0600-0000-64e782530000"'
+      - '"00003033-0000-0600-0000-64ee188d0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -7911,16 +8621,16 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0",
-        "name": "a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
+        "name": "faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store",
-        "status": "Deleting", "startTime": "2023-08-24T16:16:19.0475184Z"}'
+        "status": "Deleting", "startTime": "2023-08-29T16:10:53.6036813Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -7928,13 +8638,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:16:18 GMT
+      - Tue, 29 Aug 2023 16:10:53 GMT
       etag:
-      - '"6900e01b-0000-0600-0000-64e782530000"'
+      - '"00004506-0000-0600-0000-64ee188d0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -7961,16 +8671,16 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0",
-        "name": "a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
+        "name": "faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store",
-        "status": "Deleting", "startTime": "2023-08-24T16:16:19.0475184Z"}'
+        "status": "Deleting", "startTime": "2023-08-29T16:10:53.6036813Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -7978,13 +8688,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:16:48 GMT
+      - Tue, 29 Aug 2023 16:11:23 GMT
       etag:
-      - '"6900e01b-0000-0600-0000-64e782530000"'
+      - '"00004506-0000-0600-0000-64ee188d0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -8011,16 +8721,16 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0",
-        "name": "a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
+        "name": "faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store",
-        "status": "Deleting", "startTime": "2023-08-24T16:16:19.0475184Z"}'
+        "status": "Deleting", "startTime": "2023-08-29T16:10:53.6036813Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -8028,13 +8738,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:17:19 GMT
+      - Tue, 29 Aug 2023 16:11:53 GMT
       etag:
-      - '"6900e01b-0000-0600-0000-64e782530000"'
+      - '"00004506-0000-0600-0000-64ee188d0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -8061,16 +8771,16 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0",
-        "name": "a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
+        "name": "faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store",
-        "status": "Deleting", "startTime": "2023-08-24T16:16:19.0475184Z"}'
+        "status": "Deleting", "startTime": "2023-08-29T16:10:53.6036813Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -8078,13 +8788,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:17:51 GMT
+      - Tue, 29 Aug 2023 16:12:24 GMT
       etag:
-      - '"6900e01b-0000-0600-0000-64e782530000"'
+      - '"00004506-0000-0600-0000-64ee188d0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -8111,16 +8821,16 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0",
-        "name": "a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
+        "name": "faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store",
-        "status": "Deleting", "startTime": "2023-08-24T16:16:19.0475184Z"}'
+        "status": "Deleting", "startTime": "2023-08-29T16:10:53.6036813Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -8128,13 +8838,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:18:23 GMT
+      - Tue, 29 Aug 2023 16:12:53 GMT
       etag:
-      - '"6900e01b-0000-0600-0000-64e782530000"'
+      - '"00004506-0000-0600-0000-64ee188d0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -8161,16 +8871,16 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0",
-        "name": "a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
+        "name": "faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store",
-        "status": "Deleting", "startTime": "2023-08-24T16:16:19.0475184Z"}'
+        "status": "Deleting", "startTime": "2023-08-29T16:10:53.6036813Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -8178,13 +8888,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:18:54 GMT
+      - Tue, 29 Aug 2023 16:13:24 GMT
       etag:
-      - '"6900e01b-0000-0600-0000-64e782530000"'
+      - '"00004506-0000-0600-0000-64ee188d0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -8211,16 +8921,16 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0",
-        "name": "a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
+        "name": "faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store",
-        "status": "Deleting", "startTime": "2023-08-24T16:16:19.0475184Z"}'
+        "status": "Deleting", "startTime": "2023-08-29T16:10:53.6036813Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -8228,13 +8938,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:19:24 GMT
+      - Tue, 29 Aug 2023 16:13:54 GMT
       etag:
-      - '"6900e01b-0000-0600-0000-64e782530000"'
+      - '"00004506-0000-0600-0000-64ee188d0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -8261,13 +8971,13 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0",
-        "name": "a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
+        "name": "faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store",
-        "status": "Succeeded", "startTime": "2023-08-24T16:16:19.0475184Z", "properties":
+        "status": "Succeeded", "startTime": "2023-08-29T16:10:53.6036813Z", "properties":
         null}'
     headers:
       cache-control:
@@ -8277,9 +8987,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:19:57 GMT
+      - Tue, 29 Aug 2023 16:14:24 GMT
       etag:
-      - '"6300da61-0000-0100-0000-64e7830e0000"'
+      - '"00005106-0000-0600-0000-64ee19490000"'
       expires:
       - '-1'
       pragma:
@@ -8312,13 +9022,13 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0",
-        "name": "a42de484-0aa0-4172-a431-de74d44ee435*BA0DC5AEE6CA8D2853010C439BC0D492FCD6138389C1A542C20294E8066128F0",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
+        "name": "faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store",
-        "status": "Succeeded", "startTime": "2023-08-24T16:16:19.0475184Z", "properties":
+        "status": "Succeeded", "startTime": "2023-08-29T16:10:53.6036813Z", "properties":
         null}'
     headers:
       cache-control:
@@ -8328,9 +9038,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:19:57 GMT
+      - Tue, 29 Aug 2023 16:14:24 GMT
       etag:
-      - '"6300da61-0000-0100-0000-64e7830e0000"'
+      - '"00005106-0000-0600-0000-64ee19490000"'
       expires:
       - '-1'
       pragma:
@@ -8371,7 +9081,7 @@ interactions:
       string: 'null'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/9c17a845-51e6-49a9-ac2a-bab87a516099*61386E9D475D356830EFD4E736C811580B85F4B40B3E931DE66755A06CD89012?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -8379,13 +9089,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:20:03 GMT
+      - Tue, 29 Aug 2023 16:14:30 GMT
       etag:
-      - '"200047f1-0000-0600-0000-64e783330000"'
+      - '"00003f03-0000-0600-0000-64ee19660000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/9c17a845-51e6-49a9-ac2a-bab87a516099*61386E9D475D356830EFD4E736C811580B85F4B40B3E931DE66755A06CD89012?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -8418,16 +9128,16 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/9c17a845-51e6-49a9-ac2a-bab87a516099*61386E9D475D356830EFD4E736C811580B85F4B40B3E931DE66755A06CD89012?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/9c17a845-51e6-49a9-ac2a-bab87a516099*61386E9D475D356830EFD4E736C811580B85F4B40B3E931DE66755A06CD89012",
-        "name": "9c17a845-51e6-49a9-ac2a-bab87a516099*61386E9D475D356830EFD4E736C811580B85F4B40B3E931DE66755A06CD89012",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E",
+        "name": "1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher",
-        "status": "Deleting", "startTime": "2023-08-24T16:20:03.6361889Z"}'
+        "status": "Deleting", "startTime": "2023-08-29T16:14:30.1589659Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/9c17a845-51e6-49a9-ac2a-bab87a516099*61386E9D475D356830EFD4E736C811580B85F4B40B3E931DE66755A06CD89012?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -8435,13 +9145,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:20:03 GMT
+      - Tue, 29 Aug 2023 16:14:30 GMT
       etag:
-      - '"6900da24-0000-0600-0000-64e783330000"'
+      - '"0300ebfe-0000-0600-0000-64ee19660000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/9c17a845-51e6-49a9-ac2a-bab87a516099*61386E9D475D356830EFD4E736C811580B85F4B40B3E931DE66755A06CD89012?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -8468,16 +9178,16 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/9c17a845-51e6-49a9-ac2a-bab87a516099*61386E9D475D356830EFD4E736C811580B85F4B40B3E931DE66755A06CD89012?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/9c17a845-51e6-49a9-ac2a-bab87a516099*61386E9D475D356830EFD4E736C811580B85F4B40B3E931DE66755A06CD89012",
-        "name": "9c17a845-51e6-49a9-ac2a-bab87a516099*61386E9D475D356830EFD4E736C811580B85F4B40B3E931DE66755A06CD89012",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E",
+        "name": "1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher",
-        "status": "Deleting", "startTime": "2023-08-24T16:20:03.6361889Z"}'
+        "status": "Deleting", "startTime": "2023-08-29T16:14:30.1589659Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/9c17a845-51e6-49a9-ac2a-bab87a516099*61386E9D475D356830EFD4E736C811580B85F4B40B3E931DE66755A06CD89012?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -8485,13 +9195,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:20:34 GMT
+      - Tue, 29 Aug 2023 16:15:00 GMT
       etag:
-      - '"6900da24-0000-0600-0000-64e783330000"'
+      - '"0300ebfe-0000-0600-0000-64ee19660000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/9c17a845-51e6-49a9-ac2a-bab87a516099*61386E9D475D356830EFD4E736C811580B85F4B40B3E931DE66755A06CD89012?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -8518,16 +9228,16 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/9c17a845-51e6-49a9-ac2a-bab87a516099*61386E9D475D356830EFD4E736C811580B85F4B40B3E931DE66755A06CD89012?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/9c17a845-51e6-49a9-ac2a-bab87a516099*61386E9D475D356830EFD4E736C811580B85F4B40B3E931DE66755A06CD89012",
-        "name": "9c17a845-51e6-49a9-ac2a-bab87a516099*61386E9D475D356830EFD4E736C811580B85F4B40B3E931DE66755A06CD89012",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E",
+        "name": "1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher",
-        "status": "Deleting", "startTime": "2023-08-24T16:20:03.6361889Z"}'
+        "status": "Deleting", "startTime": "2023-08-29T16:14:30.1589659Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/9c17a845-51e6-49a9-ac2a-bab87a516099*61386E9D475D356830EFD4E736C811580B85F4B40B3E931DE66755A06CD89012?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -8535,13 +9245,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:21:05 GMT
+      - Tue, 29 Aug 2023 16:15:30 GMT
       etag:
-      - '"6900da24-0000-0600-0000-64e783330000"'
+      - '"0300ebfe-0000-0600-0000-64ee19660000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/9c17a845-51e6-49a9-ac2a-bab87a516099*61386E9D475D356830EFD4E736C811580B85F4B40B3E931DE66755A06CD89012?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -8568,13 +9278,13 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/9c17a845-51e6-49a9-ac2a-bab87a516099*61386E9D475D356830EFD4E736C811580B85F4B40B3E931DE66755A06CD89012?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/9c17a845-51e6-49a9-ac2a-bab87a516099*61386E9D475D356830EFD4E736C811580B85F4B40B3E931DE66755A06CD89012",
-        "name": "9c17a845-51e6-49a9-ac2a-bab87a516099*61386E9D475D356830EFD4E736C811580B85F4B40B3E931DE66755A06CD89012",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E",
+        "name": "1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher",
-        "status": "Succeeded", "startTime": "2023-08-24T16:20:03.6361889Z", "properties":
+        "status": "Succeeded", "startTime": "2023-08-29T16:14:30.1589659Z", "properties":
         null}'
     headers:
       cache-control:
@@ -8584,9 +9294,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:21:35 GMT
+      - Tue, 29 Aug 2023 16:16:00 GMT
       etag:
-      - '"0b01b159-0000-0800-0000-64e783760000"'
+      - '"3a019872-0000-0700-0000-64ee19a90000"'
       expires:
       - '-1'
       pragma:
@@ -8619,13 +9329,13 @@ interactions:
       - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
         (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/9c17a845-51e6-49a9-ac2a-bab87a516099*61386E9D475D356830EFD4E736C811580B85F4B40B3E931DE66755A06CD89012?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/9c17a845-51e6-49a9-ac2a-bab87a516099*61386E9D475D356830EFD4E736C811580B85F4B40B3E931DE66755A06CD89012",
-        "name": "9c17a845-51e6-49a9-ac2a-bab87a516099*61386E9D475D356830EFD4E736C811580B85F4B40B3E931DE66755A06CD89012",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E",
+        "name": "1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher",
-        "status": "Succeeded", "startTime": "2023-08-24T16:20:03.6361889Z", "properties":
+        "status": "Succeeded", "startTime": "2023-08-29T16:14:30.1589659Z", "properties":
         null}'
     headers:
       cache-control:
@@ -8635,9 +9345,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 24 Aug 2023 16:21:35 GMT
+      - Tue, 29 Aug 2023 16:16:01 GMT
       etag:
-      - '"0b01b159-0000-0800-0000-64e783760000"'
+      - '"3a019872-0000-0700-0000-64ee19a90000"'
       expires:
       - '-1'
       pragma:

--- a/src/aosm/azext_aosm/tests/latest/recordings/test_vnf_nsd_publish_and_delete.yaml
+++ b/src/aosm/azext_aosm/tests/latest/recordings/test_vnf_nsd_publish_and_delete.yaml
@@ -13,7 +13,7 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/Allow-2023-09-01?api-version=2021-07-01
   response:
@@ -28,142 +28,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:46:33 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json, text/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aosm nfd publish
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -f --definition-type
-      User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/AllowPreReleaseFeatures?api-version=2021-07-01
-  response:
-    body:
-      string: '{"properties": {"state": "Registered"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/AllowPreReleaseFeatures",
-        "type": "Microsoft.Features/providers/features", "name": "Microsoft.HybridNetwork/AllowPreReleaseFeatures"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 29 Aug 2023 15:46:33 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json, text/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aosm nfd publish
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -f --definition-type
-      User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/Allow-2023-04-01-preview?api-version=2021-07-01
-  response:
-    body:
-      string: '{"properties": {"state": "Registered"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/Allow-2023-04-01-preview",
-        "type": "Microsoft.Features/providers/features", "name": "Microsoft.HybridNetwork/Allow-2023-04-01-preview"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '306'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 29 Aug 2023 15:46:33 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json, text/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aosm nfd publish
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -f --definition-type
-      User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/MsiForResourceEnabled?api-version=2021-07-01
-  response:
-    body:
-      string: '{"properties": {"state": "Registered"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/MsiForResourceEnabled",
-        "type": "Microsoft.Features/providers/features", "name": "Microsoft.HybridNetwork/MsiForResourceEnabled"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '300'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 29 Aug 2023 15:46:33 GMT
+      - Tue, 05 Sep 2023 09:40:13 GMT
       expires:
       - '-1'
       pragma:
@@ -193,7 +58,7 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: HEAD
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001?api-version=2022-09-01
   response:
@@ -205,7 +70,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 29 Aug 2023 15:46:33 GMT
+      - Tue, 05 Sep 2023 09:40:13 GMT
       expires:
       - '-1'
       pragma:
@@ -231,7 +96,7 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001?api-version=2022-09-01
   response:
@@ -239,8 +104,8 @@ interactions:
       string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001",
         "name": "cli_test_vnf_nsd_000001", "type": "Microsoft.Resources/resourceGroups",
         "location": "westcentralus", "tags": {"product": "azurecli", "cause": "automation",
-        "test": "test_vnf_nsd_publish_and_delete", "date": "2023-08-29T15:46:31Z",
-        "module": "aosm", "autoDelete": "true", "expiresOn": "2023-09-28T15:46:31.4504856Z"},
+        "test": "test_vnf_nsd_publish_and_delete", "date": "2023-09-05T09:40:10Z",
+        "module": "aosm", "autoDelete": "true", "expiresOn": "2023-10-05T09:40:11.0915609Z"},
         "properties": {"provisioningState": "Succeeded"}}'
     headers:
       cache-control:
@@ -250,7 +115,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:46:34 GMT
+      - Tue, 05 Sep 2023 09:40:13 GMT
       expires:
       - '-1'
       pragma:
@@ -278,8 +143,8 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher?api-version=2023-04-01-preview
   response:
@@ -295,7 +160,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:46:34 GMT
+      - Tue, 05 Sep 2023 09:40:13 GMT
       expires:
       - '-1'
       pragma:
@@ -327,32 +192,32 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher?api-version=2023-04-01-preview
   response:
     body:
       string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher",
         "name": "ubuntuPublisher", "type": "microsoft.hybridnetwork/publishers", "location":
-        "westcentralus", "systemData": {"createdBy": "sunnycarter@microsoft.com",
-        "createdByType": "User", "createdAt": "2023-08-29T15:46:35.343537Z", "lastModifiedBy":
-        "sunnycarter@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2023-08-29T15:46:35.343537Z"}, "properties": {"scope": "Private", "provisioningState":
+        "westcentralus", "systemData": {"createdBy": "jamieparsons@microsoft.com",
+        "createdByType": "User", "createdAt": "2023-09-05T09:40:14.6593186Z", "lastModifiedBy":
+        "jamieparsons@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
+        "2023-09-05T09:40:14.6593186Z"}, "properties": {"scope": "Private", "provisioningState":
         "Accepted"}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d432786f-2bb0-4ab6-a110-8c838d02c669*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/927325b8-b741-46a2-8b86-3c7de770811b*E0E8123B8C2940C6FB6A994A886BB852744C1D495D5F7020C52DC66D69A77085?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
-      - '585'
+      - '589'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:46:36 GMT
+      - Tue, 05 Sep 2023 09:40:15 GMT
       etag:
-      - '"00003a03-0000-0600-0000-64ee12dc0000"'
+      - '"2a00bc8b-0000-0800-0000-64f6f7800000"'
       expires:
       - '-1'
       pragma:
@@ -384,16 +249,16 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d432786f-2bb0-4ab6-a110-8c838d02c669*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/927325b8-b741-46a2-8b86-3c7de770811b*E0E8123B8C2940C6FB6A994A886BB852744C1D495D5F7020C52DC66D69A77085?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d432786f-2bb0-4ab6-a110-8c838d02c669*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E",
-        "name": "d432786f-2bb0-4ab6-a110-8c838d02c669*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/927325b8-b741-46a2-8b86-3c7de770811b*E0E8123B8C2940C6FB6A994A886BB852744C1D495D5F7020C52DC66D69A77085",
+        "name": "927325b8-b741-46a2-8b86-3c7de770811b*E0E8123B8C2940C6FB6A994A886BB852744C1D495D5F7020C52DC66D69A77085",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher",
-        "status": "Accepted", "startTime": "2023-08-29T15:46:36.3703473Z"}'
+        "status": "Accepted", "startTime": "2023-09-05T09:40:16.2761887Z"}'
     headers:
       cache-control:
       - no-cache
@@ -402,9 +267,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:46:36 GMT
+      - Tue, 05 Sep 2023 09:40:15 GMT
       etag:
-      - '"0300f9b2-0000-0600-0000-64ee12dc0000"'
+      - '"510212cf-0000-0800-0000-64f6f7800000"'
       expires:
       - '-1'
       pragma:
@@ -434,16 +299,16 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d432786f-2bb0-4ab6-a110-8c838d02c669*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/927325b8-b741-46a2-8b86-3c7de770811b*E0E8123B8C2940C6FB6A994A886BB852744C1D495D5F7020C52DC66D69A77085?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d432786f-2bb0-4ab6-a110-8c838d02c669*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E",
-        "name": "d432786f-2bb0-4ab6-a110-8c838d02c669*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/927325b8-b741-46a2-8b86-3c7de770811b*E0E8123B8C2940C6FB6A994A886BB852744C1D495D5F7020C52DC66D69A77085",
+        "name": "927325b8-b741-46a2-8b86-3c7de770811b*E0E8123B8C2940C6FB6A994A886BB852744C1D495D5F7020C52DC66D69A77085",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher",
-        "status": "Accepted", "startTime": "2023-08-29T15:46:36.3703473Z"}'
+        "status": "Accepted", "startTime": "2023-09-05T09:40:16.2761887Z"}'
     headers:
       cache-control:
       - no-cache
@@ -452,9 +317,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:47:07 GMT
+      - Tue, 05 Sep 2023 09:40:46 GMT
       etag:
-      - '"0300f9b2-0000-0600-0000-64ee12dc0000"'
+      - '"510212cf-0000-0800-0000-64f6f7800000"'
       expires:
       - '-1'
       pragma:
@@ -484,16 +349,16 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d432786f-2bb0-4ab6-a110-8c838d02c669*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/927325b8-b741-46a2-8b86-3c7de770811b*E0E8123B8C2940C6FB6A994A886BB852744C1D495D5F7020C52DC66D69A77085?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d432786f-2bb0-4ab6-a110-8c838d02c669*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E",
-        "name": "d432786f-2bb0-4ab6-a110-8c838d02c669*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/927325b8-b741-46a2-8b86-3c7de770811b*E0E8123B8C2940C6FB6A994A886BB852744C1D495D5F7020C52DC66D69A77085",
+        "name": "927325b8-b741-46a2-8b86-3c7de770811b*E0E8123B8C2940C6FB6A994A886BB852744C1D495D5F7020C52DC66D69A77085",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher",
-        "status": "Accepted", "startTime": "2023-08-29T15:46:36.3703473Z"}'
+        "status": "Accepted", "startTime": "2023-09-05T09:40:16.2761887Z"}'
     headers:
       cache-control:
       - no-cache
@@ -502,9 +367,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:47:36 GMT
+      - Tue, 05 Sep 2023 09:41:16 GMT
       etag:
-      - '"0300f9b2-0000-0600-0000-64ee12dc0000"'
+      - '"510212cf-0000-0800-0000-64f6f7800000"'
       expires:
       - '-1'
       pragma:
@@ -534,16 +399,16 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d432786f-2bb0-4ab6-a110-8c838d02c669*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/927325b8-b741-46a2-8b86-3c7de770811b*E0E8123B8C2940C6FB6A994A886BB852744C1D495D5F7020C52DC66D69A77085?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d432786f-2bb0-4ab6-a110-8c838d02c669*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E",
-        "name": "d432786f-2bb0-4ab6-a110-8c838d02c669*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/927325b8-b741-46a2-8b86-3c7de770811b*E0E8123B8C2940C6FB6A994A886BB852744C1D495D5F7020C52DC66D69A77085",
+        "name": "927325b8-b741-46a2-8b86-3c7de770811b*E0E8123B8C2940C6FB6A994A886BB852744C1D495D5F7020C52DC66D69A77085",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher",
-        "status": "Succeeded", "startTime": "2023-08-29T15:46:36.3703473Z", "properties":
+        "status": "Succeeded", "startTime": "2023-09-05T09:40:16.2761887Z", "properties":
         null}'
     headers:
       cache-control:
@@ -553,9 +418,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:48:06 GMT
+      - Tue, 05 Sep 2023 09:41:47 GMT
       etag:
-      - '"3a017121-0000-0700-0000-64ee131f0000"'
+      - '"5102aed4-0000-0800-0000-64f6f7c20000"'
       expires:
       - '-1'
       pragma:
@@ -585,30 +450,30 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher?api-version=2023-04-01-preview
   response:
     body:
       string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher",
         "name": "ubuntuPublisher", "type": "microsoft.hybridnetwork/publishers", "location":
-        "westcentralus", "systemData": {"createdBy": "sunnycarter@microsoft.com",
-        "createdByType": "User", "createdAt": "2023-08-29T15:46:35.343537Z", "lastModifiedBy":
-        "sunnycarter@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2023-08-29T15:46:35.343537Z"}, "properties": {"scope": "Private", "provisioningState":
+        "westcentralus", "systemData": {"createdBy": "jamieparsons@microsoft.com",
+        "createdByType": "User", "createdAt": "2023-09-05T09:40:14.6593186Z", "lastModifiedBy":
+        "jamieparsons@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
+        "2023-09-05T09:40:14.6593186Z"}, "properties": {"scope": "Private", "provisioningState":
         "Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '586'
+      - '590'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:48:07 GMT
+      - Tue, 05 Sep 2023 09:41:47 GMT
       etag:
-      - '"00003c03-0000-0600-0000-64ee12e60000"'
+      - '"2a00d48b-0000-0800-0000-64f6f78a0000"'
       expires:
       - '-1'
       pragma:
@@ -640,8 +505,8 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr?api-version=2023-04-01-preview
   response:
@@ -657,7 +522,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:48:07 GMT
+      - Tue, 05 Sep 2023 09:41:47 GMT
       expires:
       - '-1'
       pragma:
@@ -689,33 +554,33 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr?api-version=2023-04-01-preview
   response:
     body:
       string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr",
         "name": "ubuntu-acr", "type": "microsoft.hybridnetwork/publishers/artifactstores",
-        "location": "westcentralus", "systemData": {"createdBy": "sunnycarter@microsoft.com",
-        "createdByType": "User", "createdAt": "2023-08-29T15:48:08.8909773Z", "lastModifiedBy":
-        "sunnycarter@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2023-08-29T15:48:08.8909773Z"}, "properties": {"storeType": "AzureContainerRegistry",
+        "location": "westcentralus", "systemData": {"createdBy": "jamieparsons@microsoft.com",
+        "createdByType": "User", "createdAt": "2023-09-05T09:41:48.6283289Z", "lastModifiedBy":
+        "jamieparsons@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
+        "2023-09-05T09:41:48.6283289Z"}, "properties": {"storeType": "AzureContainerRegistry",
         "managedResourceGroupConfiguration": {"location": "westcentralus", "name":
-        "ubuntu-acr-HostedResources-663B284E"}, "provisioningState": "Accepted"}}'
+        "ubuntu-acr-HostedResources-50EB00B6"}, "provisioningState": "Accepted"}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ea36bfeb-7c82-4a37-846c-5ec81e0807ad*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a1ad746e-3795-4587-b003-59d5104bce5a*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
-      - '757'
+      - '759'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:48:22 GMT
+      - Tue, 05 Sep 2023 09:41:49 GMT
       etag:
-      - '"0000422c-0000-0600-0000-64ee13470000"'
+      - '"7502a04a-0000-0800-0000-64f6f7dd0000"'
       expires:
       - '-1'
       pragma:
@@ -747,16 +612,16 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ea36bfeb-7c82-4a37-846c-5ec81e0807ad*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a1ad746e-3795-4587-b003-59d5104bce5a*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ea36bfeb-7c82-4a37-846c-5ec81e0807ad*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
-        "name": "ea36bfeb-7c82-4a37-846c-5ec81e0807ad*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a1ad746e-3795-4587-b003-59d5104bce5a*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A",
+        "name": "a1ad746e-3795-4587-b003-59d5104bce5a*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr",
-        "status": "Accepted", "startTime": "2023-08-29T15:48:23.0483823Z"}'
+        "status": "Accepted", "startTime": "2023-09-05T09:41:49.8542843Z"}'
     headers:
       cache-control:
       - no-cache
@@ -765,9 +630,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:48:22 GMT
+      - Tue, 05 Sep 2023 09:41:50 GMT
       etag:
-      - '"00000d06-0000-0600-0000-64ee13470000"'
+      - '"210c78fd-0000-0800-0000-64f6f7dd0000"'
       expires:
       - '-1'
       pragma:
@@ -797,16 +662,16 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ea36bfeb-7c82-4a37-846c-5ec81e0807ad*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a1ad746e-3795-4587-b003-59d5104bce5a*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ea36bfeb-7c82-4a37-846c-5ec81e0807ad*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
-        "name": "ea36bfeb-7c82-4a37-846c-5ec81e0807ad*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a1ad746e-3795-4587-b003-59d5104bce5a*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A",
+        "name": "a1ad746e-3795-4587-b003-59d5104bce5a*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr",
-        "status": "Accepted", "startTime": "2023-08-29T15:48:23.0483823Z"}'
+        "status": "Accepted", "startTime": "2023-09-05T09:41:49.8542843Z"}'
     headers:
       cache-control:
       - no-cache
@@ -815,9 +680,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:48:52 GMT
+      - Tue, 05 Sep 2023 09:42:19 GMT
       etag:
-      - '"00000d06-0000-0600-0000-64ee13470000"'
+      - '"210c78fd-0000-0800-0000-64f6f7dd0000"'
       expires:
       - '-1'
       pragma:
@@ -847,16 +712,16 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ea36bfeb-7c82-4a37-846c-5ec81e0807ad*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a1ad746e-3795-4587-b003-59d5104bce5a*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ea36bfeb-7c82-4a37-846c-5ec81e0807ad*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
-        "name": "ea36bfeb-7c82-4a37-846c-5ec81e0807ad*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a1ad746e-3795-4587-b003-59d5104bce5a*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A",
+        "name": "a1ad746e-3795-4587-b003-59d5104bce5a*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr",
-        "status": "Accepted", "startTime": "2023-08-29T15:48:23.0483823Z"}'
+        "status": "Accepted", "startTime": "2023-09-05T09:41:49.8542843Z"}'
     headers:
       cache-control:
       - no-cache
@@ -865,9 +730,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:49:23 GMT
+      - Tue, 05 Sep 2023 09:42:50 GMT
       etag:
-      - '"00000d06-0000-0600-0000-64ee13470000"'
+      - '"210c78fd-0000-0800-0000-64f6f7dd0000"'
       expires:
       - '-1'
       pragma:
@@ -897,16 +762,16 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ea36bfeb-7c82-4a37-846c-5ec81e0807ad*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a1ad746e-3795-4587-b003-59d5104bce5a*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ea36bfeb-7c82-4a37-846c-5ec81e0807ad*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
-        "name": "ea36bfeb-7c82-4a37-846c-5ec81e0807ad*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a1ad746e-3795-4587-b003-59d5104bce5a*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A",
+        "name": "a1ad746e-3795-4587-b003-59d5104bce5a*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr",
-        "status": "Accepted", "startTime": "2023-08-29T15:48:23.0483823Z"}'
+        "status": "Accepted", "startTime": "2023-09-05T09:41:49.8542843Z"}'
     headers:
       cache-control:
       - no-cache
@@ -915,9 +780,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:49:53 GMT
+      - Tue, 05 Sep 2023 09:43:20 GMT
       etag:
-      - '"00000d06-0000-0600-0000-64ee13470000"'
+      - '"210c78fd-0000-0800-0000-64f6f7dd0000"'
       expires:
       - '-1'
       pragma:
@@ -947,16 +812,16 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ea36bfeb-7c82-4a37-846c-5ec81e0807ad*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a1ad746e-3795-4587-b003-59d5104bce5a*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ea36bfeb-7c82-4a37-846c-5ec81e0807ad*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
-        "name": "ea36bfeb-7c82-4a37-846c-5ec81e0807ad*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a1ad746e-3795-4587-b003-59d5104bce5a*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A",
+        "name": "a1ad746e-3795-4587-b003-59d5104bce5a*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr",
-        "status": "Accepted", "startTime": "2023-08-29T15:48:23.0483823Z"}'
+        "status": "Accepted", "startTime": "2023-09-05T09:41:49.8542843Z"}'
     headers:
       cache-control:
       - no-cache
@@ -965,9 +830,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:50:24 GMT
+      - Tue, 05 Sep 2023 09:43:50 GMT
       etag:
-      - '"00000d06-0000-0600-0000-64ee13470000"'
+      - '"210c78fd-0000-0800-0000-64f6f7dd0000"'
       expires:
       - '-1'
       pragma:
@@ -997,16 +862,16 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ea36bfeb-7c82-4a37-846c-5ec81e0807ad*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a1ad746e-3795-4587-b003-59d5104bce5a*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ea36bfeb-7c82-4a37-846c-5ec81e0807ad*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
-        "name": "ea36bfeb-7c82-4a37-846c-5ec81e0807ad*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a1ad746e-3795-4587-b003-59d5104bce5a*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A",
+        "name": "a1ad746e-3795-4587-b003-59d5104bce5a*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr",
-        "status": "Succeeded", "startTime": "2023-08-29T15:48:23.0483823Z", "properties":
+        "status": "Succeeded", "startTime": "2023-09-05T09:41:49.8542843Z", "properties":
         null}'
     headers:
       cache-control:
@@ -1016,9 +881,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:50:54 GMT
+      - Tue, 05 Sep 2023 09:44:21 GMT
       etag:
-      - '"2602caa8-0000-0100-0000-64ee13c70000"'
+      - '"8703b433-0000-0100-0000-64f6f86b0000"'
       expires:
       - '-1'
       pragma:
@@ -1048,32 +913,32 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr?api-version=2023-04-01-preview
   response:
     body:
       string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr",
         "name": "ubuntu-acr", "type": "microsoft.hybridnetwork/publishers/artifactstores",
-        "location": "westcentralus", "systemData": {"createdBy": "sunnycarter@microsoft.com",
-        "createdByType": "User", "createdAt": "2023-08-29T15:48:08.8909773Z", "lastModifiedBy":
-        "sunnycarter@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2023-08-29T15:48:08.8909773Z"}, "properties": {"storeType": "AzureContainerRegistry",
+        "location": "westcentralus", "systemData": {"createdBy": "jamieparsons@microsoft.com",
+        "createdByType": "User", "createdAt": "2023-09-05T09:41:48.6283289Z", "lastModifiedBy":
+        "jamieparsons@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
+        "2023-09-05T09:41:48.6283289Z"}, "properties": {"storeType": "AzureContainerRegistry",
         "replicationStrategy": "SingleReplication", "managedResourceGroupConfiguration":
-        {"name": "ubuntu-acr-HostedResources-663B284E", "location": "westcentralus"},
-        "provisioningState": "Succeeded", "storageResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/ubuntu-acr-HostedResources-663B284E/providers/Microsoft.ContainerRegistry/registries/UbuntupublisherUbuntuAcr8e894d23e6"}}'
+        {"name": "ubuntu-acr-HostedResources-50EB00B6", "location": "westcentralus"},
+        "provisioningState": "Succeeded", "storageResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/ubuntu-acr-HostedResources-50EB00B6/providers/Microsoft.ContainerRegistry/registries/UbuntupublisherUbuntuAcr3811a7f31a"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1013'
+      - '1015'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:50:54 GMT
+      - Tue, 05 Sep 2023 09:44:21 GMT
       etag:
-      - '"0000e22c-0000-0600-0000-64ee139a0000"'
+      - '"75029b50-0000-0800-0000-64f6f83c0000"'
       expires:
       - '-1'
       pragma:
@@ -1105,8 +970,8 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store?api-version=2023-04-01-preview
   response:
@@ -1122,7 +987,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:50:55 GMT
+      - Tue, 05 Sep 2023 09:44:22 GMT
       expires:
       - '-1'
       pragma:
@@ -1154,33 +1019,33 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store?api-version=2023-04-01-preview
   response:
     body:
       string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store",
         "name": "ubuntu-blob-store", "type": "microsoft.hybridnetwork/publishers/artifactstores",
-        "location": "westcentralus", "systemData": {"createdBy": "sunnycarter@microsoft.com",
-        "createdByType": "User", "createdAt": "2023-08-29T15:50:56.2512265Z", "lastModifiedBy":
-        "sunnycarter@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2023-08-29T15:50:56.2512265Z"}, "properties": {"storeType": "AzureStorageAccount",
+        "location": "westcentralus", "systemData": {"createdBy": "jamieparsons@microsoft.com",
+        "createdByType": "User", "createdAt": "2023-09-05T09:44:23.1908257Z", "lastModifiedBy":
+        "jamieparsons@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
+        "2023-09-05T09:44:23.1908257Z"}, "properties": {"storeType": "AzureStorageAccount",
         "managedResourceGroupConfiguration": {"location": "westcentralus", "name":
-        "ubuntu-blob-store-HostedResources-0C8DFD0E"}, "provisioningState": "Accepted"}}'
+        "ubuntu-blob-store-HostedResources-2E9F9380"}, "provisioningState": "Accepted"}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d3a33817-9106-4a6e-a2f3-10462ca5c7ae*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/5d3f9412-e114-46d4-ac4f-06316d6e1dba*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
-      - '775'
+      - '777'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:50:57 GMT
+      - Tue, 05 Sep 2023 09:44:24 GMT
       etag:
-      - '"0000652d-0000-0600-0000-64ee13e10000"'
+      - '"75028d54-0000-0800-0000-64f6f8780000"'
       expires:
       - '-1'
       pragma:
@@ -1212,16 +1077,16 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d3a33817-9106-4a6e-a2f3-10462ca5c7ae*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/5d3f9412-e114-46d4-ac4f-06316d6e1dba*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d3a33817-9106-4a6e-a2f3-10462ca5c7ae*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
-        "name": "d3a33817-9106-4a6e-a2f3-10462ca5c7ae*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/5d3f9412-e114-46d4-ac4f-06316d6e1dba*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8",
+        "name": "5d3f9412-e114-46d4-ac4f-06316d6e1dba*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store",
-        "status": "Accepted", "startTime": "2023-08-29T15:50:57.2229314Z"}'
+        "status": "Accepted", "startTime": "2023-09-05T09:44:24.8590071Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1230,9 +1095,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:50:57 GMT
+      - Tue, 05 Sep 2023 09:44:24 GMT
       etag:
-      - '"00001b06-0000-0600-0000-64ee13e10000"'
+      - '"5102f5e2-0000-0800-0000-64f6f8780000"'
       expires:
       - '-1'
       pragma:
@@ -1262,16 +1127,16 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d3a33817-9106-4a6e-a2f3-10462ca5c7ae*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/5d3f9412-e114-46d4-ac4f-06316d6e1dba*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d3a33817-9106-4a6e-a2f3-10462ca5c7ae*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
-        "name": "d3a33817-9106-4a6e-a2f3-10462ca5c7ae*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/5d3f9412-e114-46d4-ac4f-06316d6e1dba*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8",
+        "name": "5d3f9412-e114-46d4-ac4f-06316d6e1dba*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store",
-        "status": "Accepted", "startTime": "2023-08-29T15:50:57.2229314Z"}'
+        "status": "Accepted", "startTime": "2023-09-05T09:44:24.8590071Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1280,9 +1145,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:51:27 GMT
+      - Tue, 05 Sep 2023 09:44:55 GMT
       etag:
-      - '"00001b06-0000-0600-0000-64ee13e10000"'
+      - '"5102f5e2-0000-0800-0000-64f6f8780000"'
       expires:
       - '-1'
       pragma:
@@ -1312,16 +1177,16 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d3a33817-9106-4a6e-a2f3-10462ca5c7ae*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/5d3f9412-e114-46d4-ac4f-06316d6e1dba*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d3a33817-9106-4a6e-a2f3-10462ca5c7ae*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
-        "name": "d3a33817-9106-4a6e-a2f3-10462ca5c7ae*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/5d3f9412-e114-46d4-ac4f-06316d6e1dba*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8",
+        "name": "5d3f9412-e114-46d4-ac4f-06316d6e1dba*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store",
-        "status": "Accepted", "startTime": "2023-08-29T15:50:57.2229314Z"}'
+        "status": "Accepted", "startTime": "2023-09-05T09:44:24.8590071Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1330,9 +1195,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:51:56 GMT
+      - Tue, 05 Sep 2023 09:45:24 GMT
       etag:
-      - '"00001b06-0000-0600-0000-64ee13e10000"'
+      - '"5102f5e2-0000-0800-0000-64f6f8780000"'
       expires:
       - '-1'
       pragma:
@@ -1362,16 +1227,16 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d3a33817-9106-4a6e-a2f3-10462ca5c7ae*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/5d3f9412-e114-46d4-ac4f-06316d6e1dba*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d3a33817-9106-4a6e-a2f3-10462ca5c7ae*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
-        "name": "d3a33817-9106-4a6e-a2f3-10462ca5c7ae*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/5d3f9412-e114-46d4-ac4f-06316d6e1dba*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8",
+        "name": "5d3f9412-e114-46d4-ac4f-06316d6e1dba*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store",
-        "status": "Accepted", "startTime": "2023-08-29T15:50:57.2229314Z"}'
+        "status": "Accepted", "startTime": "2023-09-05T09:44:24.8590071Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1380,9 +1245,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:52:28 GMT
+      - Tue, 05 Sep 2023 09:45:56 GMT
       etag:
-      - '"00001b06-0000-0600-0000-64ee13e10000"'
+      - '"5102f5e2-0000-0800-0000-64f6f8780000"'
       expires:
       - '-1'
       pragma:
@@ -1412,16 +1277,16 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d3a33817-9106-4a6e-a2f3-10462ca5c7ae*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/5d3f9412-e114-46d4-ac4f-06316d6e1dba*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d3a33817-9106-4a6e-a2f3-10462ca5c7ae*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
-        "name": "d3a33817-9106-4a6e-a2f3-10462ca5c7ae*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/5d3f9412-e114-46d4-ac4f-06316d6e1dba*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8",
+        "name": "5d3f9412-e114-46d4-ac4f-06316d6e1dba*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store",
-        "status": "Accepted", "startTime": "2023-08-29T15:50:57.2229314Z"}'
+        "status": "Accepted", "startTime": "2023-09-05T09:44:24.8590071Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1430,9 +1295,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:52:58 GMT
+      - Tue, 05 Sep 2023 09:46:25 GMT
       etag:
-      - '"00001b06-0000-0600-0000-64ee13e10000"'
+      - '"5102f5e2-0000-0800-0000-64f6f8780000"'
       expires:
       - '-1'
       pragma:
@@ -1462,16 +1327,16 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d3a33817-9106-4a6e-a2f3-10462ca5c7ae*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/5d3f9412-e114-46d4-ac4f-06316d6e1dba*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d3a33817-9106-4a6e-a2f3-10462ca5c7ae*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
-        "name": "d3a33817-9106-4a6e-a2f3-10462ca5c7ae*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/5d3f9412-e114-46d4-ac4f-06316d6e1dba*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8",
+        "name": "5d3f9412-e114-46d4-ac4f-06316d6e1dba*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store",
-        "status": "Succeeded", "startTime": "2023-08-29T15:50:57.2229314Z", "properties":
+        "status": "Succeeded", "startTime": "2023-09-05T09:44:24.8590071Z", "properties":
         null}'
     headers:
       cache-control:
@@ -1481,9 +1346,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:53:28 GMT
+      - Tue, 05 Sep 2023 09:46:56 GMT
       etag:
-      - '"00002106-0000-0600-0000-64ee14610000"'
+      - '"2c018712-0000-0100-0000-64f6f8f80000"'
       expires:
       - '-1'
       pragma:
@@ -1513,32 +1378,32 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store?api-version=2023-04-01-preview
   response:
     body:
       string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store",
         "name": "ubuntu-blob-store", "type": "microsoft.hybridnetwork/publishers/artifactstores",
-        "location": "westcentralus", "systemData": {"createdBy": "sunnycarter@microsoft.com",
-        "createdByType": "User", "createdAt": "2023-08-29T15:50:56.2512265Z", "lastModifiedBy":
-        "sunnycarter@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2023-08-29T15:50:56.2512265Z"}, "properties": {"storeType": "AzureStorageAccount",
+        "location": "westcentralus", "systemData": {"createdBy": "jamieparsons@microsoft.com",
+        "createdByType": "User", "createdAt": "2023-09-05T09:44:23.1908257Z", "lastModifiedBy":
+        "jamieparsons@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
+        "2023-09-05T09:44:23.1908257Z"}, "properties": {"storeType": "AzureStorageAccount",
         "replicationStrategy": "SingleReplication", "managedResourceGroupConfiguration":
-        {"name": "ubuntu-blob-store-HostedResources-0C8DFD0E", "location": "westcentralus"},
-        "provisioningState": "Succeeded", "storageResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/ubuntu-blob-store-HostedResources-0C8DFD0E/providers/Microsoft.Storage/storageAccounts/0c8dfd0eubuntublobstored"}}'
+        {"name": "ubuntu-blob-store-HostedResources-2E9F9380", "location": "westcentralus"},
+        "provisioningState": "Succeeded", "storageResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/ubuntu-blob-store-HostedResources-2E9F9380/providers/Microsoft.Storage/storageAccounts/2e9f9380ubuntublobstore2"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1023'
+      - '1025'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:53:28 GMT
+      - Tue, 05 Sep 2023 09:46:56 GMT
       etag:
-      - '"0000b92d-0000-0600-0000-64ee14400000"'
+      - '"7502785a-0000-0800-0000-64f6f8d20000"'
       expires:
       - '-1'
       pragma:
@@ -1570,8 +1435,8 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg?api-version=2023-04-01-preview
   response:
@@ -1587,7 +1452,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:53:28 GMT
+      - Tue, 05 Sep 2023 09:46:57 GMT
       expires:
       - '-1'
       pragma:
@@ -1619,31 +1484,31 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg?api-version=2023-04-01-preview
   response:
     body:
       string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg",
         "name": "ubuntu-vm-nfdg", "type": "microsoft.hybridnetwork/publishers/networkfunctiondefinitiongroups",
-        "location": "westcentralus", "systemData": {"createdBy": "sunnycarter@microsoft.com",
-        "createdByType": "User", "createdAt": "2023-08-29T15:53:30.5177253Z", "lastModifiedBy":
-        "sunnycarter@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2023-08-29T15:53:30.5177253Z"}, "properties": {"provisioningState": "Accepted"}}'
+        "location": "westcentralus", "systemData": {"createdBy": "jamieparsons@microsoft.com",
+        "createdByType": "User", "createdAt": "2023-09-05T09:46:58.7370007Z", "lastModifiedBy":
+        "jamieparsons@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
+        "2023-09-05T09:46:58.7370007Z"}, "properties": {"provisioningState": "Accepted"}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/f6282936-0229-4f1d-a3a2-f24f421970f1*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aaa823d9-69ae-4540-ac95-ec58d415f46f*F718B1F161EB7226E4EC39CC19770E9403ACD5E880A312391A01B8B8914A2268?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
-      - '645'
+      - '647'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:53:31 GMT
+      - Tue, 05 Sep 2023 09:46:59 GMT
       etag:
-      - '"00003c04-0000-0600-0000-64ee147b0000"'
+      - '"9a0268ba-0000-0800-0000-64f6f9140000"'
       expires:
       - '-1'
       pragma:
@@ -1675,27 +1540,27 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/f6282936-0229-4f1d-a3a2-f24f421970f1*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aaa823d9-69ae-4540-ac95-ec58d415f46f*F718B1F161EB7226E4EC39CC19770E9403ACD5E880A312391A01B8B8914A2268?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/f6282936-0229-4f1d-a3a2-f24f421970f1*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890",
-        "name": "f6282936-0229-4f1d-a3a2-f24f421970f1*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aaa823d9-69ae-4540-ac95-ec58d415f46f*F718B1F161EB7226E4EC39CC19770E9403ACD5E880A312391A01B8B8914A2268",
+        "name": "aaa823d9-69ae-4540-ac95-ec58d415f46f*F718B1F161EB7226E4EC39CC19770E9403ACD5E880A312391A01B8B8914A2268",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg",
-        "status": "Accepted", "startTime": "2023-08-29T15:53:31.672989Z"}'
+        "status": "Accepted", "startTime": "2023-09-05T09:47:00.2777369Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '583'
+      - '584'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:53:31 GMT
+      - Tue, 05 Sep 2023 09:47:00 GMT
       etag:
-      - '"0300bbc5-0000-0600-0000-64ee147b0000"'
+      - '"220c2c61-0000-0800-0000-64f6f9140000"'
       expires:
       - '-1'
       pragma:
@@ -1725,27 +1590,27 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/f6282936-0229-4f1d-a3a2-f24f421970f1*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aaa823d9-69ae-4540-ac95-ec58d415f46f*F718B1F161EB7226E4EC39CC19770E9403ACD5E880A312391A01B8B8914A2268?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/f6282936-0229-4f1d-a3a2-f24f421970f1*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890",
-        "name": "f6282936-0229-4f1d-a3a2-f24f421970f1*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aaa823d9-69ae-4540-ac95-ec58d415f46f*F718B1F161EB7226E4EC39CC19770E9403ACD5E880A312391A01B8B8914A2268",
+        "name": "aaa823d9-69ae-4540-ac95-ec58d415f46f*F718B1F161EB7226E4EC39CC19770E9403ACD5E880A312391A01B8B8914A2268",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg",
-        "status": "Accepted", "startTime": "2023-08-29T15:53:31.672989Z"}'
+        "status": "Accepted", "startTime": "2023-09-05T09:47:00.2777369Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '583'
+      - '584'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:54:01 GMT
+      - Tue, 05 Sep 2023 09:47:30 GMT
       etag:
-      - '"0300bbc5-0000-0600-0000-64ee147b0000"'
+      - '"220c2c61-0000-0800-0000-64f6f9140000"'
       expires:
       - '-1'
       pragma:
@@ -1775,27 +1640,27 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/f6282936-0229-4f1d-a3a2-f24f421970f1*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aaa823d9-69ae-4540-ac95-ec58d415f46f*F718B1F161EB7226E4EC39CC19770E9403ACD5E880A312391A01B8B8914A2268?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/f6282936-0229-4f1d-a3a2-f24f421970f1*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890",
-        "name": "f6282936-0229-4f1d-a3a2-f24f421970f1*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aaa823d9-69ae-4540-ac95-ec58d415f46f*F718B1F161EB7226E4EC39CC19770E9403ACD5E880A312391A01B8B8914A2268",
+        "name": "aaa823d9-69ae-4540-ac95-ec58d415f46f*F718B1F161EB7226E4EC39CC19770E9403ACD5E880A312391A01B8B8914A2268",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg",
-        "status": "Accepted", "startTime": "2023-08-29T15:53:31.672989Z"}'
+        "status": "Accepted", "startTime": "2023-09-05T09:47:00.2777369Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '583'
+      - '584'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:54:32 GMT
+      - Tue, 05 Sep 2023 09:48:01 GMT
       etag:
-      - '"0300bbc5-0000-0600-0000-64ee147b0000"'
+      - '"220c2c61-0000-0800-0000-64f6f9140000"'
       expires:
       - '-1'
       pragma:
@@ -1825,28 +1690,28 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/f6282936-0229-4f1d-a3a2-f24f421970f1*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aaa823d9-69ae-4540-ac95-ec58d415f46f*F718B1F161EB7226E4EC39CC19770E9403ACD5E880A312391A01B8B8914A2268?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/f6282936-0229-4f1d-a3a2-f24f421970f1*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890",
-        "name": "f6282936-0229-4f1d-a3a2-f24f421970f1*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aaa823d9-69ae-4540-ac95-ec58d415f46f*F718B1F161EB7226E4EC39CC19770E9403ACD5E880A312391A01B8B8914A2268",
+        "name": "aaa823d9-69ae-4540-ac95-ec58d415f46f*F718B1F161EB7226E4EC39CC19770E9403ACD5E880A312391A01B8B8914A2268",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg",
-        "status": "Succeeded", "startTime": "2023-08-29T15:53:31.672989Z", "properties":
+        "status": "Succeeded", "startTime": "2023-09-05T09:47:00.2777369Z", "properties":
         null}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '604'
+      - '605'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:55:01 GMT
+      - Tue, 05 Sep 2023 09:48:30 GMT
       etag:
-      - '"9701c20a-0000-0800-0000-64ee14bf0000"'
+      - '"0000b2e3-0000-0600-0000-64f6f9560000"'
       expires:
       - '-1'
       pragma:
@@ -1876,30 +1741,30 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg?api-version=2023-04-01-preview
   response:
     body:
       string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg",
         "name": "ubuntu-vm-nfdg", "type": "microsoft.hybridnetwork/publishers/networkfunctiondefinitiongroups",
-        "location": "westcentralus", "systemData": {"createdBy": "sunnycarter@microsoft.com",
-        "createdByType": "User", "createdAt": "2023-08-29T15:53:30.5177253Z", "lastModifiedBy":
-        "sunnycarter@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2023-08-29T15:53:30.5177253Z"}, "properties": {"description": null, "provisioningState":
+        "location": "westcentralus", "systemData": {"createdBy": "jamieparsons@microsoft.com",
+        "createdByType": "User", "createdAt": "2023-09-05T09:46:58.7370007Z", "lastModifiedBy":
+        "jamieparsons@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
+        "2023-09-05T09:46:58.7370007Z"}, "properties": {"description": null, "provisioningState":
         "Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '667'
+      - '669'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:55:02 GMT
+      - Tue, 05 Sep 2023 09:48:31 GMT
       etag:
-      - '"00003e04-0000-0600-0000-64ee14860000"'
+      - '"9a0223bb-0000-0800-0000-64f6f91e0000"'
       expires:
       - '-1'
       pragma:
@@ -1931,8 +1796,8 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-acr-manifest-1-0-0?api-version=2023-04-01-preview
   response:
@@ -1948,7 +1813,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:55:02 GMT
+      - Tue, 05 Sep 2023 09:48:31 GMT
       expires:
       - '-1'
       pragma:
@@ -1976,8 +1841,8 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store/artifactManifests/ubuntu-vm-sa-manifest-1-0-0?api-version=2023-04-01-preview
   response:
@@ -1993,7 +1858,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:55:02 GMT
+      - Tue, 05 Sep 2023 09:48:31 GMT
       expires:
       - '-1'
       pragma:
@@ -2010,7 +1875,7 @@ interactions:
 - request:
     body: '{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
       "contentVersion": "1.0.0.0", "metadata": {"_generator": {"name": "bicep", "version":
-      "0.12.40.16777", "templateHash": "15169602856414121474"}}, "parameters": {"location":
+      "0.15.31.15270", "templateHash": "17926458934195505860"}}, "parameters": {"location":
       {"type": "string"}, "publisherName": {"type": "string", "metadata": {"description":
       "Name of an existing publisher, expected to be in the resource group where you
       deploy the template"}}, "acrArtifactStoreName": {"type": "string", "metadata":
@@ -2059,14 +1924,14 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/validate?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693324506",
-        "name": "AOSM_CLI_deployment_1693324506", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "15169602856414121474", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693907315",
+        "name": "AOSM_CLI_deployment_1693907315", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "17926458934195505860", "parameters": {"location":
         {"type": "String", "value": "westcentralus"}, "publisherName": {"type": "String",
         "value": "ubuntuPublisher"}, "acrArtifactStoreName": {"type": "String", "value":
         "ubuntu-acr"}, "saArtifactStoreName": {"type": "String", "value": "ubuntu-blob-store"},
@@ -2075,7 +1940,7 @@ interactions:
         "nfName": {"type": "String", "value": "ubuntu-vm"}, "vhdVersion": {"type":
         "String", "value": "1-0-0"}, "armTemplateVersion": {"type": "String", "value":
         "1.0.0"}}, "mode": "Incremental", "provisioningState": "Succeeded", "timestamp":
-        "0001-01-01T00:00:00Z", "duration": "PT0S", "correlationId": "3feaa34a-f426-4216-905a-f489fff3160d",
+        "0001-01-01T00:00:00Z", "duration": "PT0S", "correlationId": "8eeb7f33-aaee-4078-bfcc-e61c25158b7b",
         "providers": [{"namespace": "Microsoft.Hybridnetwork", "resourceTypes": [{"resourceType":
         "publishers/artifactStores/artifactManifests", "locations": ["westcentralus"]}]}],
         "dependencies": [], "validatedResources": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store/artifactManifests/ubuntu-vm-sa-manifest-1-0-0"},
@@ -2088,7 +1953,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:55:08 GMT
+      - Tue, 05 Sep 2023 09:48:38 GMT
       expires:
       - '-1'
       pragma:
@@ -2109,7 +1974,7 @@ interactions:
 - request:
     body: '{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
       "contentVersion": "1.0.0.0", "metadata": {"_generator": {"name": "bicep", "version":
-      "0.12.40.16777", "templateHash": "15169602856414121474"}}, "parameters": {"location":
+      "0.15.31.15270", "templateHash": "17926458934195505860"}}, "parameters": {"location":
       {"type": "string"}, "publisherName": {"type": "string", "metadata": {"description":
       "Name of an existing publisher, expected to be in the resource group where you
       deploy the template"}}, "acrArtifactStoreName": {"type": "string", "metadata":
@@ -2158,14 +2023,14 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693324506",
-        "name": "AOSM_CLI_deployment_1693324506", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "15169602856414121474", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693907315",
+        "name": "AOSM_CLI_deployment_1693907315", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "17926458934195505860", "parameters": {"location":
         {"type": "String", "value": "westcentralus"}, "publisherName": {"type": "String",
         "value": "ubuntuPublisher"}, "acrArtifactStoreName": {"type": "String", "value":
         "ubuntu-acr"}, "saArtifactStoreName": {"type": "String", "value": "ubuntu-blob-store"},
@@ -2174,13 +2039,13 @@ interactions:
         "nfName": {"type": "String", "value": "ubuntu-vm"}, "vhdVersion": {"type":
         "String", "value": "1-0-0"}, "armTemplateVersion": {"type": "String", "value":
         "1.0.0"}}, "mode": "Incremental", "provisioningState": "Accepted", "timestamp":
-        "2023-08-29T15:55:11.7583889Z", "duration": "PT0.0002148S", "correlationId":
-        "f964cef3-3041-45ad-81ac-c11eaaae08b7", "providers": [{"namespace": "Microsoft.Hybridnetwork",
+        "2023-09-05T09:48:42.2319118Z", "duration": "PT0.0008839S", "correlationId":
+        "30d6163b-1ceb-4978-b06b-c0d88b8d9cca", "providers": [{"namespace": "Microsoft.Hybridnetwork",
         "resourceTypes": [{"resourceType": "publishers/artifactStores/artifactManifests",
         "locations": ["westcentralus"]}]}], "dependencies": []}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693324506/operationStatuses/08585082823751958274?api-version=2022-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693907315/operationStatuses/08585076995649056632?api-version=2022-09-01
       cache-control:
       - no-cache
       content-length:
@@ -2188,7 +2053,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:55:11 GMT
+      - Tue, 05 Sep 2023 09:48:43 GMT
       expires:
       - '-1'
       pragma:
@@ -2216,21 +2081,21 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585082823751958274?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585076995649056632?api-version=2022-09-01
   response:
     body:
-      string: '{"status": "Accepted"}'
+      string: '{"status": "Running"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '22'
+      - '21'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:55:12 GMT
+      - Tue, 05 Sep 2023 09:48:43 GMT
       expires:
       - '-1'
       pragma:
@@ -2258,9 +2123,9 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585082823751958274?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585076995649056632?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Succeeded"}'
@@ -2272,7 +2137,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:55:43 GMT
+      - Tue, 05 Sep 2023 09:49:13 GMT
       expires:
       - '-1'
       pragma:
@@ -2300,14 +2165,14 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693324506",
-        "name": "AOSM_CLI_deployment_1693324506", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "15169602856414121474", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693907315",
+        "name": "AOSM_CLI_deployment_1693907315", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "17926458934195505860", "parameters": {"location":
         {"type": "String", "value": "westcentralus"}, "publisherName": {"type": "String",
         "value": "ubuntuPublisher"}, "acrArtifactStoreName": {"type": "String", "value":
         "ubuntu-acr"}, "saArtifactStoreName": {"type": "String", "value": "ubuntu-blob-store"},
@@ -2316,8 +2181,8 @@ interactions:
         "nfName": {"type": "String", "value": "ubuntu-vm"}, "vhdVersion": {"type":
         "String", "value": "1-0-0"}, "armTemplateVersion": {"type": "String", "value":
         "1.0.0"}}, "mode": "Incremental", "provisioningState": "Succeeded", "timestamp":
-        "2023-08-29T15:55:42.3955798Z", "duration": "PT30.6374057S", "correlationId":
-        "f964cef3-3041-45ad-81ac-c11eaaae08b7", "providers": [{"namespace": "Microsoft.Hybridnetwork",
+        "2023-09-05T09:49:10.0675579Z", "duration": "PT27.83653S", "correlationId":
+        "30d6163b-1ceb-4978-b06b-c0d88b8d9cca", "providers": [{"namespace": "Microsoft.Hybridnetwork",
         "resourceTypes": [{"resourceType": "publishers/artifactStores/artifactManifests",
         "locations": ["westcentralus"]}]}], "dependencies": [], "outputResources":
         [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-acr-manifest-1-0-0"},
@@ -2326,11 +2191,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1795'
+      - '1793'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:55:43 GMT
+      - Tue, 05 Sep 2023 09:49:13 GMT
       expires:
       - '-1'
       pragma:
@@ -2358,31 +2223,31 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store/artifactManifests/ubuntu-vm-sa-manifest-1-0-0?api-version=2023-04-01-preview
   response:
     body:
       string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store/artifactManifests/ubuntu-vm-sa-manifest-1-0-0",
         "name": "ubuntu-vm-sa-manifest-1-0-0", "type": "microsoft.hybridnetwork/publishers/artifactstores/artifactmanifests",
-        "location": "westcentralus", "systemData": {"createdBy": "sunnycarter@microsoft.com",
-        "createdByType": "User", "createdAt": "2023-08-29T15:55:16.1701519Z", "lastModifiedBy":
-        "sunnycarter@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2023-08-29T15:55:16.1701519Z"}, "properties": {"artifacts": [{"artifactName":
+        "location": "westcentralus", "systemData": {"createdBy": "jamieparsons@microsoft.com",
+        "createdByType": "User", "createdAt": "2023-09-05T09:48:46.2517856Z", "lastModifiedBy":
+        "jamieparsons@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
+        "2023-09-05T09:48:46.2517856Z"}, "properties": {"artifacts": [{"artifactName":
         "ubuntu-vm-vhd", "artifactType": "VhdImageFile", "artifactVersion": "1-0-0"}],
         "artifactManifestState": "Uploading", "provisioningState": "Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '840'
+      - '842'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:55:43 GMT
+      - Tue, 05 Sep 2023 09:49:14 GMT
       etag:
-      - '"0000160f-0000-0600-0000-64ee14ea0000"'
+      - '"25003b56-0000-0800-0000-64f6f9860000"'
       expires:
       - '-1'
       pragma:
@@ -2416,25 +2281,25 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store/artifactManifests/ubuntu-vm-sa-manifest-1-0-0/listCredential?api-version=2023-04-01-preview
   response:
     body:
-      string: '{"storageAccountId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/ubuntu-blob-store-HostedResources-0C8DFD0E/providers/Microsoft.Storage/storageAccounts/0c8dfd0eubuntublobstored",
+      string: '{"storageAccountId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/ubuntu-blob-store-HostedResources-2E9F9380/providers/Microsoft.Storage/storageAccounts/2e9f9380ubuntublobstore2",
         "containerCredentials": [{"containerName": "ubuntuvmvhd-1-0-0", "containerSasUri":
         "https://xxxxxxxxxxxxxxx.blob.core.windows.net/ubuntuvmvhd-1-0-0?sv=2021-08-06&si=StorageAccountAccessPolicy&sr=xxxxxxxxxxxxxxxxxxxx"}],
-        "expiry": "2023-08-30T15:55:45.6103964+00:00", "credentialType": "AzureStorageAccountToken"}'
+        "expiry": "2023-09-06T09:49:17.149496+00:00", "credentialType": "AzureStorageAccountToken"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '515'
+      - '514'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:55:44 GMT
+      - Tue, 05 Sep 2023 09:49:16 GMT
       expires:
       - '-1'
       pragma:
@@ -2470,18 +2335,18 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-acr-manifest-1-0-0?api-version=2023-04-01-preview
   response:
     body:
       string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-acr-manifest-1-0-0",
         "name": "ubuntu-vm-acr-manifest-1-0-0", "type": "microsoft.hybridnetwork/publishers/artifactstores/artifactmanifests",
-        "location": "westcentralus", "systemData": {"createdBy": "sunnycarter@microsoft.com",
-        "createdByType": "User", "createdAt": "2023-08-29T15:55:16.1232743Z", "lastModifiedBy":
-        "sunnycarter@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2023-08-29T15:55:16.1232743Z"}, "properties": {"artifacts": [{"artifactName":
+        "location": "westcentralus", "systemData": {"createdBy": "jamieparsons@microsoft.com",
+        "createdByType": "User", "createdAt": "2023-09-05T09:48:46.236188Z", "lastModifiedBy":
+        "jamieparsons@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
+        "2023-09-05T09:48:46.236188Z"}, "properties": {"artifacts": [{"artifactName":
         "ubuntu-vm-arm-template", "artifactType": "ArmTemplate", "artifactVersion":
         "1.0.0"}], "artifactManifestState": "Uploading", "provisioningState": "Succeeded"}}'
     headers:
@@ -2492,9 +2357,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:55:54 GMT
+      - Tue, 05 Sep 2023 09:49:16 GMT
       etag:
-      - '"0000180f-0000-0600-0000-64ee14f90000"'
+      - '"25006256-0000-0800-0000-64f6f98f0000"'
       expires:
       - '-1'
       pragma:
@@ -2528,15 +2393,15 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-acr-manifest-1-0-0/listCredential?api-version=2023-04-01-preview
   response:
     body:
       string: '{"username": "ubuntu-vm-acr-manifest-1-0-0", "acrToken": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-        "acrServerUrl": "https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io", "repositories":
-        ["ubuntu-vm-arm-template"], "expiry": "2023-08-30T15:55:55.9964501+00:00",
+        "acrServerUrl": "https://ubuntupublisherubuntuacr3811a7f31a.azurecr.io", "repositories":
+        ["ubuntu-vm-arm-template"], "expiry": "2023-09-06T09:49:18.7486246+00:00",
         "credentialType": "AzureContainerRegistryScopedToken"}'
     headers:
       cache-control:
@@ -2546,7 +2411,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:55:56 GMT
+      - Tue, 05 Sep 2023 09:49:18 GMT
       expires:
       - '-1'
       pragma:
@@ -2580,15 +2445,15 @@ interactions:
       Content-Length:
       - '0'
       User-Agent:
-      - azsdk-python-storage-blob/12.17.0 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - azsdk-python-storage-blob/12.16.0 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
       x-ms-blob-content-length:
       - '512'
       x-ms-blob-type:
       - PageBlob
       x-ms-date:
-      - Tue, 29 Aug 2023 15:55:56 GMT
+      - Tue, 05 Sep 2023 09:49:19 GMT
       x-ms-version:
-      - '2023-01-03'
+      - '2022-11-02'
     method: PUT
     uri: https://xxxxxxxxxxxxxxx.blob.core.windows.net/ubuntuvmvhd-1-0-0/ubuntuvm-1-0-0.vhd?sv=2021-08-06&si=StorageAccountAccessPolicy&sr=xxxxxxxxxxxxxxxxxxxx
   response:
@@ -2598,17 +2463,17 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 29 Aug 2023 15:55:56 GMT
+      - Tue, 05 Sep 2023 09:49:19 GMT
       etag:
-      - '"0x8DBA8A86EE207F7"'
+      - '"0x8DBADF5608E0663"'
       last-modified:
-      - Tue, 29 Aug 2023 15:55:57 GMT
+      - Tue, 05 Sep 2023 09:49:20 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2023-01-03'
+      - '2022-11-02'
     status:
       code: 201
       message: Created
@@ -2632,17 +2497,17 @@ interactions:
       Content-Type:
       - application/octet-stream
       If-Match:
-      - '"0x8DBA8A86EE207F7"'
+      - '"0x8DBADF5608E0663"'
       User-Agent:
-      - azsdk-python-storage-blob/12.17.0 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - azsdk-python-storage-blob/12.16.0 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
       x-ms-date:
-      - Tue, 29 Aug 2023 15:55:57 GMT
+      - Tue, 05 Sep 2023 09:49:20 GMT
       x-ms-page-write:
       - update
       x-ms-range:
       - bytes=0-511
       x-ms-version:
-      - '2023-01-03'
+      - '2022-11-02'
     method: PUT
     uri: https://xxxxxxxxxxxxxxx.blob.core.windows.net/ubuntuvmvhd-1-0-0/ubuntuvm-1-0-0.vhd?comp=page&sv=2021-08-06&si=StorageAccountAccessPolicy&sr=xxxxxxxxxxxxxxxxxxxx
   response:
@@ -2652,11 +2517,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 29 Aug 2023 15:55:57 GMT
+      - Tue, 05 Sep 2023 09:49:19 GMT
       etag:
-      - '"0x8DBA8A86EFD541F"'
+      - '"0x8DBADF560B18EBD"'
       last-modified:
-      - Tue, 29 Aug 2023 15:55:57 GMT
+      - Tue, 05 Sep 2023 09:49:20 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-sequence-number:
@@ -2666,7 +2531,7 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2023-01-03'
+      - '2022-11-02'
     status:
       code: 201
       message: Created
@@ -2684,9 +2549,9 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - python-requests/2.31.0
+      - python-requests/2.26.0
     method: POST
-    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/v2/ubuntu-vm-arm-template/blobs/uploads/
+    uri: https://ubuntupublisherubuntuacr3811a7f31a.azurecr.io/v2/ubuntu-vm-arm-template/blobs/uploads/
   response:
     body:
       string: '{"errors": [{"code": "UNAUTHORIZED", "message": "authentication required,
@@ -2706,7 +2571,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:55:58 GMT
+      - Tue, 05 Sep 2023 09:49:22 GMT
       docker-distribution-api-version:
       - registry/2.0
       server:
@@ -2715,7 +2580,7 @@ interactions:
       - max-age=31536000; includeSubDomains
       - max-age=31536000; includeSubDomains
       www-authenticate:
-      - Bearer realm="https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/oauth2/token",service="ubuntupublisherubuntuacr8e894d23e6.azurecr.io",scope="repository:ubuntu-vm-arm-template:pull,push"
+      - Bearer realm="https://ubuntupublisherubuntuacr3811a7f31a.azurecr.io/oauth2/token",service="ubuntupublisherubuntuacr3811a7f31a.azurecr.io",scope="repository:ubuntu-vm-arm-template:pull,push"
       x-content-type-options:
       - nosniff
     status:
@@ -2731,11 +2596,11 @@ interactions:
       Connection:
       - keep-alive
       Service:
-      - ubuntupublisherubuntuacr8e894d23e6.azurecr.io
+      - ubuntupublisherubuntuacr3811a7f31a.azurecr.io
       User-Agent:
       - oras-py
     method: GET
-    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/oauth2/token?service=ubuntupublisherubuntuacr8e894d23e6.azurecr.io&scope=repository%3Aubuntu-vm-arm-template%3Apull%2Cpush
+    uri: https://ubuntupublisherubuntuacr3811a7f31a.azurecr.io/oauth2/token?service=ubuntupublisherubuntuacr3811a7f31a.azurecr.io&scope=repository%3Aubuntu-vm-arm-template%3Apull%2Cpush
   response:
     body:
       string: '{"access_token": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}'
@@ -2745,7 +2610,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:55:58 GMT
+      - Tue, 05 Sep 2023 09:49:22 GMT
       server:
       - openresty
       strict-transport-security:
@@ -2771,9 +2636,9 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - python-requests/2.31.0
+      - python-requests/2.26.0
     method: POST
-    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/v2/ubuntu-vm-arm-template/blobs/uploads/
+    uri: https://ubuntupublisherubuntuacr3811a7f31a.azurecr.io/v2/ubuntu-vm-arm-template/blobs/uploads/
   response:
     body:
       string: ''
@@ -2788,13 +2653,13 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 29 Aug 2023 15:55:58 GMT
+      - Tue, 05 Sep 2023 09:49:22 GMT
       docker-distribution-api-version:
       - registry/2.0
       docker-upload-uuid:
-      - 5fadc8f5-b3d6-40d1-8668-3e4af73befb7
+      - 795a938f-696d-4904-b818-7a4a25d013e2
       location:
-      - /v2/ubuntu-vm-arm-template/blobs/uploads/5fadc8f5-b3d6-40d1-8668-3e4af73befb7?_nouploadcache=false&_state=4Fo-lXSoT6fpl62615Nxz5oPtqNHHDwXHb3REoA7pbx7Ik5hbWUiOiJ1YnVudHUtdm0tYXJtLXRlbXBsYXRlIiwiVVVJRCI6IjVmYWRjOGY1LWIzZDYtNDBkMS04NjY4LTNlNGFmNzNiZWZiNyIsIk9mZnNldCI6MCwiU3RhcnRlZEF0IjoiMjAyMy0wOC0yOVQxNTo1NTo1OC41MzEzMDc3NTVaIn0%3D
+      - /v2/ubuntu-vm-arm-template/blobs/uploads/795a938f-696d-4904-b818-7a4a25d013e2?_nouploadcache=false&_state=RtBjcc5hfvVsCBlYKVX2T5-B0bLimkbmD0Zlg0v5QjB7Ik5hbWUiOiJ1YnVudHUtdm0tYXJtLXRlbXBsYXRlIiwiVVVJRCI6Ijc5NWE5MzhmLTY5NmQtNDkwNC1iODE4LTdhNGEyNWQwMTNlMiIsIk9mZnNldCI6MCwiU3RhcnRlZEF0IjoiMjAyMy0wOS0wNVQwOTo0OToyMi41NDU3MDk5NzdaIn0%3D
       range:
       - 0-0
       server:
@@ -2865,9 +2730,9 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - python-requests/2.31.0
+      - python-requests/2.26.0
     method: PUT
-    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/v2/ubuntu-vm-arm-template/blobs/uploads/5fadc8f5-b3d6-40d1-8668-3e4af73befb7?_nouploadcache=false&_state=4Fo-lXSoT6fpl62615Nxz5oPtqNHHDwXHb3REoA7pbx7Ik5hbWUiOiJ1YnVudHUtdm0tYXJtLXRlbXBsYXRlIiwiVVVJRCI6IjVmYWRjOGY1LWIzZDYtNDBkMS04NjY4LTNlNGFmNzNiZWZiNyIsIk9mZnNldCI6MCwiU3RhcnRlZEF0IjoiMjAyMy0wOC0yOVQxNTo1NTo1OC41MzEzMDc3NTVaIn0%3D&digest=sha256%3Ae71bf56543dc33dc8e550a0c574efe9a4875754a4ddf74347e448dec2462798b
+    uri: https://ubuntupublisherubuntuacr3811a7f31a.azurecr.io/v2/ubuntu-vm-arm-template/blobs/uploads/795a938f-696d-4904-b818-7a4a25d013e2?_nouploadcache=false&_state=RtBjcc5hfvVsCBlYKVX2T5-B0bLimkbmD0Zlg0v5QjB7Ik5hbWUiOiJ1YnVudHUtdm0tYXJtLXRlbXBsYXRlIiwiVVVJRCI6Ijc5NWE5MzhmLTY5NmQtNDkwNC1iODE4LTdhNGEyNWQwMTNlMiIsIk9mZnNldCI6MCwiU3RhcnRlZEF0IjoiMjAyMy0wOS0wNVQwOTo0OToyMi41NDU3MDk5NzdaIn0%3D&digest=sha256%3Ae71bf56543dc33dc8e550a0c574efe9a4875754a4ddf74347e448dec2462798b
   response:
     body:
       string: ''
@@ -2882,7 +2747,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 29 Aug 2023 15:55:58 GMT
+      - Tue, 05 Sep 2023 09:49:22 GMT
       docker-content-digest:
       - sha256:e71bf56543dc33dc8e550a0c574efe9a4875754a4ddf74347e448dec2462798b
       docker-distribution-api-version:
@@ -2913,9 +2778,9 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - python-requests/2.31.0
+      - python-requests/2.26.0
     method: POST
-    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/v2/ubuntu-vm-arm-template/blobs/uploads/
+    uri: https://ubuntupublisherubuntuacr3811a7f31a.azurecr.io/v2/ubuntu-vm-arm-template/blobs/uploads/
   response:
     body:
       string: '{"errors": [{"code": "UNAUTHORIZED", "message": "authentication required,
@@ -2935,7 +2800,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:55:58 GMT
+      - Tue, 05 Sep 2023 09:49:23 GMT
       docker-distribution-api-version:
       - registry/2.0
       server:
@@ -2944,7 +2809,7 @@ interactions:
       - max-age=31536000; includeSubDomains
       - max-age=31536000; includeSubDomains
       www-authenticate:
-      - Bearer realm="https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/oauth2/token",service="ubuntupublisherubuntuacr8e894d23e6.azurecr.io",scope="repository:ubuntu-vm-arm-template:pull,push"
+      - Bearer realm="https://ubuntupublisherubuntuacr3811a7f31a.azurecr.io/oauth2/token",service="ubuntupublisherubuntuacr3811a7f31a.azurecr.io",scope="repository:ubuntu-vm-arm-template:pull,push"
       x-content-type-options:
       - nosniff
     status:
@@ -2960,11 +2825,11 @@ interactions:
       Connection:
       - keep-alive
       Service:
-      - ubuntupublisherubuntuacr8e894d23e6.azurecr.io
+      - ubuntupublisherubuntuacr3811a7f31a.azurecr.io
       User-Agent:
       - oras-py
     method: GET
-    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/oauth2/token?service=ubuntupublisherubuntuacr8e894d23e6.azurecr.io&scope=repository%3Aubuntu-vm-arm-template%3Apull%2Cpush
+    uri: https://ubuntupublisherubuntuacr3811a7f31a.azurecr.io/oauth2/token?service=ubuntupublisherubuntuacr3811a7f31a.azurecr.io&scope=repository%3Aubuntu-vm-arm-template%3Apull%2Cpush
   response:
     body:
       string: '{"access_token": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}'
@@ -2974,7 +2839,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:55:59 GMT
+      - Tue, 05 Sep 2023 09:49:23 GMT
       server:
       - openresty
       strict-transport-security:
@@ -3000,9 +2865,9 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - python-requests/2.31.0
+      - python-requests/2.26.0
     method: POST
-    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/v2/ubuntu-vm-arm-template/blobs/uploads/
+    uri: https://ubuntupublisherubuntuacr3811a7f31a.azurecr.io/v2/ubuntu-vm-arm-template/blobs/uploads/
   response:
     body:
       string: ''
@@ -3017,13 +2882,13 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 29 Aug 2023 15:55:59 GMT
+      - Tue, 05 Sep 2023 09:49:23 GMT
       docker-distribution-api-version:
       - registry/2.0
       docker-upload-uuid:
-      - a4753e4b-54a9-4fc6-8e84-99359fdf505f
+      - e6d952bf-3f27-4ca7-a5ad-593c0f73f702
       location:
-      - /v2/ubuntu-vm-arm-template/blobs/uploads/a4753e4b-54a9-4fc6-8e84-99359fdf505f?_nouploadcache=false&_state=brpszlUaMZlcgHIXdbdAImcdrg0zRwo_CWknisOSRap7Ik5hbWUiOiJ1YnVudHUtdm0tYXJtLXRlbXBsYXRlIiwiVVVJRCI6ImE0NzUzZTRiLTU0YTktNGZjNi04ZTg0LTk5MzU5ZmRmNTA1ZiIsIk9mZnNldCI6MCwiU3RhcnRlZEF0IjoiMjAyMy0wOC0yOVQxNTo1NTo1OS4zMTA2MTY1OTVaIn0%3D
+      - /v2/ubuntu-vm-arm-template/blobs/uploads/e6d952bf-3f27-4ca7-a5ad-593c0f73f702?_nouploadcache=false&_state=YqYxr5wLrDW0DvMS6gIlunDceHazfSETL_u-qW_Op_N7Ik5hbWUiOiJ1YnVudHUtdm0tYXJtLXRlbXBsYXRlIiwiVVVJRCI6ImU2ZDk1MmJmLTNmMjctNGNhNy1hNWFkLTU5M2MwZjczZjcwMiIsIk9mZnNldCI6MCwiU3RhcnRlZEF0IjoiMjAyMy0wOS0wNVQwOTo0OToyMy4zNDMyMDkyMTRaIn0%3D
       range:
       - 0-0
       server:
@@ -3050,9 +2915,9 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - python-requests/2.31.0
+      - python-requests/2.26.0
     method: PUT
-    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/v2/ubuntu-vm-arm-template/blobs/uploads/a4753e4b-54a9-4fc6-8e84-99359fdf505f?_nouploadcache=false&_state=brpszlUaMZlcgHIXdbdAImcdrg0zRwo_CWknisOSRap7Ik5hbWUiOiJ1YnVudHUtdm0tYXJtLXRlbXBsYXRlIiwiVVVJRCI6ImE0NzUzZTRiLTU0YTktNGZjNi04ZTg0LTk5MzU5ZmRmNTA1ZiIsIk9mZnNldCI6MCwiU3RhcnRlZEF0IjoiMjAyMy0wOC0yOVQxNTo1NTo1OS4zMTA2MTY1OTVaIn0%3D&digest=sha256%3Ae3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    uri: https://ubuntupublisherubuntuacr3811a7f31a.azurecr.io/v2/ubuntu-vm-arm-template/blobs/uploads/e6d952bf-3f27-4ca7-a5ad-593c0f73f702?_nouploadcache=false&_state=YqYxr5wLrDW0DvMS6gIlunDceHazfSETL_u-qW_Op_N7Ik5hbWUiOiJ1YnVudHUtdm0tYXJtLXRlbXBsYXRlIiwiVVVJRCI6ImU2ZDk1MmJmLTNmMjctNGNhNy1hNWFkLTU5M2MwZjczZjcwMiIsIk9mZnNldCI6MCwiU3RhcnRlZEF0IjoiMjAyMy0wOS0wNVQwOTo0OToyMy4zNDMyMDkyMTRaIn0%3D&digest=sha256%3Ae3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   response:
     body:
       string: ''
@@ -3067,7 +2932,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 29 Aug 2023 15:55:59 GMT
+      - Tue, 05 Sep 2023 09:49:23 GMT
       docker-content-digest:
       - sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       docker-distribution-api-version:
@@ -3104,9 +2969,9 @@ interactions:
       Content-Type:
       - application/vnd.oci.image.manifest.v1+json
       User-Agent:
-      - python-requests/2.31.0
+      - python-requests/2.26.0
     method: PUT
-    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/v2/ubuntu-vm-arm-template/manifests/1.0.0
+    uri: https://ubuntupublisherubuntuacr3811a7f31a.azurecr.io/v2/ubuntu-vm-arm-template/manifests/1.0.0
   response:
     body:
       string: '{"errors": [{"code": "UNAUTHORIZED", "message": "authentication required,
@@ -3126,7 +2991,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:55:59 GMT
+      - Tue, 05 Sep 2023 09:49:23 GMT
       docker-distribution-api-version:
       - registry/2.0
       server:
@@ -3135,7 +3000,7 @@ interactions:
       - max-age=31536000; includeSubDomains
       - max-age=31536000; includeSubDomains
       www-authenticate:
-      - Bearer realm="https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/oauth2/token",service="ubuntupublisherubuntuacr8e894d23e6.azurecr.io",scope="repository:ubuntu-vm-arm-template:pull,push"
+      - Bearer realm="https://ubuntupublisherubuntuacr3811a7f31a.azurecr.io/oauth2/token",service="ubuntupublisherubuntuacr3811a7f31a.azurecr.io",scope="repository:ubuntu-vm-arm-template:pull,push"
       x-content-type-options:
       - nosniff
     status:
@@ -3151,11 +3016,11 @@ interactions:
       Connection:
       - keep-alive
       Service:
-      - ubuntupublisherubuntuacr8e894d23e6.azurecr.io
+      - ubuntupublisherubuntuacr3811a7f31a.azurecr.io
       User-Agent:
       - oras-py
     method: GET
-    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/oauth2/token?service=ubuntupublisherubuntuacr8e894d23e6.azurecr.io&scope=repository%3Aubuntu-vm-arm-template%3Apull%2Cpush
+    uri: https://ubuntupublisherubuntuacr3811a7f31a.azurecr.io/oauth2/token?service=ubuntupublisherubuntuacr3811a7f31a.azurecr.io&scope=repository%3Aubuntu-vm-arm-template%3Apull%2Cpush
   response:
     body:
       string: '{"access_token": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}'
@@ -3165,7 +3030,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:55:59 GMT
+      - Tue, 05 Sep 2023 09:49:23 GMT
       server:
       - openresty
       strict-transport-security:
@@ -3197,9 +3062,9 @@ interactions:
       Content-Type:
       - application/vnd.oci.image.manifest.v1+json
       User-Agent:
-      - python-requests/2.31.0
+      - python-requests/2.26.0
     method: PUT
-    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/v2/ubuntu-vm-arm-template/manifests/1.0.0
+    uri: https://ubuntupublisherubuntuacr3811a7f31a.azurecr.io/v2/ubuntu-vm-arm-template/manifests/1.0.0
   response:
     body:
       string: ''
@@ -3214,7 +3079,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 29 Aug 2023 15:56:00 GMT
+      - Tue, 05 Sep 2023 09:49:24 GMT
       docker-content-digest:
       - sha256:8923fa544da97914212bc9173ec512741d331940e4a2c7b6fbad979657a5c507
       docker-distribution-api-version:
@@ -3234,7 +3099,7 @@ interactions:
 - request:
     body: '{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
       "contentVersion": "1.0.0.0", "metadata": {"_generator": {"name": "bicep", "version":
-      "0.12.40.16777", "templateHash": "1926705401567781373"}}, "parameters": {"location":
+      "0.15.31.15270", "templateHash": "9758159467150602695"}}, "parameters": {"location":
       {"type": "string"}, "publisherName": {"type": "string", "metadata": {"description":
       "Name of an existing publisher, expected to be in the resource group where you
       deploy the template"}}, "acrArtifactStoreName": {"type": "string", "metadata":
@@ -3300,14 +3165,14 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/validate?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693324562",
-        "name": "AOSM_CLI_deployment_1693324562", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "1926705401567781373", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693907367",
+        "name": "AOSM_CLI_deployment_1693907367", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "9758159467150602695", "parameters": {"location":
         {"type": "String", "value": "westcentralus"}, "publisherName": {"type": "String",
         "value": "ubuntuPublisher"}, "acrArtifactStoreName": {"type": "String", "value":
         "ubuntu-acr"}, "saArtifactStoreName": {"type": "String", "value": "ubuntu-blob-store"},
@@ -3316,7 +3181,7 @@ interactions:
         "value": "1.0.0"}, "vhdVersion": {"type": "String", "value": "1-0-0"}, "armTemplateVersion":
         {"type": "String", "value": "1.0.0"}}, "mode": "Incremental", "provisioningState":
         "Succeeded", "timestamp": "0001-01-01T00:00:00Z", "duration": "PT0S", "correlationId":
-        "358fefb4-997e-4764-93ee-8dce6e41f410", "providers": [{"namespace": "Microsoft.Hybridnetwork",
+        "ac2df063-4f9a-480b-ae7f-a3f1cd3c88d8", "providers": [{"namespace": "Microsoft.Hybridnetwork",
         "resourceTypes": [{"resourceType": "publishers/networkfunctiondefinitiongroups/networkfunctiondefinitionversions",
         "locations": ["westcentralus"]}]}], "dependencies": [], "validatedResources":
         [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/ubuntuPublisher/networkfunctiondefinitiongroups/ubuntu-vm-nfdg/networkfunctiondefinitionversions/1.0.0"}]}}'
@@ -3328,7 +3193,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:56:03 GMT
+      - Tue, 05 Sep 2023 09:49:28 GMT
       expires:
       - '-1'
       pragma:
@@ -3349,7 +3214,7 @@ interactions:
 - request:
     body: '{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
       "contentVersion": "1.0.0.0", "metadata": {"_generator": {"name": "bicep", "version":
-      "0.12.40.16777", "templateHash": "1926705401567781373"}}, "parameters": {"location":
+      "0.15.31.15270", "templateHash": "9758159467150602695"}}, "parameters": {"location":
       {"type": "string"}, "publisherName": {"type": "string", "metadata": {"description":
       "Name of an existing publisher, expected to be in the resource group where you
       deploy the template"}}, "acrArtifactStoreName": {"type": "string", "metadata":
@@ -3415,14 +3280,14 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693324562",
-        "name": "AOSM_CLI_deployment_1693324562", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "1926705401567781373", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693907367",
+        "name": "AOSM_CLI_deployment_1693907367", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "9758159467150602695", "parameters": {"location":
         {"type": "String", "value": "westcentralus"}, "publisherName": {"type": "String",
         "value": "ubuntuPublisher"}, "acrArtifactStoreName": {"type": "String", "value":
         "ubuntu-acr"}, "saArtifactStoreName": {"type": "String", "value": "ubuntu-blob-store"},
@@ -3430,13 +3295,13 @@ interactions:
         "String", "value": "ubuntu-vm-nfdg"}, "nfDefinitionVersion": {"type": "String",
         "value": "1.0.0"}, "vhdVersion": {"type": "String", "value": "1-0-0"}, "armTemplateVersion":
         {"type": "String", "value": "1.0.0"}}, "mode": "Incremental", "provisioningState":
-        "Accepted", "timestamp": "2023-08-29T15:56:07.0620969Z", "duration": "PT0.0001316S",
-        "correlationId": "c12ea2f4-c906-4529-961f-4faf217719d0", "providers": [{"namespace":
+        "Accepted", "timestamp": "2023-09-05T09:49:30.6661821Z", "duration": "PT0.0000952S",
+        "correlationId": "325ae515-57b2-4ac9-8f1a-f765a5f3f74f", "providers": [{"namespace":
         "Microsoft.Hybridnetwork", "resourceTypes": [{"resourceType": "publishers/networkfunctiondefinitiongroups/networkfunctiondefinitionversions",
         "locations": ["westcentralus"]}]}], "dependencies": []}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693324562/operationStatuses/08585082823207719763?api-version=2022-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693907367/operationStatuses/08585076995154451923?api-version=2022-09-01
       cache-control:
       - no-cache
       content-length:
@@ -3444,7 +3309,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:56:07 GMT
+      - Tue, 05 Sep 2023 09:49:30 GMT
       expires:
       - '-1'
       pragma:
@@ -3472,9 +3337,9 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585082823207719763?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585076995154451923?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Accepted"}'
@@ -3486,7 +3351,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:56:08 GMT
+      - Tue, 05 Sep 2023 09:49:30 GMT
       expires:
       - '-1'
       pragma:
@@ -3514,9 +3379,9 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585082823207719763?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585076995154451923?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Running"}'
@@ -3528,7 +3393,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:56:38 GMT
+      - Tue, 05 Sep 2023 09:50:01 GMT
       expires:
       - '-1'
       pragma:
@@ -3556,9 +3421,9 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585082823207719763?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585076995154451923?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Running"}'
@@ -3570,7 +3435,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:57:09 GMT
+      - Tue, 05 Sep 2023 09:50:31 GMT
       expires:
       - '-1'
       pragma:
@@ -3598,9 +3463,9 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585082823207719763?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585076995154451923?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Succeeded"}'
@@ -3612,7 +3477,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:57:39 GMT
+      - Tue, 05 Sep 2023 09:51:01 GMT
       expires:
       - '-1'
       pragma:
@@ -3640,14 +3505,14 @@ interactions:
       ParameterSetName:
       - -f --definition-type
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693324562",
-        "name": "AOSM_CLI_deployment_1693324562", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "1926705401567781373", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693907367",
+        "name": "AOSM_CLI_deployment_1693907367", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "9758159467150602695", "parameters": {"location":
         {"type": "String", "value": "westcentralus"}, "publisherName": {"type": "String",
         "value": "ubuntuPublisher"}, "acrArtifactStoreName": {"type": "String", "value":
         "ubuntu-acr"}, "saArtifactStoreName": {"type": "String", "value": "ubuntu-blob-store"},
@@ -3655,8 +3520,8 @@ interactions:
         "String", "value": "ubuntu-vm-nfdg"}, "nfDefinitionVersion": {"type": "String",
         "value": "1.0.0"}, "vhdVersion": {"type": "String", "value": "1-0-0"}, "armTemplateVersion":
         {"type": "String", "value": "1.0.0"}}, "mode": "Incremental", "provisioningState":
-        "Succeeded", "timestamp": "2023-08-29T15:57:28.5850113Z", "duration": "PT1M21.523046S",
-        "correlationId": "c12ea2f4-c906-4529-961f-4faf217719d0", "providers": [{"namespace":
+        "Succeeded", "timestamp": "2023-09-05T09:50:51.8138496Z", "duration": "PT1M21.1477627S",
+        "correlationId": "325ae515-57b2-4ac9-8f1a-f765a5f3f74f", "providers": [{"namespace":
         "Microsoft.Hybridnetwork", "resourceTypes": [{"resourceType": "publishers/networkfunctiondefinitiongroups/networkfunctiondefinitionversions",
         "locations": ["westcentralus"]}]}], "dependencies": [], "outputResources":
         [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/ubuntuPublisher/networkfunctiondefinitiongroups/ubuntu-vm-nfdg/networkfunctiondefinitionversions/1.0.0"}]}}'
@@ -3664,11 +3529,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1571'
+      - '1572'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:57:39 GMT
+      - Tue, 05 Sep 2023 09:51:02 GMT
       expires:
       - '-1'
       pragma:
@@ -3696,44 +3561,32 @@ interactions:
       ParameterSetName:
       - -f --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg/networkFunctionDefinitionVersions/1.0.0?api-version=2023-04-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.HybridNetwork/proxyPublishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg/networkFunctionDefinitionVersions/1.0.0?publisherScope=private&publisherLocation=westcentralus&api-version=2023-04-01-preview
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/ubuntuPublisher/networkfunctiondefinitiongroups/ubuntu-vm-nfdg/networkfunctiondefinitionversions/1.0.0",
-        "name": "1.0.0", "type": "microsoft.hybridnetwork/publishers/networkfunctiondefinitiongroups/networkfunctiondefinitionversions",
-        "location": "westcentralus", "systemData": {"createdBy": "sunnycarter@microsoft.com",
-        "createdByType": "User", "createdAt": "2023-08-29T15:56:10.8293417Z", "lastModifiedBy":
-        "sunnycarter@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2023-08-29T15:56:10.8293417Z"}, "properties": {"networkFunctionTemplate":
-        {"networkFunctionApplications": [{"artifactProfile": {"vhdArtifactProfile":
-        {"vhdName": "ubuntu-vm-vhd", "vhdVersion": "1-0-0"}, "artifactStore": {"id":
-        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store"}},
-        "deployParametersMappingRuleProfile": {"vhdImageMappingRuleProfile": {"userConfiguration":
-        "{\"imageName\":\"ubuntu-vmImage\",\"azureDeployLocation\":\"{deployParameters.location}\"}"},
-        "applicationEnablement": "Unknown"}, "artifactType": "VhdImageFile", "dependsOnProfile":
-        null, "name": "ubuntu-vmImage"}, {"artifactProfile": {"templateArtifactProfile":
-        {"templateName": "ubuntu-vm-arm-template", "templateVersion": "1.0.0"}, "artifactStore":
-        {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr"}},
-        "deployParametersMappingRuleProfile": {"templateMappingRuleProfile": {"templateParameters":
-        "{\"location\":\"{deployParameters.location}\",\"subnetName\":\"{deployParameters.subnetName}\",\"ubuntuVmName\":\"{deployParameters.ubuntuVmName}\",\"virtualNetworkId\":\"{deployParameters.virtualNetworkId}\",\"sshPublicKeyAdmin\":\"{deployParameters.sshPublicKeyAdmin}\",\"imageName\":\"ubuntu-vmImage\"}"},
-        "applicationEnablement": "Unknown"}, "artifactType": "ArmTemplate", "dependsOnProfile":
-        null, "name": "ubuntu-vm"}], "nfviType": "AzureCore"}, "versionState": "Preview",
-        "description": null, "deployParameters": "{\"$schema\":\"https://json-schema.org/draft-07/schema#\",\"title\":\"DeployParametersSchema\",\"type\":\"object\",\"properties\":{\"location\":{\"type\":\"string\"},\"subnetName\":{\"type\":\"string\"},\"ubuntuVmName\":{\"type\":\"string\"},\"virtualNetworkId\":{\"type\":\"string\"},\"sshPublicKeyAdmin\":{\"type\":\"string\"}},\"required\":[\"location\",\"subnetName\",\"ubuntuVmName\",\"virtualNetworkId\",\"sshPublicKeyAdmin\"]}",
-        "networkFunctionType": "VirtualNetworkFunction", "provisioningState": "Succeeded"}}'
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.HybridNetwork/proxyPublishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg/networkFunctionDefinitionVersions/1.0.0?publisherscope=Private&publisherlocation=westcentralus",
+        "name": "1.0.0", "type": "proxyPublishers/networkFunctionDefinitionGroups/networkFunctionDefinitionVersions",
+        "properties": {"versionState": "Preview", "description": null, "networkFunctionType":
+        "VirtualNetworkFunction", "nfviType": "AzureCore", "deployParameters": "{\"$schema\":\"https://json-schema.org/draft-07/schema#\",\"title\":\"DeployParametersSchema\",\"type\":\"object\",\"properties\":{\"location\":{\"type\":\"string\"},\"subnetName\":{\"type\":\"string\"},\"ubuntuVmName\":{\"type\":\"string\"},\"virtualNetworkId\":{\"type\":\"string\"},\"sshPublicKeyAdmin\":{\"type\":\"string\"}},\"required\":[\"location\",\"subnetName\",\"ubuntuVmName\",\"virtualNetworkId\",\"sshPublicKeyAdmin\"]}",
+        "networkFunctionApplications": [{"deployParametersMappingRuleProfile": {"vhdImageMappingRuleProfile":
+        {"userConfiguration": "{\"imageName\":\"ubuntu-vmImage\",\"azureDeployLocation\":\"{deployParameters.location}\"}"},
+        "applicationEnablement": "Unknown"}, "name": "ubuntu-vmImage", "artifactType":
+        "VhdImageFile"}, {"deployParametersMappingRuleProfile": {"templateMappingRuleProfile":
+        {"templateParameters": "{\"location\":\"{deployParameters.location}\",\"subnetName\":\"{deployParameters.subnetName}\",\"ubuntuVmName\":\"{deployParameters.ubuntuVmName}\",\"virtualNetworkId\":\"{deployParameters.virtualNetworkId}\",\"sshPublicKeyAdmin\":\"{deployParameters.sshPublicKeyAdmin}\",\"imageName\":\"ubuntu-vmImage\"}"},
+        "applicationEnablement": "Unknown"}, "name": "ubuntu-vm", "artifactType":
+        "ArmTemplate"}]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '2815'
+      - '1783'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:57:40 GMT
-      etag:
-      - '"00003600-0000-0600-0000-64ee152a0000"'
+      - Tue, 05 Sep 2023 09:51:04 GMT
       expires:
       - '-1'
       pragma:
@@ -3746,6 +3599,8 @@ interactions:
       - Accept-Encoding
       x-content-type-options:
       - nosniff
+      x-ms-build-version:
+      - 1.0.02386.1640
       x-ms-providerhub-traffic:
       - 'True'
     status:
@@ -3765,7 +3620,7 @@ interactions:
       ParameterSetName:
       - -f
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/Allow-2023-09-01?api-version=2021-07-01
   response:
@@ -3780,142 +3635,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:57:40 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json, text/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aosm nsd publish
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -f
-      User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/AllowPreReleaseFeatures?api-version=2021-07-01
-  response:
-    body:
-      string: '{"properties": {"state": "Registered"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/AllowPreReleaseFeatures",
-        "type": "Microsoft.Features/providers/features", "name": "Microsoft.HybridNetwork/AllowPreReleaseFeatures"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 29 Aug 2023 15:57:40 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json, text/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aosm nsd publish
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -f
-      User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/Allow-2023-04-01-preview?api-version=2021-07-01
-  response:
-    body:
-      string: '{"properties": {"state": "Registered"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/Allow-2023-04-01-preview",
-        "type": "Microsoft.Features/providers/features", "name": "Microsoft.HybridNetwork/Allow-2023-04-01-preview"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '306'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 29 Aug 2023 15:57:40 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json, text/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aosm nsd publish
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -f
-      User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/MsiForResourceEnabled?api-version=2021-07-01
-  response:
-    body:
-      string: '{"properties": {"state": "Registered"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/MsiForResourceEnabled",
-        "type": "Microsoft.Features/providers/features", "name": "Microsoft.HybridNetwork/MsiForResourceEnabled"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '300'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 29 Aug 2023 15:57:40 GMT
+      - Tue, 05 Sep 2023 09:51:04 GMT
       expires:
       - '-1'
       pragma:
@@ -3945,7 +3665,7 @@ interactions:
       ParameterSetName:
       - -f
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: HEAD
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001?api-version=2022-09-01
   response:
@@ -3957,7 +3677,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 29 Aug 2023 15:57:41 GMT
+      - Tue, 05 Sep 2023 09:51:05 GMT
       expires:
       - '-1'
       pragma:
@@ -3983,7 +3703,7 @@ interactions:
       ParameterSetName:
       - -f
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001?api-version=2022-09-01
   response:
@@ -3991,8 +3711,8 @@ interactions:
       string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001",
         "name": "cli_test_vnf_nsd_000001", "type": "Microsoft.Resources/resourceGroups",
         "location": "westcentralus", "tags": {"product": "azurecli", "cause": "automation",
-        "test": "test_vnf_nsd_publish_and_delete", "date": "2023-08-29T15:46:31Z",
-        "module": "aosm", "autoDelete": "true", "expiresOn": "2023-09-28T15:46:31.4504856Z"},
+        "test": "test_vnf_nsd_publish_and_delete", "date": "2023-09-05T09:40:10Z",
+        "module": "aosm", "autoDelete": "true", "expiresOn": "2023-10-05T09:40:11.0915609Z"},
         "properties": {"provisioningState": "Succeeded"}}'
     headers:
       cache-control:
@@ -4002,7 +3722,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:57:41 GMT
+      - Tue, 05 Sep 2023 09:51:05 GMT
       expires:
       - '-1'
       pragma:
@@ -4030,30 +3750,30 @@ interactions:
       ParameterSetName:
       - -f
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher?api-version=2023-04-01-preview
   response:
     body:
       string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher",
         "name": "ubuntuPublisher", "type": "microsoft.hybridnetwork/publishers", "location":
-        "westcentralus", "systemData": {"createdBy": "sunnycarter@microsoft.com",
-        "createdByType": "User", "createdAt": "2023-08-29T15:46:35.343537Z", "lastModifiedBy":
-        "sunnycarter@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2023-08-29T15:46:35.343537Z"}, "properties": {"scope": "Private", "provisioningState":
+        "westcentralus", "systemData": {"createdBy": "jamieparsons@microsoft.com",
+        "createdByType": "User", "createdAt": "2023-09-05T09:40:14.6593186Z", "lastModifiedBy":
+        "jamieparsons@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
+        "2023-09-05T09:40:14.6593186Z"}, "properties": {"scope": "Private", "provisioningState":
         "Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '586'
+      - '590'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:57:42 GMT
+      - Tue, 05 Sep 2023 09:51:05 GMT
       etag:
-      - '"00003c03-0000-0600-0000-64ee12e60000"'
+      - '"2a00d48b-0000-0800-0000-64f6f78a0000"'
       expires:
       - '-1'
       pragma:
@@ -4085,32 +3805,32 @@ interactions:
       ParameterSetName:
       - -f
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr?api-version=2023-04-01-preview
   response:
     body:
       string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr",
         "name": "ubuntu-acr", "type": "microsoft.hybridnetwork/publishers/artifactstores",
-        "location": "westcentralus", "systemData": {"createdBy": "sunnycarter@microsoft.com",
-        "createdByType": "User", "createdAt": "2023-08-29T15:48:08.8909773Z", "lastModifiedBy":
+        "location": "westcentralus", "systemData": {"createdBy": "jamieparsons@microsoft.com",
+        "createdByType": "User", "createdAt": "2023-09-05T09:41:48.6283289Z", "lastModifiedBy":
         "b8ed041c-aa91-418e-8f47-20c70abc2de1", "lastModifiedByType": "Application",
-        "lastModifiedAt": "2023-08-29T15:56:25.5771605Z"}, "properties": {"storeType":
+        "lastModifiedAt": "2023-09-05T09:49:49.0874061Z"}, "properties": {"storeType":
         "AzureContainerRegistry", "replicationStrategy": "SingleReplication", "managedResourceGroupConfiguration":
-        {"name": "ubuntu-acr-HostedResources-663B284E", "location": "westcentralus"},
-        "provisioningState": "Succeeded", "storageResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/ubuntu-acr-HostedResources-663B284E/providers/Microsoft.ContainerRegistry/registries/UbuntupublisherUbuntuAcr8e894d23e6"}}'
+        {"name": "ubuntu-acr-HostedResources-50EB00B6", "location": "westcentralus"},
+        "provisioningState": "Succeeded", "storageResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/ubuntu-acr-HostedResources-50EB00B6/providers/Microsoft.ContainerRegistry/registries/UbuntupublisherUbuntuAcr3811a7f31a"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1031'
+      - '1032'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:57:42 GMT
+      - Tue, 05 Sep 2023 09:51:06 GMT
       etag:
-      - '"0000ec2e-0000-0600-0000-64ee152a0000"'
+      - '"75027469-0000-0800-0000-64f6f9bd0000"'
       expires:
       - '-1'
       pragma:
@@ -4146,32 +3866,32 @@ interactions:
       ParameterSetName:
       - -f
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkServiceDesignGroups/ubuntu?api-version=2023-04-01-preview
   response:
     body:
       string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkServiceDesignGroups/ubuntu",
         "name": "ubuntu", "type": "microsoft.hybridnetwork/publishers/networkservicedesigngroups",
-        "location": "westcentralus", "systemData": {"createdBy": "sunnycarter@microsoft.com",
-        "createdByType": "User", "createdAt": "2023-08-29T15:57:43.9163403Z", "lastModifiedBy":
-        "sunnycarter@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2023-08-29T15:57:43.9163403Z"}, "properties": {"description": null, "provisioningState":
+        "location": "westcentralus", "systemData": {"createdBy": "jamieparsons@microsoft.com",
+        "createdByType": "User", "createdAt": "2023-09-05T09:51:07.1676813Z", "lastModifiedBy":
+        "jamieparsons@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
+        "2023-09-05T09:51:07.1676813Z"}, "properties": {"description": null, "provisioningState":
         "Accepted"}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/8e5f8d49-efa6-47d9-8cdd-6ed90c40c51f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d8c7c505-e81f-49f0-8c0e-c88a228ab6db*4E5D58CE1F5E11E4533AFEE9111A2F1068594B87C55C4009C61A2FA4C46117F3?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
-      - '640'
+      - '642'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:57:53 GMT
+      - Tue, 05 Sep 2023 09:51:09 GMT
       etag:
-      - '"00003901-0000-0600-0000-64ee15810000"'
+      - '"2f00e247-0000-0800-0000-64f6fa0d0000"'
       expires:
       - '-1'
       pragma:
@@ -4203,27 +3923,27 @@ interactions:
       ParameterSetName:
       - -f
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/8e5f8d49-efa6-47d9-8cdd-6ed90c40c51f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d8c7c505-e81f-49f0-8c0e-c88a228ab6db*4E5D58CE1F5E11E4533AFEE9111A2F1068594B87C55C4009C61A2FA4C46117F3?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/8e5f8d49-efa6-47d9-8cdd-6ed90c40c51f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B",
-        "name": "8e5f8d49-efa6-47d9-8cdd-6ed90c40c51f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d8c7c505-e81f-49f0-8c0e-c88a228ab6db*4E5D58CE1F5E11E4533AFEE9111A2F1068594B87C55C4009C61A2FA4C46117F3",
+        "name": "d8c7c505-e81f-49f0-8c0e-c88a228ab6db*4E5D58CE1F5E11E4533AFEE9111A2F1068594B87C55C4009C61A2FA4C46117F3",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkServiceDesignGroups/ubuntu",
-        "status": "Accepted", "startTime": "2023-08-29T15:57:53.242231Z"}'
+        "status": "Accepted", "startTime": "2023-09-05T09:51:08.1760086Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '570'
+      - '571'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:57:53 GMT
+      - Tue, 05 Sep 2023 09:51:09 GMT
       etag:
-      - '"00002606-0000-0600-0000-64ee15810000"'
+      - '"220c64b4-0000-0800-0000-64f6fa0c0000"'
       expires:
       - '-1'
       pragma:
@@ -4253,28 +3973,28 @@ interactions:
       ParameterSetName:
       - -f
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/8e5f8d49-efa6-47d9-8cdd-6ed90c40c51f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d8c7c505-e81f-49f0-8c0e-c88a228ab6db*4E5D58CE1F5E11E4533AFEE9111A2F1068594B87C55C4009C61A2FA4C46117F3?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/8e5f8d49-efa6-47d9-8cdd-6ed90c40c51f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B",
-        "name": "8e5f8d49-efa6-47d9-8cdd-6ed90c40c51f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/d8c7c505-e81f-49f0-8c0e-c88a228ab6db*4E5D58CE1F5E11E4533AFEE9111A2F1068594B87C55C4009C61A2FA4C46117F3",
+        "name": "d8c7c505-e81f-49f0-8c0e-c88a228ab6db*4E5D58CE1F5E11E4533AFEE9111A2F1068594B87C55C4009C61A2FA4C46117F3",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkServiceDesignGroups/ubuntu",
-        "status": "Succeeded", "startTime": "2023-08-29T15:57:53.242231Z", "endTime":
-        "2023-08-29T15:58:01.2586688Z", "properties": null}'
+        "status": "Succeeded", "startTime": "2023-09-05T09:51:08.1760086Z", "endTime":
+        "2023-09-05T09:51:12.0204676Z", "properties": null}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '634'
+      - '635'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:58:24 GMT
+      - Tue, 05 Sep 2023 09:51:39 GMT
       etag:
-      - '"00002706-0000-0600-0000-64ee15890000"'
+      - '"220ca1b5-0000-0800-0000-64f6fa100000"'
       expires:
       - '-1'
       pragma:
@@ -4304,30 +4024,30 @@ interactions:
       ParameterSetName:
       - -f
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkServiceDesignGroups/ubuntu?api-version=2023-04-01-preview
   response:
     body:
       string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkServiceDesignGroups/ubuntu",
         "name": "ubuntu", "type": "microsoft.hybridnetwork/publishers/networkservicedesigngroups",
-        "location": "westcentralus", "systemData": {"createdBy": "sunnycarter@microsoft.com",
-        "createdByType": "User", "createdAt": "2023-08-29T15:57:43.9163403Z", "lastModifiedBy":
-        "sunnycarter@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2023-08-29T15:57:43.9163403Z"}, "properties": {"description": null, "provisioningState":
+        "location": "westcentralus", "systemData": {"createdBy": "jamieparsons@microsoft.com",
+        "createdByType": "User", "createdAt": "2023-09-05T09:51:07.1676813Z", "lastModifiedBy":
+        "jamieparsons@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
+        "2023-09-05T09:51:07.1676813Z"}, "properties": {"description": null, "provisioningState":
         "Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '641'
+      - '643'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:58:24 GMT
+      - Tue, 05 Sep 2023 09:51:39 GMT
       etag:
-      - '"00003a01-0000-0600-0000-64ee15890000"'
+      - '"2f00e347-0000-0800-0000-64f6fa100000"'
       expires:
       - '-1'
       pragma:
@@ -4359,8 +4079,8 @@ interactions:
       ParameterSetName:
       - -f
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-nfdg-nf-acr-manifest-1-0-0?api-version=2023-04-01-preview
   response:
@@ -4376,7 +4096,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:58:25 GMT
+      - Tue, 05 Sep 2023 09:51:40 GMT
       expires:
       - '-1'
       pragma:
@@ -4393,7 +4113,7 @@ interactions:
 - request:
     body: '{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
       "contentVersion": "1.0.0.0", "metadata": {"_generator": {"name": "bicep", "version":
-      "0.12.40.16777", "templateHash": "2851085707422332070"}}, "parameters": {"location":
+      "0.15.31.15270", "templateHash": "12504378736665252435"}}, "parameters": {"location":
       {"type": "string"}, "publisherName": {"type": "string", "metadata": {"description":
       "Name of an existing publisher, expected to be in the resource group where you
       deploy the template"}}, "acrArtifactStoreName": {"type": "string", "metadata":
@@ -4425,27 +4145,27 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '2067'
+      - '2068'
       Content-Type:
       - application/json
       ParameterSetName:
       - -f
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/validate?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693324707",
-        "name": "AOSM_CLI_deployment_1693324707", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "2851085707422332070", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693907503",
+        "name": "AOSM_CLI_deployment_1693907503", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "12504378736665252435", "parameters": {"location":
         {"type": "String", "value": "westcentralus"}, "publisherName": {"type": "String",
         "value": "ubuntuPublisher"}, "acrArtifactStoreName": {"type": "String", "value":
         "ubuntu-acr"}, "acrManifestNames": {"type": "Array", "value": ["ubuntu-vm-nfdg-nf-acr-manifest-1-0-0"]},
         "armTemplateNames": {"type": "Array", "value": ["ubuntu-vm-nfdg_nf_artifact"]},
         "armTemplateVersion": {"type": "String", "value": "1.0.0"}}, "mode": "Incremental",
         "provisioningState": "Succeeded", "timestamp": "0001-01-01T00:00:00Z", "duration":
-        "PT0S", "correlationId": "c7001363-001e-40fd-957e-3e8d9eec8f78", "providers":
+        "PT0S", "correlationId": "fda57aa2-3584-4425-86cb-502f0f99dd87", "providers":
         [{"namespace": "Microsoft.Hybridnetwork", "resourceTypes": [{"resourceType":
         "publishers/artifactStores/artifactManifests", "locations": ["westcentralus"]}]}],
         "dependencies": [], "validatedResources": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-nfdg-nf-acr-manifest-1-0-0"}]}}'
@@ -4453,11 +4173,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1381'
+      - '1382'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:58:29 GMT
+      - Tue, 05 Sep 2023 09:51:47 GMT
       expires:
       - '-1'
       pragma:
@@ -4478,7 +4198,7 @@ interactions:
 - request:
     body: '{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
       "contentVersion": "1.0.0.0", "metadata": {"_generator": {"name": "bicep", "version":
-      "0.12.40.16777", "templateHash": "2851085707422332070"}}, "parameters": {"location":
+      "0.15.31.15270", "templateHash": "12504378736665252435"}}, "parameters": {"location":
       {"type": "string"}, "publisherName": {"type": "string", "metadata": {"description":
       "Name of an existing publisher, expected to be in the resource group where you
       deploy the template"}}, "acrArtifactStoreName": {"type": "string", "metadata":
@@ -4510,41 +4230,41 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '2067'
+      - '2068'
       Content-Type:
       - application/json
       ParameterSetName:
       - -f
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693324707",
-        "name": "AOSM_CLI_deployment_1693324707", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "2851085707422332070", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693907503",
+        "name": "AOSM_CLI_deployment_1693907503", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "12504378736665252435", "parameters": {"location":
         {"type": "String", "value": "westcentralus"}, "publisherName": {"type": "String",
         "value": "ubuntuPublisher"}, "acrArtifactStoreName": {"type": "String", "value":
         "ubuntu-acr"}, "acrManifestNames": {"type": "Array", "value": ["ubuntu-vm-nfdg-nf-acr-manifest-1-0-0"]},
         "armTemplateNames": {"type": "Array", "value": ["ubuntu-vm-nfdg_nf_artifact"]},
         "armTemplateVersion": {"type": "String", "value": "1.0.0"}}, "mode": "Incremental",
-        "provisioningState": "Accepted", "timestamp": "2023-08-29T15:58:32.6763857Z",
-        "duration": "PT0.0002267S", "correlationId": "09cc96a3-cdc7-44c1-bb35-9d1fbb6828c7",
+        "provisioningState": "Accepted", "timestamp": "2023-09-05T09:51:50.6114456Z",
+        "duration": "PT0.0001764S", "correlationId": "0ca7da5a-c6d0-4e6c-9553-4ea7cf0614ca",
         "providers": [{"namespace": "Microsoft.Hybridnetwork", "resourceTypes": [{"resourceType":
         "publishers/artifactStores/artifactManifests", "locations": ["westcentralus"]}]}],
         "dependencies": []}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693324707/operationStatuses/08585082821741459869?api-version=2022-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693907503/operationStatuses/08585076993762694393?api-version=2022-09-01
       cache-control:
       - no-cache
       content-length:
-      - '1128'
+      - '1129'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:58:33 GMT
+      - Tue, 05 Sep 2023 09:51:51 GMT
       expires:
       - '-1'
       pragma:
@@ -4572,21 +4292,23 @@ interactions:
       ParameterSetName:
       - -f
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585082821741459869?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585076993762694393?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Accepted"}'
     headers:
       cache-control:
       - no-cache
+      connection:
+      - close
       content-length:
       - '22'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:58:33 GMT
+      - Tue, 05 Sep 2023 09:51:51 GMT
       expires:
       - '-1'
       pragma:
@@ -4614,51 +4336,9 @@ interactions:
       ParameterSetName:
       - -f
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585082821741459869?api-version=2022-09-01
-  response:
-    body:
-      string: '{"status": "Running"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 29 Aug 2023 15:59:03 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aosm nsd publish
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -f
-      User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585082821741459869?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585076993762694393?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Succeeded"}'
@@ -4670,7 +4350,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:59:33 GMT
+      - Tue, 05 Sep 2023 09:52:22 GMT
       expires:
       - '-1'
       pragma:
@@ -4698,21 +4378,21 @@ interactions:
       ParameterSetName:
       - -f
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693324707",
-        "name": "AOSM_CLI_deployment_1693324707", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "2851085707422332070", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693907503",
+        "name": "AOSM_CLI_deployment_1693907503", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "12504378736665252435", "parameters": {"location":
         {"type": "String", "value": "westcentralus"}, "publisherName": {"type": "String",
         "value": "ubuntuPublisher"}, "acrArtifactStoreName": {"type": "String", "value":
         "ubuntu-acr"}, "acrManifestNames": {"type": "Array", "value": ["ubuntu-vm-nfdg-nf-acr-manifest-1-0-0"]},
         "armTemplateNames": {"type": "Array", "value": ["ubuntu-vm-nfdg_nf_artifact"]},
         "armTemplateVersion": {"type": "String", "value": "1.0.0"}}, "mode": "Incremental",
-        "provisioningState": "Succeeded", "timestamp": "2023-08-29T15:59:16.4310587Z",
-        "duration": "PT43.7548997S", "correlationId": "09cc96a3-cdc7-44c1-bb35-9d1fbb6828c7",
+        "provisioningState": "Succeeded", "timestamp": "2023-09-05T09:52:18.7179466Z",
+        "duration": "PT28.1066774S", "correlationId": "0ca7da5a-c6d0-4e6c-9553-4ea7cf0614ca",
         "providers": [{"namespace": "Microsoft.Hybridnetwork", "resourceTypes": [{"resourceType":
         "publishers/artifactStores/artifactManifests", "locations": ["westcentralus"]}]}],
         "dependencies": [], "outputResources": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-nfdg-nf-acr-manifest-1-0-0"}]}}'
@@ -4720,11 +4400,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1395'
+      - '1396'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:59:33 GMT
+      - Tue, 05 Sep 2023 09:52:22 GMT
       expires:
       - '-1'
       pragma:
@@ -4752,31 +4432,31 @@ interactions:
       ParameterSetName:
       - -f
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-nfdg-nf-acr-manifest-1-0-0?api-version=2023-04-01-preview
   response:
     body:
       string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-nfdg-nf-acr-manifest-1-0-0",
         "name": "ubuntu-vm-nfdg-nf-acr-manifest-1-0-0", "type": "microsoft.hybridnetwork/publishers/artifactstores/artifactmanifests",
-        "location": "westcentralus", "systemData": {"createdBy": "sunnycarter@microsoft.com",
-        "createdByType": "User", "createdAt": "2023-08-29T15:58:36.6237908Z", "lastModifiedBy":
-        "sunnycarter@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2023-08-29T15:58:36.6237908Z"}, "properties": {"artifacts": [{"artifactName":
+        "location": "westcentralus", "systemData": {"createdBy": "jamieparsons@microsoft.com",
+        "createdByType": "User", "createdAt": "2023-09-05T09:51:54.9257911Z", "lastModifiedBy":
+        "jamieparsons@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
+        "2023-09-05T09:51:54.9257911Z"}, "properties": {"artifacts": [{"artifactName":
         "ubuntu-vm-nfdg_nf_artifact", "artifactType": "ArmTemplate", "artifactVersion":
         "1.0.0"}], "artifactManifestState": "Uploading", "provisioningState": "Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '863'
+      - '865'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:59:35 GMT
+      - Tue, 05 Sep 2023 09:52:23 GMT
       etag:
-      - '"00002e0f-0000-0600-0000-64ee15c20000"'
+      - '"2500c857-0000-0800-0000-64f6fa440000"'
       expires:
       - '-1'
       pragma:
@@ -4810,15 +4490,15 @@ interactions:
       ParameterSetName:
       - -f
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-nfdg-nf-acr-manifest-1-0-0/listCredential?api-version=2023-04-01-preview
   response:
     body:
       string: '{"username": "ubuntu-vm-nfdg-nf-acr-manifest-1-0-0", "acrToken": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-        "acrServerUrl": "https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io", "repositories":
-        ["ubuntu-vm-nfdg_nf_artifact"], "expiry": "2023-08-30T15:59:36.9854136+00:00",
+        "acrServerUrl": "https://ubuntupublisherubuntuacr3811a7f31a.azurecr.io", "repositories":
+        ["ubuntu-vm-nfdg_nf_artifact"], "expiry": "2023-09-06T09:52:24.7636616+00:00",
         "credentialType": "AzureContainerRegistryScopedToken"}'
     headers:
       cache-control:
@@ -4828,7 +4508,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:59:37 GMT
+      - Tue, 05 Sep 2023 09:52:25 GMT
       expires:
       - '-1'
       pragma:
@@ -4864,9 +4544,9 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - python-requests/2.31.0
+      - python-requests/2.26.0
     method: POST
-    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/v2/ubuntu-vm-nfdg_nf_artifact/blobs/uploads/
+    uri: https://ubuntupublisherubuntuacr3811a7f31a.azurecr.io/v2/ubuntu-vm-nfdg_nf_artifact/blobs/uploads/
   response:
     body:
       string: '{"errors": [{"code": "UNAUTHORIZED", "message": "authentication required,
@@ -4886,7 +4566,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:59:40 GMT
+      - Tue, 05 Sep 2023 09:52:29 GMT
       docker-distribution-api-version:
       - registry/2.0
       server:
@@ -4895,7 +4575,7 @@ interactions:
       - max-age=31536000; includeSubDomains
       - max-age=31536000; includeSubDomains
       www-authenticate:
-      - Bearer realm="https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/oauth2/token",service="ubuntupublisherubuntuacr8e894d23e6.azurecr.io",scope="repository:ubuntu-vm-nfdg_nf_artifact:pull,push"
+      - Bearer realm="https://ubuntupublisherubuntuacr3811a7f31a.azurecr.io/oauth2/token",service="ubuntupublisherubuntuacr3811a7f31a.azurecr.io",scope="repository:ubuntu-vm-nfdg_nf_artifact:pull,push"
       x-content-type-options:
       - nosniff
     status:
@@ -4911,11 +4591,11 @@ interactions:
       Connection:
       - keep-alive
       Service:
-      - ubuntupublisherubuntuacr8e894d23e6.azurecr.io
+      - ubuntupublisherubuntuacr3811a7f31a.azurecr.io
       User-Agent:
       - oras-py
     method: GET
-    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/oauth2/token?service=ubuntupublisherubuntuacr8e894d23e6.azurecr.io&scope=repository%3Aubuntu-vm-nfdg_nf_artifact%3Apull%2Cpush
+    uri: https://ubuntupublisherubuntuacr3811a7f31a.azurecr.io/oauth2/token?service=ubuntupublisherubuntuacr3811a7f31a.azurecr.io&scope=repository%3Aubuntu-vm-nfdg_nf_artifact%3Apull%2Cpush
   response:
     body:
       string: '{"access_token": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}'
@@ -4925,7 +4605,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:59:41 GMT
+      - Tue, 05 Sep 2023 09:52:29 GMT
       server:
       - openresty
       strict-transport-security:
@@ -4951,9 +4631,9 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - python-requests/2.31.0
+      - python-requests/2.26.0
     method: POST
-    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/v2/ubuntu-vm-nfdg_nf_artifact/blobs/uploads/
+    uri: https://ubuntupublisherubuntuacr3811a7f31a.azurecr.io/v2/ubuntu-vm-nfdg_nf_artifact/blobs/uploads/
   response:
     body:
       string: ''
@@ -4968,13 +4648,13 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 29 Aug 2023 15:59:41 GMT
+      - Tue, 05 Sep 2023 09:52:29 GMT
       docker-distribution-api-version:
       - registry/2.0
       docker-upload-uuid:
-      - 616589d9-557e-4af4-871d-f280e01b03a0
+      - 9ff55b23-9ffa-42f4-a33e-46aa1cbb3fdf
       location:
-      - /v2/ubuntu-vm-nfdg_nf_artifact/blobs/uploads/616589d9-557e-4af4-871d-f280e01b03a0?_nouploadcache=false&_state=ITMtpjWT0X3FyZxRkfW8TSCsQEgfPobzsxGv3RD2amh7Ik5hbWUiOiJ1YnVudHUtdm0tbmZkZ19uZl9hcnRpZmFjdCIsIlVVSUQiOiI2MTY1ODlkOS01NTdlLTRhZjQtODcxZC1mMjgwZTAxYjAzYTAiLCJPZmZzZXQiOjAsIlN0YXJ0ZWRBdCI6IjIwMjMtMDgtMjlUMTU6NTk6NDEuMzI1OTkwNjQyWiJ9
+      - /v2/ubuntu-vm-nfdg_nf_artifact/blobs/uploads/9ff55b23-9ffa-42f4-a33e-46aa1cbb3fdf?_nouploadcache=false&_state=MsjM-ya1K9Oru3ZUr_IMfPcgOKoLmOJ6_szQXl61tGN7Ik5hbWUiOiJ1YnVudHUtdm0tbmZkZ19uZl9hcnRpZmFjdCIsIlVVSUQiOiI5ZmY1NWIyMy05ZmZhLTQyZjQtYTMzZS00NmFhMWNiYjNmZGYiLCJPZmZzZXQiOjAsIlN0YXJ0ZWRBdCI6IjIwMjMtMDktMDVUMDk6NTI6MjkuODI0ODI5NjE4WiJ9
       range:
       - 0-0
       server:
@@ -4990,12 +4670,13 @@ interactions:
 - request:
     body: "{\n    \"$schema\": \"https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#\",\n
       \   \"contentVersion\": \"1.0.0.0\",\n    \"metadata\": {\n        \"_generator\":
-      {\n            \"name\": \"bicep\",\n            \"version\": \"0.12.40.16777\",\n
-      \           \"templateHash\": \"7534571119701202339\"\n        }\n    },\n    \"parameters\":
-      {\n        \"publisherName\": {\n            \"type\": \"string\",\n            \"defaultValue\":
-      \"ubuntuPublisher\",\n            \"metadata\": {\n                \"description\":
-      \"Publisher where the NFD is published\"\n            }\n        },\n        \"networkFunctionDefinitionGroupName\":
-      {\n            \"type\": \"string\",\n            \"defaultValue\": \"ubuntu-vm-nfdg\",\n
+      {\n            \"name\": \"bicep\",\n            \"version\": \"0.15.31.15270\",\n
+      \           \"templateHash\": \"16213402533690095645\"\n        }\n    },\n
+      \   \"parameters\": {\n        \"publisherName\": {\n            \"type\": \"string\",\n
+      \           \"defaultValue\": \"ubuntuPublisher\",\n            \"metadata\":
+      {\n                \"description\": \"Publisher where the NFD is published\"\n
+      \           }\n        },\n        \"networkFunctionDefinitionGroupName\": {\n
+      \           \"type\": \"string\",\n            \"defaultValue\": \"ubuntu-vm-nfdg\",\n
       \           \"metadata\": {\n                \"description\": \"NFD Group name
       for the Network Function\"\n            }\n        },\n        \"ubuntu_vm_nfdg_nfd_version\":
       {\n            \"type\": \"string\",\n            \"metadata\": {\n                \"description\":
@@ -5035,13 +4716,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '3341'
+      - '3342'
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - python-requests/2.31.0
+      - python-requests/2.26.0
     method: PUT
-    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/v2/ubuntu-vm-nfdg_nf_artifact/blobs/uploads/616589d9-557e-4af4-871d-f280e01b03a0?_nouploadcache=false&_state=ITMtpjWT0X3FyZxRkfW8TSCsQEgfPobzsxGv3RD2amh7Ik5hbWUiOiJ1YnVudHUtdm0tbmZkZ19uZl9hcnRpZmFjdCIsIlVVSUQiOiI2MTY1ODlkOS01NTdlLTRhZjQtODcxZC1mMjgwZTAxYjAzYTAiLCJPZmZzZXQiOjAsIlN0YXJ0ZWRBdCI6IjIwMjMtMDgtMjlUMTU6NTk6NDEuMzI1OTkwNjQyWiJ9&digest=sha256%3Acda1bbb871260a2c7624e8adc401dec0667351f923fe545647b887e9f5271aad
+    uri: https://ubuntupublisherubuntuacr3811a7f31a.azurecr.io/v2/ubuntu-vm-nfdg_nf_artifact/blobs/uploads/9ff55b23-9ffa-42f4-a33e-46aa1cbb3fdf?_nouploadcache=false&_state=MsjM-ya1K9Oru3ZUr_IMfPcgOKoLmOJ6_szQXl61tGN7Ik5hbWUiOiJ1YnVudHUtdm0tbmZkZ19uZl9hcnRpZmFjdCIsIlVVSUQiOiI5ZmY1NWIyMy05ZmZhLTQyZjQtYTMzZS00NmFhMWNiYjNmZGYiLCJPZmZzZXQiOjAsIlN0YXJ0ZWRBdCI6IjIwMjMtMDktMDVUMDk6NTI6MjkuODI0ODI5NjE4WiJ9&digest=sha256%3A3ed1035cbc2467e2e9ac9a9acbedba35995511ab5d8e54879250423d5e4f6680
   response:
     body:
       string: ''
@@ -5056,13 +4737,13 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 29 Aug 2023 15:59:41 GMT
+      - Tue, 05 Sep 2023 09:52:30 GMT
       docker-content-digest:
-      - sha256:cda1bbb871260a2c7624e8adc401dec0667351f923fe545647b887e9f5271aad
+      - sha256:3ed1035cbc2467e2e9ac9a9acbedba35995511ab5d8e54879250423d5e4f6680
       docker-distribution-api-version:
       - registry/2.0
       location:
-      - /v2/ubuntu-vm-nfdg_nf_artifact/blobs/sha256:cda1bbb871260a2c7624e8adc401dec0667351f923fe545647b887e9f5271aad
+      - /v2/ubuntu-vm-nfdg_nf_artifact/blobs/sha256:3ed1035cbc2467e2e9ac9a9acbedba35995511ab5d8e54879250423d5e4f6680
       server:
       - openresty
       strict-transport-security:
@@ -5087,9 +4768,9 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - python-requests/2.31.0
+      - python-requests/2.26.0
     method: POST
-    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/v2/ubuntu-vm-nfdg_nf_artifact/blobs/uploads/
+    uri: https://ubuntupublisherubuntuacr3811a7f31a.azurecr.io/v2/ubuntu-vm-nfdg_nf_artifact/blobs/uploads/
   response:
     body:
       string: '{"errors": [{"code": "UNAUTHORIZED", "message": "authentication required,
@@ -5109,7 +4790,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:59:41 GMT
+      - Tue, 05 Sep 2023 09:52:30 GMT
       docker-distribution-api-version:
       - registry/2.0
       server:
@@ -5118,7 +4799,7 @@ interactions:
       - max-age=31536000; includeSubDomains
       - max-age=31536000; includeSubDomains
       www-authenticate:
-      - Bearer realm="https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/oauth2/token",service="ubuntupublisherubuntuacr8e894d23e6.azurecr.io",scope="repository:ubuntu-vm-nfdg_nf_artifact:push,pull"
+      - Bearer realm="https://ubuntupublisherubuntuacr3811a7f31a.azurecr.io/oauth2/token",service="ubuntupublisherubuntuacr3811a7f31a.azurecr.io",scope="repository:ubuntu-vm-nfdg_nf_artifact:pull,push"
       x-content-type-options:
       - nosniff
     status:
@@ -5134,11 +4815,11 @@ interactions:
       Connection:
       - keep-alive
       Service:
-      - ubuntupublisherubuntuacr8e894d23e6.azurecr.io
+      - ubuntupublisherubuntuacr3811a7f31a.azurecr.io
       User-Agent:
       - oras-py
     method: GET
-    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/oauth2/token?service=ubuntupublisherubuntuacr8e894d23e6.azurecr.io&scope=repository%3Aubuntu-vm-nfdg_nf_artifact%3Apush%2Cpull
+    uri: https://ubuntupublisherubuntuacr3811a7f31a.azurecr.io/oauth2/token?service=ubuntupublisherubuntuacr3811a7f31a.azurecr.io&scope=repository%3Aubuntu-vm-nfdg_nf_artifact%3Apull%2Cpush
   response:
     body:
       string: '{"access_token": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}'
@@ -5148,7 +4829,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:59:41 GMT
+      - Tue, 05 Sep 2023 09:52:30 GMT
       server:
       - openresty
       strict-transport-security:
@@ -5174,9 +4855,9 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - python-requests/2.31.0
+      - python-requests/2.26.0
     method: POST
-    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/v2/ubuntu-vm-nfdg_nf_artifact/blobs/uploads/
+    uri: https://ubuntupublisherubuntuacr3811a7f31a.azurecr.io/v2/ubuntu-vm-nfdg_nf_artifact/blobs/uploads/
   response:
     body:
       string: ''
@@ -5191,13 +4872,13 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 29 Aug 2023 15:59:42 GMT
+      - Tue, 05 Sep 2023 09:52:30 GMT
       docker-distribution-api-version:
       - registry/2.0
       docker-upload-uuid:
-      - 7e7be12d-db35-4887-b41a-2114682c1037
+      - 73d5effe-8352-478e-b7a2-67043d9ea517
       location:
-      - /v2/ubuntu-vm-nfdg_nf_artifact/blobs/uploads/7e7be12d-db35-4887-b41a-2114682c1037?_nouploadcache=false&_state=GVN-YkeTyht6G_aBax7zYcamgtM7JtwGtvNV0AOv9tV7Ik5hbWUiOiJ1YnVudHUtdm0tbmZkZ19uZl9hcnRpZmFjdCIsIlVVSUQiOiI3ZTdiZTEyZC1kYjM1LTQ4ODctYjQxYS0yMTE0NjgyYzEwMzciLCJPZmZzZXQiOjAsIlN0YXJ0ZWRBdCI6IjIwMjMtMDgtMjlUMTU6NTk6NDIuMTE3NDg5ODQ4WiJ9
+      - /v2/ubuntu-vm-nfdg_nf_artifact/blobs/uploads/73d5effe-8352-478e-b7a2-67043d9ea517?_nouploadcache=false&_state=4xNYQhwOTXUiSZieb9kgg96ptMT9uVVbGN7x_Qo9w7F7Ik5hbWUiOiJ1YnVudHUtdm0tbmZkZ19uZl9hcnRpZmFjdCIsIlVVSUQiOiI3M2Q1ZWZmZS04MzUyLTQ3OGUtYjdhMi02NzA0M2Q5ZWE1MTciLCJPZmZzZXQiOjAsIlN0YXJ0ZWRBdCI6IjIwMjMtMDktMDVUMDk6NTI6MzAuNTQ0NjA2Nzc2WiJ9
       range:
       - 0-0
       server:
@@ -5224,9 +4905,9 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - python-requests/2.31.0
+      - python-requests/2.26.0
     method: PUT
-    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/v2/ubuntu-vm-nfdg_nf_artifact/blobs/uploads/7e7be12d-db35-4887-b41a-2114682c1037?_nouploadcache=false&_state=GVN-YkeTyht6G_aBax7zYcamgtM7JtwGtvNV0AOv9tV7Ik5hbWUiOiJ1YnVudHUtdm0tbmZkZ19uZl9hcnRpZmFjdCIsIlVVSUQiOiI3ZTdiZTEyZC1kYjM1LTQ4ODctYjQxYS0yMTE0NjgyYzEwMzciLCJPZmZzZXQiOjAsIlN0YXJ0ZWRBdCI6IjIwMjMtMDgtMjlUMTU6NTk6NDIuMTE3NDg5ODQ4WiJ9&digest=sha256%3Ae3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    uri: https://ubuntupublisherubuntuacr3811a7f31a.azurecr.io/v2/ubuntu-vm-nfdg_nf_artifact/blobs/uploads/73d5effe-8352-478e-b7a2-67043d9ea517?_nouploadcache=false&_state=4xNYQhwOTXUiSZieb9kgg96ptMT9uVVbGN7x_Qo9w7F7Ik5hbWUiOiJ1YnVudHUtdm0tbmZkZ19uZl9hcnRpZmFjdCIsIlVVSUQiOiI3M2Q1ZWZmZS04MzUyLTQ3OGUtYjdhMi02NzA0M2Q5ZWE1MTciLCJPZmZzZXQiOjAsIlN0YXJ0ZWRBdCI6IjIwMjMtMDktMDVUMDk6NTI6MzAuNTQ0NjA2Nzc2WiJ9&digest=sha256%3Ae3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   response:
     body:
       string: ''
@@ -5241,7 +4922,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 29 Aug 2023 15:59:42 GMT
+      - Tue, 05 Sep 2023 09:52:30 GMT
       docker-content-digest:
       - sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       docker-distribution-api-version:
@@ -5262,8 +4943,8 @@ interactions:
     body: '{"schemaVersion": 2, "mediaType": "application/vnd.oci.image.manifest.v1+json",
       "config": {"mediaType": "application/vnd.unknown.config.v1+json", "size": 0,
       "digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
-      "layers": [{"mediaType": "application/vnd.oci.image.layer.v1.tar", "size": 3341,
-      "digest": "sha256:cda1bbb871260a2c7624e8adc401dec0667351f923fe545647b887e9f5271aad",
+      "layers": [{"mediaType": "application/vnd.oci.image.layer.v1.tar", "size": 3342,
+      "digest": "sha256:3ed1035cbc2467e2e9ac9a9acbedba35995511ab5d8e54879250423d5e4f6680",
       "annotations": {"org.opencontainers.image.title": "nf_definition.json"}}], "annotations":
       {}}'
     headers:
@@ -5278,9 +4959,9 @@ interactions:
       Content-Type:
       - application/vnd.oci.image.manifest.v1+json
       User-Agent:
-      - python-requests/2.31.0
+      - python-requests/2.26.0
     method: PUT
-    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/v2/ubuntu-vm-nfdg_nf_artifact/manifests/1.0.0
+    uri: https://ubuntupublisherubuntuacr3811a7f31a.azurecr.io/v2/ubuntu-vm-nfdg_nf_artifact/manifests/1.0.0
   response:
     body:
       string: '{"errors": [{"code": "UNAUTHORIZED", "message": "authentication required,
@@ -5300,7 +4981,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:59:42 GMT
+      - Tue, 05 Sep 2023 09:52:30 GMT
       docker-distribution-api-version:
       - registry/2.0
       server:
@@ -5309,7 +4990,7 @@ interactions:
       - max-age=31536000; includeSubDomains
       - max-age=31536000; includeSubDomains
       www-authenticate:
-      - Bearer realm="https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/oauth2/token",service="ubuntupublisherubuntuacr8e894d23e6.azurecr.io",scope="repository:ubuntu-vm-nfdg_nf_artifact:pull,push"
+      - Bearer realm="https://ubuntupublisherubuntuacr3811a7f31a.azurecr.io/oauth2/token",service="ubuntupublisherubuntuacr3811a7f31a.azurecr.io",scope="repository:ubuntu-vm-nfdg_nf_artifact:pull,push"
       x-content-type-options:
       - nosniff
     status:
@@ -5325,11 +5006,11 @@ interactions:
       Connection:
       - keep-alive
       Service:
-      - ubuntupublisherubuntuacr8e894d23e6.azurecr.io
+      - ubuntupublisherubuntuacr3811a7f31a.azurecr.io
       User-Agent:
       - oras-py
     method: GET
-    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/oauth2/token?service=ubuntupublisherubuntuacr8e894d23e6.azurecr.io&scope=repository%3Aubuntu-vm-nfdg_nf_artifact%3Apull%2Cpush
+    uri: https://ubuntupublisherubuntuacr3811a7f31a.azurecr.io/oauth2/token?service=ubuntupublisherubuntuacr3811a7f31a.azurecr.io&scope=repository%3Aubuntu-vm-nfdg_nf_artifact%3Apull%2Cpush
   response:
     body:
       string: '{"access_token": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}'
@@ -5339,7 +5020,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:59:42 GMT
+      - Tue, 05 Sep 2023 09:52:31 GMT
       server:
       - openresty
       strict-transport-security:
@@ -5355,8 +5036,8 @@ interactions:
     body: '{"schemaVersion": 2, "mediaType": "application/vnd.oci.image.manifest.v1+json",
       "config": {"mediaType": "application/vnd.unknown.config.v1+json", "size": 0,
       "digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
-      "layers": [{"mediaType": "application/vnd.oci.image.layer.v1.tar", "size": 3341,
-      "digest": "sha256:cda1bbb871260a2c7624e8adc401dec0667351f923fe545647b887e9f5271aad",
+      "layers": [{"mediaType": "application/vnd.oci.image.layer.v1.tar", "size": 3342,
+      "digest": "sha256:3ed1035cbc2467e2e9ac9a9acbedba35995511ab5d8e54879250423d5e4f6680",
       "annotations": {"org.opencontainers.image.title": "nf_definition.json"}}], "annotations":
       {}}'
     headers:
@@ -5371,9 +5052,9 @@ interactions:
       Content-Type:
       - application/vnd.oci.image.manifest.v1+json
       User-Agent:
-      - python-requests/2.31.0
+      - python-requests/2.26.0
     method: PUT
-    uri: https://ubuntupublisherubuntuacr8e894d23e6.azurecr.io/v2/ubuntu-vm-nfdg_nf_artifact/manifests/1.0.0
+    uri: https://ubuntupublisherubuntuacr3811a7f31a.azurecr.io/v2/ubuntu-vm-nfdg_nf_artifact/manifests/1.0.0
   response:
     body:
       string: ''
@@ -5388,13 +5069,13 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 29 Aug 2023 15:59:43 GMT
+      - Tue, 05 Sep 2023 09:52:31 GMT
       docker-content-digest:
-      - sha256:7b3db21b27fb97e6d1c92f21747cf67e213ae2360c4a63a390b859a7b5e17b77
+      - sha256:89d7b30196ef9e9c7c94c363a4e25000f1abafc5d1a65d6da599415f8091e0f2
       docker-distribution-api-version:
       - registry/2.0
       location:
-      - /v2/ubuntu-vm-nfdg_nf_artifact/manifests/sha256:7b3db21b27fb97e6d1c92f21747cf67e213ae2360c4a63a390b859a7b5e17b77
+      - /v2/ubuntu-vm-nfdg_nf_artifact/manifests/sha256:89d7b30196ef9e9c7c94c363a4e25000f1abafc5d1a65d6da599415f8091e0f2
       server:
       - openresty
       strict-transport-security:
@@ -5408,7 +5089,7 @@ interactions:
 - request:
     body: '{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
       "contentVersion": "1.0.0.0", "metadata": {"_generator": {"name": "bicep", "version":
-      "0.12.40.16777", "templateHash": "18201962655924189778"}}, "parameters": {"location":
+      "0.15.31.15270", "templateHash": "15386908252537985940"}}, "parameters": {"location":
       {"type": "string"}, "publisherName": {"type": "string", "metadata": {"description":
       "Name of an existing publisher, expected to be in the resource group where you
       deploy the template"}}, "acrArtifactStoreName": {"type": "string", "metadata":
@@ -5473,21 +5154,21 @@ interactions:
       ParameterSetName:
       - -f
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/validate?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693324785",
-        "name": "AOSM_CLI_deployment_1693324785", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "18201962655924189778", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693907554",
+        "name": "AOSM_CLI_deployment_1693907554", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "15386908252537985940", "parameters": {"location":
         {"type": "String", "value": "westcentralus"}, "publisherName": {"type": "String",
         "value": "ubuntuPublisher"}, "acrArtifactStoreName": {"type": "String", "value":
         "ubuntu-acr"}, "nsDesignGroup": {"type": "String", "value": "ubuntu"}, "nsDesignVersion":
         {"type": "String", "value": "1.0.0"}, "nfviSiteName": {"type": "String", "value":
         "ubuntu_NFVI"}}, "mode": "Incremental", "provisioningState": "Succeeded",
         "timestamp": "0001-01-01T00:00:00Z", "duration": "PT0S", "correlationId":
-        "0df9ebe1-6935-4823-ab6f-9a0a8a099640", "providers": [{"namespace": "Microsoft.Hybridnetwork",
+        "6027dd76-bba2-47f3-b272-03fa5c00c75c", "providers": [{"namespace": "Microsoft.Hybridnetwork",
         "resourceTypes": [{"resourceType": "publishers/configurationGroupSchemas",
         "locations": ["westcentralus"]}, {"resourceType": "publishers/networkservicedesigngroups/networkservicedesignversions",
         "locations": ["westcentralus"]}]}], "dependencies": [{"dependsOn": [{"id":
@@ -5506,7 +5187,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:59:46 GMT
+      - Tue, 05 Sep 2023 09:52:37 GMT
       expires:
       - '-1'
       pragma:
@@ -5520,14 +5201,14 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
     status:
       code: 200
       message: OK
 - request:
     body: '{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
       "contentVersion": "1.0.0.0", "metadata": {"_generator": {"name": "bicep", "version":
-      "0.12.40.16777", "templateHash": "18201962655924189778"}}, "parameters": {"location":
+      "0.15.31.15270", "templateHash": "15386908252537985940"}}, "parameters": {"location":
       {"type": "string"}, "publisherName": {"type": "string", "metadata": {"description":
       "Name of an existing publisher, expected to be in the resource group where you
       deploy the template"}}, "acrArtifactStoreName": {"type": "string", "metadata":
@@ -5592,21 +5273,21 @@ interactions:
       ParameterSetName:
       - -f
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693324785",
-        "name": "AOSM_CLI_deployment_1693324785", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "18201962655924189778", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693907554",
+        "name": "AOSM_CLI_deployment_1693907554", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "15386908252537985940", "parameters": {"location":
         {"type": "String", "value": "westcentralus"}, "publisherName": {"type": "String",
         "value": "ubuntuPublisher"}, "acrArtifactStoreName": {"type": "String", "value":
         "ubuntu-acr"}, "nsDesignGroup": {"type": "String", "value": "ubuntu"}, "nsDesignVersion":
         {"type": "String", "value": "1.0.0"}, "nfviSiteName": {"type": "String", "value":
         "ubuntu_NFVI"}}, "mode": "Incremental", "provisioningState": "Accepted", "timestamp":
-        "2023-08-29T15:59:49.2140578Z", "duration": "PT0.0007847S", "correlationId":
-        "ebc2b215-e495-4423-9438-efe28eb3d0d4", "providers": [{"namespace": "Microsoft.Hybridnetwork",
+        "2023-09-05T09:52:41.1374886Z", "duration": "PT0.0007833S", "correlationId":
+        "4b2fcf47-71cb-40bf-80a8-33901013a3f6", "providers": [{"namespace": "Microsoft.Hybridnetwork",
         "resourceTypes": [{"resourceType": "publishers/configurationGroupSchemas",
         "locations": ["westcentralus"]}, {"resourceType": "publishers/networkservicedesigngroups/networkservicedesignversions",
         "locations": ["westcentralus"]}]}], "dependencies": [{"dependsOn": [{"id":
@@ -5617,7 +5298,7 @@ interactions:
         "resourceName": "ubuntuPublisher/ubuntu/1.0.0"}]}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693324785/operationStatuses/08585082820977388054?api-version=2022-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693907554/operationStatuses/08585076993259357897?api-version=2022-09-01
       cache-control:
       - no-cache
       content-length:
@@ -5625,7 +5306,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:59:50 GMT
+      - Tue, 05 Sep 2023 09:52:41 GMT
       expires:
       - '-1'
       pragma:
@@ -5635,7 +5316,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
     status:
       code: 201
       message: Created
@@ -5653,9 +5334,9 @@ interactions:
       ParameterSetName:
       - -f
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585082820977388054?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585076993259357897?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Accepted"}'
@@ -5667,7 +5348,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 15:59:50 GMT
+      - Tue, 05 Sep 2023 09:52:41 GMT
       expires:
       - '-1'
       pragma:
@@ -5695,9 +5376,9 @@ interactions:
       ParameterSetName:
       - -f
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585082820977388054?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585076993259357897?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Running"}'
@@ -5709,7 +5390,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:00:19 GMT
+      - Tue, 05 Sep 2023 09:53:12 GMT
       expires:
       - '-1'
       pragma:
@@ -5737,9 +5418,9 @@ interactions:
       ParameterSetName:
       - -f
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585082820977388054?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585076993259357897?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Succeeded"}'
@@ -5751,7 +5432,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:00:50 GMT
+      - Tue, 05 Sep 2023 09:53:43 GMT
       expires:
       - '-1'
       pragma:
@@ -5779,21 +5460,21 @@ interactions:
       ParameterSetName:
       - -f
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693324785",
-        "name": "AOSM_CLI_deployment_1693324785", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "18201962655924189778", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1693907554",
+        "name": "AOSM_CLI_deployment_1693907554", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "15386908252537985940", "parameters": {"location":
         {"type": "String", "value": "westcentralus"}, "publisherName": {"type": "String",
         "value": "ubuntuPublisher"}, "acrArtifactStoreName": {"type": "String", "value":
         "ubuntu-acr"}, "nsDesignGroup": {"type": "String", "value": "ubuntu"}, "nsDesignVersion":
         {"type": "String", "value": "1.0.0"}, "nfviSiteName": {"type": "String", "value":
         "ubuntu_NFVI"}}, "mode": "Incremental", "provisioningState": "Succeeded",
-        "timestamp": "2023-08-29T16:00:42.7888709Z", "duration": "PT53.5755978S",
-        "correlationId": "ebc2b215-e495-4423-9438-efe28eb3d0d4", "providers": [{"namespace":
+        "timestamp": "2023-09-05T09:53:36.8554135Z", "duration": "PT55.7187082S",
+        "correlationId": "4b2fcf47-71cb-40bf-80a8-33901013a3f6", "providers": [{"namespace":
         "Microsoft.Hybridnetwork", "resourceTypes": [{"resourceType": "publishers/configurationGroupSchemas",
         "locations": ["westcentralus"]}, {"resourceType": "publishers/networkservicedesigngroups/networkservicedesignversions",
         "locations": ["westcentralus"]}]}], "dependencies": [{"dependsOn": [{"id":
@@ -5812,7 +5493,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:00:51 GMT
+      - Tue, 05 Sep 2023 09:53:43 GMT
       expires:
       - '-1'
       pragma:
@@ -5840,7 +5521,7 @@ interactions:
       ParameterSetName:
       - -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/Allow-2023-09-01?api-version=2021-07-01
   response:
@@ -5855,142 +5536,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:00:51 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json, text/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aosm nsd delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -f --clean --force
-      User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/AllowPreReleaseFeatures?api-version=2021-07-01
-  response:
-    body:
-      string: '{"properties": {"state": "Registered"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/AllowPreReleaseFeatures",
-        "type": "Microsoft.Features/providers/features", "name": "Microsoft.HybridNetwork/AllowPreReleaseFeatures"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 29 Aug 2023 16:00:51 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json, text/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aosm nsd delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -f --clean --force
-      User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/Allow-2023-04-01-preview?api-version=2021-07-01
-  response:
-    body:
-      string: '{"properties": {"state": "Registered"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/Allow-2023-04-01-preview",
-        "type": "Microsoft.Features/providers/features", "name": "Microsoft.HybridNetwork/Allow-2023-04-01-preview"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '306'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 29 Aug 2023 16:00:51 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json, text/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aosm nsd delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -f --clean --force
-      User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/MsiForResourceEnabled?api-version=2021-07-01
-  response:
-    body:
-      string: '{"properties": {"state": "Registered"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/MsiForResourceEnabled",
-        "type": "Microsoft.Features/providers/features", "name": "Microsoft.HybridNetwork/MsiForResourceEnabled"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '300'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 29 Aug 2023 16:00:51 GMT
+      - Tue, 05 Sep 2023 09:53:43 GMT
       expires:
       - '-1'
       pragma:
@@ -6022,8 +5568,8 @@ interactions:
       ParameterSetName:
       - -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkServiceDesignGroups/ubuntu/networkServiceDesignVersions/1.0.0?api-version=2023-04-01-preview
   response:
@@ -6031,7 +5577,7 @@ interactions:
       string: 'null'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/0c741975-66e4-4a20-9250-8b4286973587*7F8DC5BF7193E63CB1613E8CF9959AAF6FF43D206B9468ABA965B313544E20E7?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/50820912-127d-4a83-8e5e-d993b1b03ef5*4FAB2300C3535008DBA939F6E0B477DE21A6BD736D57A549F5BAAF7E6A7489E6?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -6039,13 +5585,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:00:54 GMT
+      - Tue, 05 Sep 2023 09:53:45 GMT
       etag:
-      - '"00002a00-0000-0600-0000-64ee16360000"'
+      - '"00006dbe-0000-0800-0000-64f6faaa0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/0c741975-66e4-4a20-9250-8b4286973587*7F8DC5BF7193E63CB1613E8CF9959AAF6FF43D206B9468ABA965B313544E20E7?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/50820912-127d-4a83-8e5e-d993b1b03ef5*4FAB2300C3535008DBA939F6E0B477DE21A6BD736D57A549F5BAAF7E6A7489E6?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -6075,19 +5621,19 @@ interactions:
       ParameterSetName:
       - -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/0c741975-66e4-4a20-9250-8b4286973587*7F8DC5BF7193E63CB1613E8CF9959AAF6FF43D206B9468ABA965B313544E20E7?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/50820912-127d-4a83-8e5e-d993b1b03ef5*4FAB2300C3535008DBA939F6E0B477DE21A6BD736D57A549F5BAAF7E6A7489E6?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/0c741975-66e4-4a20-9250-8b4286973587*7F8DC5BF7193E63CB1613E8CF9959AAF6FF43D206B9468ABA965B313544E20E7",
-        "name": "0c741975-66e4-4a20-9250-8b4286973587*7F8DC5BF7193E63CB1613E8CF9959AAF6FF43D206B9468ABA965B313544E20E7",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/50820912-127d-4a83-8e5e-d993b1b03ef5*4FAB2300C3535008DBA939F6E0B477DE21A6BD736D57A549F5BAAF7E6A7489E6",
+        "name": "50820912-127d-4a83-8e5e-d993b1b03ef5*4FAB2300C3535008DBA939F6E0B477DE21A6BD736D57A549F5BAAF7E6A7489E6",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkServiceDesignGroups/ubuntu/networkServiceDesignVersions/1.0.0",
-        "status": "Deleting", "startTime": "2023-08-29T16:00:53.6598892Z"}'
+        "status": "Deleting", "startTime": "2023-09-05T09:53:45.6893688Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/0c741975-66e4-4a20-9250-8b4286973587*7F8DC5BF7193E63CB1613E8CF9959AAF6FF43D206B9468ABA965B313544E20E7?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/50820912-127d-4a83-8e5e-d993b1b03ef5*4FAB2300C3535008DBA939F6E0B477DE21A6BD736D57A549F5BAAF7E6A7489E6?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -6095,13 +5641,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:00:54 GMT
+      - Tue, 05 Sep 2023 09:53:46 GMT
       etag:
-      - '"00002b06-0000-0600-0000-64ee16350000"'
+      - '"52029a04-0000-0800-0000-64f6faa90000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/0c741975-66e4-4a20-9250-8b4286973587*7F8DC5BF7193E63CB1613E8CF9959AAF6FF43D206B9468ABA965B313544E20E7?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/50820912-127d-4a83-8e5e-d993b1b03ef5*4FAB2300C3535008DBA939F6E0B477DE21A6BD736D57A549F5BAAF7E6A7489E6?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -6125,17 +5671,17 @@ interactions:
       ParameterSetName:
       - -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/0c741975-66e4-4a20-9250-8b4286973587*7F8DC5BF7193E63CB1613E8CF9959AAF6FF43D206B9468ABA965B313544E20E7?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/50820912-127d-4a83-8e5e-d993b1b03ef5*4FAB2300C3535008DBA939F6E0B477DE21A6BD736D57A549F5BAAF7E6A7489E6?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/0c741975-66e4-4a20-9250-8b4286973587*7F8DC5BF7193E63CB1613E8CF9959AAF6FF43D206B9468ABA965B313544E20E7",
-        "name": "0c741975-66e4-4a20-9250-8b4286973587*7F8DC5BF7193E63CB1613E8CF9959AAF6FF43D206B9468ABA965B313544E20E7",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/50820912-127d-4a83-8e5e-d993b1b03ef5*4FAB2300C3535008DBA939F6E0B477DE21A6BD736D57A549F5BAAF7E6A7489E6",
+        "name": "50820912-127d-4a83-8e5e-d993b1b03ef5*4FAB2300C3535008DBA939F6E0B477DE21A6BD736D57A549F5BAAF7E6A7489E6",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkServiceDesignGroups/ubuntu/networkServiceDesignVersions/1.0.0",
-        "status": "Succeeded", "startTime": "2023-08-29T16:00:53.6598892Z", "endTime":
-        "2023-08-29T16:01:03.2956106Z", "properties": null}'
+        "status": "Succeeded", "startTime": "2023-09-05T09:53:45.6893688Z", "endTime":
+        "2023-09-05T09:53:51.0684057Z", "properties": null}'
     headers:
       cache-control:
       - no-cache
@@ -6144,9 +5690,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:01:24 GMT
+      - Tue, 05 Sep 2023 09:54:15 GMT
       etag:
-      - '"00002c06-0000-0600-0000-64ee163f0000"'
+      - '"5202d204-0000-0800-0000-64f6faaf0000"'
       expires:
       - '-1'
       pragma:
@@ -6176,17 +5722,17 @@ interactions:
       ParameterSetName:
       - -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/0c741975-66e4-4a20-9250-8b4286973587*7F8DC5BF7193E63CB1613E8CF9959AAF6FF43D206B9468ABA965B313544E20E7?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/50820912-127d-4a83-8e5e-d993b1b03ef5*4FAB2300C3535008DBA939F6E0B477DE21A6BD736D57A549F5BAAF7E6A7489E6?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/0c741975-66e4-4a20-9250-8b4286973587*7F8DC5BF7193E63CB1613E8CF9959AAF6FF43D206B9468ABA965B313544E20E7",
-        "name": "0c741975-66e4-4a20-9250-8b4286973587*7F8DC5BF7193E63CB1613E8CF9959AAF6FF43D206B9468ABA965B313544E20E7",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/50820912-127d-4a83-8e5e-d993b1b03ef5*4FAB2300C3535008DBA939F6E0B477DE21A6BD736D57A549F5BAAF7E6A7489E6",
+        "name": "50820912-127d-4a83-8e5e-d993b1b03ef5*4FAB2300C3535008DBA939F6E0B477DE21A6BD736D57A549F5BAAF7E6A7489E6",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkServiceDesignGroups/ubuntu/networkServiceDesignVersions/1.0.0",
-        "status": "Succeeded", "startTime": "2023-08-29T16:00:53.6598892Z", "endTime":
-        "2023-08-29T16:01:03.2956106Z", "properties": null}'
+        "status": "Succeeded", "startTime": "2023-09-05T09:53:45.6893688Z", "endTime":
+        "2023-09-05T09:53:51.0684057Z", "properties": null}'
     headers:
       cache-control:
       - no-cache
@@ -6195,9 +5741,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:01:24 GMT
+      - Tue, 05 Sep 2023 09:54:16 GMT
       etag:
-      - '"00002c06-0000-0600-0000-64ee163f0000"'
+      - '"5202d204-0000-0800-0000-64f6faaf0000"'
       expires:
       - '-1'
       pragma:
@@ -6229,8 +5775,8 @@ interactions:
       ParameterSetName:
       - -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-nfdg-nf-acr-manifest-1-0-0?api-version=2023-04-01-preview
   response:
@@ -6238,7 +5784,7 @@ interactions:
       string: 'null'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/9d4c799a-87a2-46a4-8835-ba55a6b403f0*DB692E0A0A4C5AD9CA3492FE4C39590F7AE07FBADAB5C39D246972FD64B25CCF?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/f1374a7f-5e79-4dc5-babd-6057d864ea10*E9EA2504C09C7FD2E091FE1FEF7383A6B4226C53345B749930E17013B5B4A8B9?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -6246,13 +5792,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:01:26 GMT
+      - Tue, 05 Sep 2023 09:54:18 GMT
       etag:
-      - '"0000de0f-0000-0600-0000-64ee16570000"'
+      - '"25005158-0000-0800-0000-64f6facb0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/9d4c799a-87a2-46a4-8835-ba55a6b403f0*DB692E0A0A4C5AD9CA3492FE4C39590F7AE07FBADAB5C39D246972FD64B25CCF?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/f1374a7f-5e79-4dc5-babd-6057d864ea10*E9EA2504C09C7FD2E091FE1FEF7383A6B4226C53345B749930E17013B5B4A8B9?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -6282,19 +5828,19 @@ interactions:
       ParameterSetName:
       - -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/9d4c799a-87a2-46a4-8835-ba55a6b403f0*DB692E0A0A4C5AD9CA3492FE4C39590F7AE07FBADAB5C39D246972FD64B25CCF?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/f1374a7f-5e79-4dc5-babd-6057d864ea10*E9EA2504C09C7FD2E091FE1FEF7383A6B4226C53345B749930E17013B5B4A8B9?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/9d4c799a-87a2-46a4-8835-ba55a6b403f0*DB692E0A0A4C5AD9CA3492FE4C39590F7AE07FBADAB5C39D246972FD64B25CCF",
-        "name": "9d4c799a-87a2-46a4-8835-ba55a6b403f0*DB692E0A0A4C5AD9CA3492FE4C39590F7AE07FBADAB5C39D246972FD64B25CCF",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/f1374a7f-5e79-4dc5-babd-6057d864ea10*E9EA2504C09C7FD2E091FE1FEF7383A6B4226C53345B749930E17013B5B4A8B9",
+        "name": "f1374a7f-5e79-4dc5-babd-6057d864ea10*E9EA2504C09C7FD2E091FE1FEF7383A6B4226C53345B749930E17013B5B4A8B9",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-nfdg-nf-acr-manifest-1-0-0",
-        "status": "Deleting", "startTime": "2023-08-29T16:01:26.2822183Z"}'
+        "status": "Deleting", "startTime": "2023-09-05T09:54:18.6858869Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/9d4c799a-87a2-46a4-8835-ba55a6b403f0*DB692E0A0A4C5AD9CA3492FE4C39590F7AE07FBADAB5C39D246972FD64B25CCF?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/f1374a7f-5e79-4dc5-babd-6057d864ea10*E9EA2504C09C7FD2E091FE1FEF7383A6B4226C53345B749930E17013B5B4A8B9?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -6302,13 +5848,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:01:27 GMT
+      - Tue, 05 Sep 2023 09:54:18 GMT
       etag:
-      - '"030003db-0000-0600-0000-64ee16560000"'
+      - '"220c5ef5-0000-0800-0000-64f6faca0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/9d4c799a-87a2-46a4-8835-ba55a6b403f0*DB692E0A0A4C5AD9CA3492FE4C39590F7AE07FBADAB5C39D246972FD64B25CCF?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/f1374a7f-5e79-4dc5-babd-6057d864ea10*E9EA2504C09C7FD2E091FE1FEF7383A6B4226C53345B749930E17013B5B4A8B9?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -6332,17 +5878,17 @@ interactions:
       ParameterSetName:
       - -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/9d4c799a-87a2-46a4-8835-ba55a6b403f0*DB692E0A0A4C5AD9CA3492FE4C39590F7AE07FBADAB5C39D246972FD64B25CCF?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/f1374a7f-5e79-4dc5-babd-6057d864ea10*E9EA2504C09C7FD2E091FE1FEF7383A6B4226C53345B749930E17013B5B4A8B9?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/9d4c799a-87a2-46a4-8835-ba55a6b403f0*DB692E0A0A4C5AD9CA3492FE4C39590F7AE07FBADAB5C39D246972FD64B25CCF",
-        "name": "9d4c799a-87a2-46a4-8835-ba55a6b403f0*DB692E0A0A4C5AD9CA3492FE4C39590F7AE07FBADAB5C39D246972FD64B25CCF",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/f1374a7f-5e79-4dc5-babd-6057d864ea10*E9EA2504C09C7FD2E091FE1FEF7383A6B4226C53345B749930E17013B5B4A8B9",
+        "name": "f1374a7f-5e79-4dc5-babd-6057d864ea10*E9EA2504C09C7FD2E091FE1FEF7383A6B4226C53345B749930E17013B5B4A8B9",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-nfdg-nf-acr-manifest-1-0-0",
-        "status": "Succeeded", "startTime": "2023-08-29T16:01:26.2822183Z", "endTime":
-        "2023-08-29T16:01:55.1417126Z", "properties": null}'
+        "status": "Succeeded", "startTime": "2023-09-05T09:54:18.6858869Z", "endTime":
+        "2023-09-05T09:54:46.4415981Z", "properties": null}'
     headers:
       cache-control:
       - no-cache
@@ -6351,9 +5897,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:01:56 GMT
+      - Tue, 05 Sep 2023 09:54:48 GMT
       etag:
-      - '"030048dc-0000-0600-0000-64ee16730000"'
+      - '"220c50fe-0000-0800-0000-64f6fae60000"'
       expires:
       - '-1'
       pragma:
@@ -6383,17 +5929,17 @@ interactions:
       ParameterSetName:
       - -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/9d4c799a-87a2-46a4-8835-ba55a6b403f0*DB692E0A0A4C5AD9CA3492FE4C39590F7AE07FBADAB5C39D246972FD64B25CCF?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/f1374a7f-5e79-4dc5-babd-6057d864ea10*E9EA2504C09C7FD2E091FE1FEF7383A6B4226C53345B749930E17013B5B4A8B9?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/9d4c799a-87a2-46a4-8835-ba55a6b403f0*DB692E0A0A4C5AD9CA3492FE4C39590F7AE07FBADAB5C39D246972FD64B25CCF",
-        "name": "9d4c799a-87a2-46a4-8835-ba55a6b403f0*DB692E0A0A4C5AD9CA3492FE4C39590F7AE07FBADAB5C39D246972FD64B25CCF",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/f1374a7f-5e79-4dc5-babd-6057d864ea10*E9EA2504C09C7FD2E091FE1FEF7383A6B4226C53345B749930E17013B5B4A8B9",
+        "name": "f1374a7f-5e79-4dc5-babd-6057d864ea10*E9EA2504C09C7FD2E091FE1FEF7383A6B4226C53345B749930E17013B5B4A8B9",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-nfdg-nf-acr-manifest-1-0-0",
-        "status": "Succeeded", "startTime": "2023-08-29T16:01:26.2822183Z", "endTime":
-        "2023-08-29T16:01:55.1417126Z", "properties": null}'
+        "status": "Succeeded", "startTime": "2023-09-05T09:54:18.6858869Z", "endTime":
+        "2023-09-05T09:54:46.4415981Z", "properties": null}'
     headers:
       cache-control:
       - no-cache
@@ -6402,9 +5948,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:01:57 GMT
+      - Tue, 05 Sep 2023 09:54:49 GMT
       etag:
-      - '"030048dc-0000-0600-0000-64ee16730000"'
+      - '"220c50fe-0000-0800-0000-64f6fae60000"'
       expires:
       - '-1'
       pragma:
@@ -6436,8 +5982,8 @@ interactions:
       ParameterSetName:
       - -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/configurationGroupSchemas/ubuntu_ConfigGroupSchema?api-version=2023-04-01-preview
   response:
@@ -6445,7 +5991,7 @@ interactions:
       string: 'null'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/608cd2f1-59d6-43a0-98ee-4b7bdb22e100*ECDDF7375EFCF3921DDCEFC854B2890F0514C1081A8FA77D7EDAA293F3B7E7FA?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ce11e343-c45f-4575-bb3c-e07454375412*F2CBA966151C4AA4A6F4777815B81A834571EFBB253273273E21D18E922086F0?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -6453,13 +5999,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:02:00 GMT
+      - Tue, 05 Sep 2023 09:54:51 GMT
       etag:
-      - '"00009201-0000-0600-0000-64ee16780000"'
+      - '"660062a6-0000-0800-0000-64f6faeb0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/608cd2f1-59d6-43a0-98ee-4b7bdb22e100*ECDDF7375EFCF3921DDCEFC854B2890F0514C1081A8FA77D7EDAA293F3B7E7FA?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ce11e343-c45f-4575-bb3c-e07454375412*F2CBA966151C4AA4A6F4777815B81A834571EFBB253273273E21D18E922086F0?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -6489,33 +6035,33 @@ interactions:
       ParameterSetName:
       - -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/608cd2f1-59d6-43a0-98ee-4b7bdb22e100*ECDDF7375EFCF3921DDCEFC854B2890F0514C1081A8FA77D7EDAA293F3B7E7FA?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ce11e343-c45f-4575-bb3c-e07454375412*F2CBA966151C4AA4A6F4777815B81A834571EFBB253273273E21D18E922086F0?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/608cd2f1-59d6-43a0-98ee-4b7bdb22e100*ECDDF7375EFCF3921DDCEFC854B2890F0514C1081A8FA77D7EDAA293F3B7E7FA",
-        "name": "608cd2f1-59d6-43a0-98ee-4b7bdb22e100*ECDDF7375EFCF3921DDCEFC854B2890F0514C1081A8FA77D7EDAA293F3B7E7FA",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ce11e343-c45f-4575-bb3c-e07454375412*F2CBA966151C4AA4A6F4777815B81A834571EFBB253273273E21D18E922086F0",
+        "name": "ce11e343-c45f-4575-bb3c-e07454375412*F2CBA966151C4AA4A6F4777815B81A834571EFBB253273273E21D18E922086F0",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/configurationGroupSchemas/ubuntu_ConfigGroupSchema",
-        "status": "Deleting", "startTime": "2023-08-29T16:01:59.477457Z"}'
+        "status": "Deleting", "startTime": "2023-09-05T09:54:51.3058651Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/608cd2f1-59d6-43a0-98ee-4b7bdb22e100*ECDDF7375EFCF3921DDCEFC854B2890F0514C1081A8FA77D7EDAA293F3B7E7FA?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/ce11e343-c45f-4575-bb3c-e07454375412*F2CBA966151C4AA4A6F4777815B81A834571EFBB253273273E21D18E922086F0?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
-      - '587'
+      - '588'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:02:00 GMT
+      - Tue, 05 Sep 2023 09:54:51 GMT
       etag:
-      - '"030078dc-0000-0600-0000-64ee16770000"'
+      - '"52020d08-0000-0800-0000-64f6faeb0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/608cd2f1-59d6-43a0-98ee-4b7bdb22e100*ECDDF7375EFCF3921DDCEFC854B2890F0514C1081A8FA77D7EDAA293F3B7E7FA?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/ce11e343-c45f-4575-bb3c-e07454375412*F2CBA966151C4AA4A6F4777815B81A834571EFBB253273273E21D18E922086F0?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -6539,28 +6085,28 @@ interactions:
       ParameterSetName:
       - -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/608cd2f1-59d6-43a0-98ee-4b7bdb22e100*ECDDF7375EFCF3921DDCEFC854B2890F0514C1081A8FA77D7EDAA293F3B7E7FA?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ce11e343-c45f-4575-bb3c-e07454375412*F2CBA966151C4AA4A6F4777815B81A834571EFBB253273273E21D18E922086F0?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/608cd2f1-59d6-43a0-98ee-4b7bdb22e100*ECDDF7375EFCF3921DDCEFC854B2890F0514C1081A8FA77D7EDAA293F3B7E7FA",
-        "name": "608cd2f1-59d6-43a0-98ee-4b7bdb22e100*ECDDF7375EFCF3921DDCEFC854B2890F0514C1081A8FA77D7EDAA293F3B7E7FA",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ce11e343-c45f-4575-bb3c-e07454375412*F2CBA966151C4AA4A6F4777815B81A834571EFBB253273273E21D18E922086F0",
+        "name": "ce11e343-c45f-4575-bb3c-e07454375412*F2CBA966151C4AA4A6F4777815B81A834571EFBB253273273E21D18E922086F0",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/configurationGroupSchemas/ubuntu_ConfigGroupSchema",
-        "status": "Succeeded", "startTime": "2023-08-29T16:01:59.477457Z", "endTime":
-        "2023-08-29T16:02:03.488937Z", "properties": null}'
+        "status": "Succeeded", "startTime": "2023-09-05T09:54:51.3058651Z", "endTime":
+        "2023-09-05T09:54:55.0544115Z", "properties": null}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '650'
+      - '652'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:02:30 GMT
+      - Tue, 05 Sep 2023 09:55:22 GMT
       etag:
-      - '"0300a2dc-0000-0600-0000-64ee167b0000"'
+      - '"52023c08-0000-0800-0000-64f6faef0000"'
       expires:
       - '-1'
       pragma:
@@ -6590,28 +6136,28 @@ interactions:
       ParameterSetName:
       - -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/608cd2f1-59d6-43a0-98ee-4b7bdb22e100*ECDDF7375EFCF3921DDCEFC854B2890F0514C1081A8FA77D7EDAA293F3B7E7FA?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ce11e343-c45f-4575-bb3c-e07454375412*F2CBA966151C4AA4A6F4777815B81A834571EFBB253273273E21D18E922086F0?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/608cd2f1-59d6-43a0-98ee-4b7bdb22e100*ECDDF7375EFCF3921DDCEFC854B2890F0514C1081A8FA77D7EDAA293F3B7E7FA",
-        "name": "608cd2f1-59d6-43a0-98ee-4b7bdb22e100*ECDDF7375EFCF3921DDCEFC854B2890F0514C1081A8FA77D7EDAA293F3B7E7FA",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/ce11e343-c45f-4575-bb3c-e07454375412*F2CBA966151C4AA4A6F4777815B81A834571EFBB253273273E21D18E922086F0",
+        "name": "ce11e343-c45f-4575-bb3c-e07454375412*F2CBA966151C4AA4A6F4777815B81A834571EFBB253273273E21D18E922086F0",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/configurationGroupSchemas/ubuntu_ConfigGroupSchema",
-        "status": "Succeeded", "startTime": "2023-08-29T16:01:59.477457Z", "endTime":
-        "2023-08-29T16:02:03.488937Z", "properties": null}'
+        "status": "Succeeded", "startTime": "2023-09-05T09:54:51.3058651Z", "endTime":
+        "2023-09-05T09:54:55.0544115Z", "properties": null}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '650'
+      - '652'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:02:30 GMT
+      - Tue, 05 Sep 2023 09:55:22 GMT
       etag:
-      - '"0300a2dc-0000-0600-0000-64ee167b0000"'
+      - '"52023c08-0000-0800-0000-64f6faef0000"'
       expires:
       - '-1'
       pragma:
@@ -6643,8 +6189,8 @@ interactions:
       ParameterSetName:
       - -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkServiceDesignGroups/ubuntu?api-version=2023-04-01-preview
   response:
@@ -6652,7 +6198,7 @@ interactions:
       string: 'null'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/65c4ef13-5825-4856-baec-0ea93c271b7f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/09b24f5c-a94f-4f04-b367-3c38b753f5b8*4E5D58CE1F5E11E4533AFEE9111A2F1068594B87C55C4009C61A2FA4C46117F3?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -6660,13 +6206,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:02:32 GMT
+      - Tue, 05 Sep 2023 09:55:24 GMT
       etag:
-      - '"00006a01-0000-0600-0000-64ee16980000"'
+      - '"2f006348-0000-0800-0000-64f6fb0c0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/65c4ef13-5825-4856-baec-0ea93c271b7f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/09b24f5c-a94f-4f04-b367-3c38b753f5b8*4E5D58CE1F5E11E4533AFEE9111A2F1068594B87C55C4009C61A2FA4C46117F3?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -6696,19 +6242,19 @@ interactions:
       ParameterSetName:
       - -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/65c4ef13-5825-4856-baec-0ea93c271b7f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/09b24f5c-a94f-4f04-b367-3c38b753f5b8*4E5D58CE1F5E11E4533AFEE9111A2F1068594B87C55C4009C61A2FA4C46117F3?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/65c4ef13-5825-4856-baec-0ea93c271b7f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B",
-        "name": "65c4ef13-5825-4856-baec-0ea93c271b7f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/09b24f5c-a94f-4f04-b367-3c38b753f5b8*4E5D58CE1F5E11E4533AFEE9111A2F1068594B87C55C4009C61A2FA4C46117F3",
+        "name": "09b24f5c-a94f-4f04-b367-3c38b753f5b8*4E5D58CE1F5E11E4533AFEE9111A2F1068594B87C55C4009C61A2FA4C46117F3",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkServiceDesignGroups/ubuntu",
-        "status": "Deleting", "startTime": "2023-08-29T16:02:31.6031656Z"}'
+        "status": "Deleting", "startTime": "2023-09-05T09:55:23.8132162Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/65c4ef13-5825-4856-baec-0ea93c271b7f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/09b24f5c-a94f-4f04-b367-3c38b753f5b8*4E5D58CE1F5E11E4533AFEE9111A2F1068594B87C55C4009C61A2FA4C46117F3?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -6716,13 +6262,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:02:32 GMT
+      - Tue, 05 Sep 2023 09:55:24 GMT
       etag:
-      - '"00002f06-0000-0600-0000-64ee16970000"'
+      - '"230c3a0a-0000-0800-0000-64f6fb0b0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/65c4ef13-5825-4856-baec-0ea93c271b7f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/09b24f5c-a94f-4f04-b367-3c38b753f5b8*4E5D58CE1F5E11E4533AFEE9111A2F1068594B87C55C4009C61A2FA4C46117F3?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -6746,28 +6292,28 @@ interactions:
       ParameterSetName:
       - -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/65c4ef13-5825-4856-baec-0ea93c271b7f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/09b24f5c-a94f-4f04-b367-3c38b753f5b8*4E5D58CE1F5E11E4533AFEE9111A2F1068594B87C55C4009C61A2FA4C46117F3?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/65c4ef13-5825-4856-baec-0ea93c271b7f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B",
-        "name": "65c4ef13-5825-4856-baec-0ea93c271b7f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/09b24f5c-a94f-4f04-b367-3c38b753f5b8*4E5D58CE1F5E11E4533AFEE9111A2F1068594B87C55C4009C61A2FA4C46117F3",
+        "name": "09b24f5c-a94f-4f04-b367-3c38b753f5b8*4E5D58CE1F5E11E4533AFEE9111A2F1068594B87C55C4009C61A2FA4C46117F3",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkServiceDesignGroups/ubuntu",
-        "status": "Succeeded", "startTime": "2023-08-29T16:02:31.6031656Z", "endTime":
-        "2023-08-29T16:02:34.488496Z", "properties": null}'
+        "status": "Succeeded", "startTime": "2023-09-05T09:55:23.8132162Z", "endTime":
+        "2023-09-05T09:55:26.5560725Z", "properties": null}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '634'
+      - '635'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:03:02 GMT
+      - Tue, 05 Sep 2023 09:55:54 GMT
       etag:
-      - '"00003006-0000-0600-0000-64ee169a0000"'
+      - '"230c0e0b-0000-0800-0000-64f6fb0e0000"'
       expires:
       - '-1'
       pragma:
@@ -6797,28 +6343,28 @@ interactions:
       ParameterSetName:
       - -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/65c4ef13-5825-4856-baec-0ea93c271b7f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/09b24f5c-a94f-4f04-b367-3c38b753f5b8*4E5D58CE1F5E11E4533AFEE9111A2F1068594B87C55C4009C61A2FA4C46117F3?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/65c4ef13-5825-4856-baec-0ea93c271b7f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B",
-        "name": "65c4ef13-5825-4856-baec-0ea93c271b7f*9D25250BBC2AF4272BC5A5112F330DF31E214F0F8177FA01557C3977EAD7CC4B",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/09b24f5c-a94f-4f04-b367-3c38b753f5b8*4E5D58CE1F5E11E4533AFEE9111A2F1068594B87C55C4009C61A2FA4C46117F3",
+        "name": "09b24f5c-a94f-4f04-b367-3c38b753f5b8*4E5D58CE1F5E11E4533AFEE9111A2F1068594B87C55C4009C61A2FA4C46117F3",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkServiceDesignGroups/ubuntu",
-        "status": "Succeeded", "startTime": "2023-08-29T16:02:31.6031656Z", "endTime":
-        "2023-08-29T16:02:34.488496Z", "properties": null}'
+        "status": "Succeeded", "startTime": "2023-09-05T09:55:23.8132162Z", "endTime":
+        "2023-09-05T09:55:26.5560725Z", "properties": null}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '634'
+      - '635'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:03:02 GMT
+      - Tue, 05 Sep 2023 09:55:54 GMT
       etag:
-      - '"00003006-0000-0600-0000-64ee169a0000"'
+      - '"230c0e0b-0000-0800-0000-64f6fb0e0000"'
       expires:
       - '-1'
       pragma:
@@ -6848,7 +6394,7 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/Allow-2023-09-01?api-version=2021-07-01
   response:
@@ -6863,142 +6409,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:03:02 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json, text/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aosm nfd delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --definition-type -f --clean --force
-      User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/AllowPreReleaseFeatures?api-version=2021-07-01
-  response:
-    body:
-      string: '{"properties": {"state": "Registered"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/AllowPreReleaseFeatures",
-        "type": "Microsoft.Features/providers/features", "name": "Microsoft.HybridNetwork/AllowPreReleaseFeatures"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '304'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 29 Aug 2023 16:03:03 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json, text/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aosm nfd delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --definition-type -f --clean --force
-      User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/Allow-2023-04-01-preview?api-version=2021-07-01
-  response:
-    body:
-      string: '{"properties": {"state": "Registered"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/Allow-2023-04-01-preview",
-        "type": "Microsoft.Features/providers/features", "name": "Microsoft.HybridNetwork/Allow-2023-04-01-preview"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '306'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 29 Aug 2023 16:03:03 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding,Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json, text/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - aosm nfd delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --definition-type -f --clean --force
-      User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/MsiForResourceEnabled?api-version=2021-07-01
-  response:
-    body:
-      string: '{"properties": {"state": "Registered"}, "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Features/providers/Microsoft.HybridNetwork/features/MsiForResourceEnabled",
-        "type": "Microsoft.Features/providers/features", "name": "Microsoft.HybridNetwork/MsiForResourceEnabled"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '300'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 29 Aug 2023 16:03:03 GMT
+      - Tue, 05 Sep 2023 09:55:55 GMT
       expires:
       - '-1'
       pragma:
@@ -7030,8 +6441,8 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg/networkFunctionDefinitionVersions/1.0.0?api-version=2023-04-01-preview
   response:
@@ -7039,7 +6450,7 @@ interactions:
       string: 'null'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/00588563-f37c-43fc-b58b-9bc1fccd56c4*122B2EDB3DA9C1AA370BE27AB3B72B7EA721530580448B898E480920A35C41FA?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -7047,13 +6458,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:03:05 GMT
+      - Tue, 05 Sep 2023 09:55:57 GMT
       etag:
-      - '"00003800-0000-0600-0000-64ee16ba0000"'
+      - '"0700d2dd-0000-0800-0000-64f6fb2d0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/00588563-f37c-43fc-b58b-9bc1fccd56c4*122B2EDB3DA9C1AA370BE27AB3B72B7EA721530580448B898E480920A35C41FA?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -7083,19 +6494,19 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/00588563-f37c-43fc-b58b-9bc1fccd56c4*122B2EDB3DA9C1AA370BE27AB3B72B7EA721530580448B898E480920A35C41FA?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47",
-        "name": "aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/00588563-f37c-43fc-b58b-9bc1fccd56c4*122B2EDB3DA9C1AA370BE27AB3B72B7EA721530580448B898E480920A35C41FA",
+        "name": "00588563-f37c-43fc-b58b-9bc1fccd56c4*122B2EDB3DA9C1AA370BE27AB3B72B7EA721530580448B898E480920A35C41FA",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg/networkFunctionDefinitionVersions/1.0.0",
-        "status": "Deleting", "startTime": "2023-08-29T16:03:06.0145598Z"}'
+        "status": "Deleting", "startTime": "2023-09-05T09:55:57.6250532Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/00588563-f37c-43fc-b58b-9bc1fccd56c4*122B2EDB3DA9C1AA370BE27AB3B72B7EA721530580448B898E480920A35C41FA?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -7103,13 +6514,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:03:06 GMT
+      - Tue, 05 Sep 2023 09:55:57 GMT
       etag:
-      - '"03008cdf-0000-0600-0000-64ee16ba0000"'
+      - '"230ce514-0000-0800-0000-64f6fb2d0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/00588563-f37c-43fc-b58b-9bc1fccd56c4*122B2EDB3DA9C1AA370BE27AB3B72B7EA721530580448B898E480920A35C41FA?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -7133,19 +6544,19 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/00588563-f37c-43fc-b58b-9bc1fccd56c4*122B2EDB3DA9C1AA370BE27AB3B72B7EA721530580448B898E480920A35C41FA?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47",
-        "name": "aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/00588563-f37c-43fc-b58b-9bc1fccd56c4*122B2EDB3DA9C1AA370BE27AB3B72B7EA721530580448B898E480920A35C41FA",
+        "name": "00588563-f37c-43fc-b58b-9bc1fccd56c4*122B2EDB3DA9C1AA370BE27AB3B72B7EA721530580448B898E480920A35C41FA",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg/networkFunctionDefinitionVersions/1.0.0",
-        "status": "Deleting", "startTime": "2023-08-29T16:03:06.0145598Z"}'
+        "status": "Deleting", "startTime": "2023-09-05T09:55:57.6250532Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/00588563-f37c-43fc-b58b-9bc1fccd56c4*122B2EDB3DA9C1AA370BE27AB3B72B7EA721530580448B898E480920A35C41FA?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -7153,13 +6564,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:03:35 GMT
+      - Tue, 05 Sep 2023 09:56:27 GMT
       etag:
-      - '"03008cdf-0000-0600-0000-64ee16ba0000"'
+      - '"230ce514-0000-0800-0000-64f6fb2d0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/00588563-f37c-43fc-b58b-9bc1fccd56c4*122B2EDB3DA9C1AA370BE27AB3B72B7EA721530580448B898E480920A35C41FA?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -7183,19 +6594,19 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/00588563-f37c-43fc-b58b-9bc1fccd56c4*122B2EDB3DA9C1AA370BE27AB3B72B7EA721530580448B898E480920A35C41FA?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47",
-        "name": "aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/00588563-f37c-43fc-b58b-9bc1fccd56c4*122B2EDB3DA9C1AA370BE27AB3B72B7EA721530580448B898E480920A35C41FA",
+        "name": "00588563-f37c-43fc-b58b-9bc1fccd56c4*122B2EDB3DA9C1AA370BE27AB3B72B7EA721530580448B898E480920A35C41FA",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg/networkFunctionDefinitionVersions/1.0.0",
-        "status": "Deleting", "startTime": "2023-08-29T16:03:06.0145598Z"}'
+        "status": "Deleting", "startTime": "2023-09-05T09:55:57.6250532Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/00588563-f37c-43fc-b58b-9bc1fccd56c4*122B2EDB3DA9C1AA370BE27AB3B72B7EA721530580448B898E480920A35C41FA?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -7203,13 +6614,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:04:06 GMT
+      - Tue, 05 Sep 2023 09:56:58 GMT
       etag:
-      - '"03008cdf-0000-0600-0000-64ee16ba0000"'
+      - '"230ce514-0000-0800-0000-64f6fb2d0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/00588563-f37c-43fc-b58b-9bc1fccd56c4*122B2EDB3DA9C1AA370BE27AB3B72B7EA721530580448B898E480920A35C41FA?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -7233,16 +6644,16 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/00588563-f37c-43fc-b58b-9bc1fccd56c4*122B2EDB3DA9C1AA370BE27AB3B72B7EA721530580448B898E480920A35C41FA?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47",
-        "name": "aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/00588563-f37c-43fc-b58b-9bc1fccd56c4*122B2EDB3DA9C1AA370BE27AB3B72B7EA721530580448B898E480920A35C41FA",
+        "name": "00588563-f37c-43fc-b58b-9bc1fccd56c4*122B2EDB3DA9C1AA370BE27AB3B72B7EA721530580448B898E480920A35C41FA",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg/networkFunctionDefinitionVersions/1.0.0",
-        "status": "Succeeded", "startTime": "2023-08-29T16:03:06.0145598Z", "properties":
+        "status": "Succeeded", "startTime": "2023-09-05T09:55:57.6250532Z", "properties":
         null}'
     headers:
       cache-control:
@@ -7252,9 +6663,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:04:36 GMT
+      - Tue, 05 Sep 2023 09:57:28 GMT
       etag:
-      - '"0300afe2-0000-0600-0000-64ee16fd0000"'
+      - '"cc00702c-0000-0700-0000-64f6fb6f0000"'
       expires:
       - '-1'
       pragma:
@@ -7284,16 +6695,16 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/00588563-f37c-43fc-b58b-9bc1fccd56c4*122B2EDB3DA9C1AA370BE27AB3B72B7EA721530580448B898E480920A35C41FA?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47",
-        "name": "aafe5dd0-a6b8-459e-9e68-ec24a0f3fd74*F2CAF33CA3B47F264B3C684F7D827296FD7E2DECF9DD193082093436D7292A47",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/00588563-f37c-43fc-b58b-9bc1fccd56c4*122B2EDB3DA9C1AA370BE27AB3B72B7EA721530580448B898E480920A35C41FA",
+        "name": "00588563-f37c-43fc-b58b-9bc1fccd56c4*122B2EDB3DA9C1AA370BE27AB3B72B7EA721530580448B898E480920A35C41FA",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg/networkFunctionDefinitionVersions/1.0.0",
-        "status": "Succeeded", "startTime": "2023-08-29T16:03:06.0145598Z", "properties":
+        "status": "Succeeded", "startTime": "2023-09-05T09:55:57.6250532Z", "properties":
         null}'
     headers:
       cache-control:
@@ -7303,9 +6714,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:04:36 GMT
+      - Tue, 05 Sep 2023 09:57:28 GMT
       etag:
-      - '"0300afe2-0000-0600-0000-64ee16fd0000"'
+      - '"cc00702c-0000-0700-0000-64f6fb6f0000"'
       expires:
       - '-1'
       pragma:
@@ -7337,8 +6748,8 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store/artifactManifests/ubuntu-vm-sa-manifest-1-0-0?api-version=2023-04-01-preview
   response:
@@ -7346,7 +6757,7 @@ interactions:
       string: 'null'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/15b4c924-80ca-4e5f-9149-835be9756471*B6943EBA12F10489DAA3AC3D9E77837B54D532FEF60B933E735DA59000AFDE79?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a6e1eab6-7e60-403f-afc1-65532291bd06*0ABB3334F0E8A38E05EE5A43045BDD49A755781B581797EC63F0A48EB118AEAA?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -7354,13 +6765,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:04:38 GMT
+      - Tue, 05 Sep 2023 09:57:30 GMT
       etag:
-      - '"00003510-0000-0600-0000-64ee17170000"'
+      - '"25002e5a-0000-0800-0000-64f6fb8a0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/15b4c924-80ca-4e5f-9149-835be9756471*B6943EBA12F10489DAA3AC3D9E77837B54D532FEF60B933E735DA59000AFDE79?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a6e1eab6-7e60-403f-afc1-65532291bd06*0ABB3334F0E8A38E05EE5A43045BDD49A755781B581797EC63F0A48EB118AEAA?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -7390,19 +6801,19 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/15b4c924-80ca-4e5f-9149-835be9756471*B6943EBA12F10489DAA3AC3D9E77837B54D532FEF60B933E735DA59000AFDE79?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a6e1eab6-7e60-403f-afc1-65532291bd06*0ABB3334F0E8A38E05EE5A43045BDD49A755781B581797EC63F0A48EB118AEAA?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/15b4c924-80ca-4e5f-9149-835be9756471*B6943EBA12F10489DAA3AC3D9E77837B54D532FEF60B933E735DA59000AFDE79",
-        "name": "15b4c924-80ca-4e5f-9149-835be9756471*B6943EBA12F10489DAA3AC3D9E77837B54D532FEF60B933E735DA59000AFDE79",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a6e1eab6-7e60-403f-afc1-65532291bd06*0ABB3334F0E8A38E05EE5A43045BDD49A755781B581797EC63F0A48EB118AEAA",
+        "name": "a6e1eab6-7e60-403f-afc1-65532291bd06*0ABB3334F0E8A38E05EE5A43045BDD49A755781B581797EC63F0A48EB118AEAA",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store/artifactManifests/ubuntu-vm-sa-manifest-1-0-0",
-        "status": "Deleting", "startTime": "2023-08-29T16:04:38.5945997Z"}'
+        "status": "Deleting", "startTime": "2023-09-05T09:57:30.0586046Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/15b4c924-80ca-4e5f-9149-835be9756471*B6943EBA12F10489DAA3AC3D9E77837B54D532FEF60B933E735DA59000AFDE79?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/a6e1eab6-7e60-403f-afc1-65532291bd06*0ABB3334F0E8A38E05EE5A43045BDD49A755781B581797EC63F0A48EB118AEAA?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -7410,13 +6821,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:04:38 GMT
+      - Tue, 05 Sep 2023 09:57:30 GMT
       etag:
-      - '"0300d8e3-0000-0600-0000-64ee17160000"'
+      - '"230cf335-0000-0800-0000-64f6fb8a0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/15b4c924-80ca-4e5f-9149-835be9756471*B6943EBA12F10489DAA3AC3D9E77837B54D532FEF60B933E735DA59000AFDE79?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/a6e1eab6-7e60-403f-afc1-65532291bd06*0ABB3334F0E8A38E05EE5A43045BDD49A755781B581797EC63F0A48EB118AEAA?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -7440,17 +6851,17 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/15b4c924-80ca-4e5f-9149-835be9756471*B6943EBA12F10489DAA3AC3D9E77837B54D532FEF60B933E735DA59000AFDE79?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a6e1eab6-7e60-403f-afc1-65532291bd06*0ABB3334F0E8A38E05EE5A43045BDD49A755781B581797EC63F0A48EB118AEAA?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/15b4c924-80ca-4e5f-9149-835be9756471*B6943EBA12F10489DAA3AC3D9E77837B54D532FEF60B933E735DA59000AFDE79",
-        "name": "15b4c924-80ca-4e5f-9149-835be9756471*B6943EBA12F10489DAA3AC3D9E77837B54D532FEF60B933E735DA59000AFDE79",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a6e1eab6-7e60-403f-afc1-65532291bd06*0ABB3334F0E8A38E05EE5A43045BDD49A755781B581797EC63F0A48EB118AEAA",
+        "name": "a6e1eab6-7e60-403f-afc1-65532291bd06*0ABB3334F0E8A38E05EE5A43045BDD49A755781B581797EC63F0A48EB118AEAA",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store/artifactManifests/ubuntu-vm-sa-manifest-1-0-0",
-        "status": "Succeeded", "startTime": "2023-08-29T16:04:38.5945997Z", "endTime":
-        "2023-08-29T16:04:42.8673091Z", "properties": null}'
+        "status": "Succeeded", "startTime": "2023-09-05T09:57:30.0586046Z", "endTime":
+        "2023-09-05T09:57:31.7211245Z", "properties": null}'
     headers:
       cache-control:
       - no-cache
@@ -7459,9 +6870,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:05:09 GMT
+      - Tue, 05 Sep 2023 09:58:01 GMT
       etag:
-      - '"0300fae3-0000-0600-0000-64ee171a0000"'
+      - '"230c6336-0000-0800-0000-64f6fb8b0000"'
       expires:
       - '-1'
       pragma:
@@ -7491,17 +6902,17 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/15b4c924-80ca-4e5f-9149-835be9756471*B6943EBA12F10489DAA3AC3D9E77837B54D532FEF60B933E735DA59000AFDE79?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a6e1eab6-7e60-403f-afc1-65532291bd06*0ABB3334F0E8A38E05EE5A43045BDD49A755781B581797EC63F0A48EB118AEAA?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/15b4c924-80ca-4e5f-9149-835be9756471*B6943EBA12F10489DAA3AC3D9E77837B54D532FEF60B933E735DA59000AFDE79",
-        "name": "15b4c924-80ca-4e5f-9149-835be9756471*B6943EBA12F10489DAA3AC3D9E77837B54D532FEF60B933E735DA59000AFDE79",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/a6e1eab6-7e60-403f-afc1-65532291bd06*0ABB3334F0E8A38E05EE5A43045BDD49A755781B581797EC63F0A48EB118AEAA",
+        "name": "a6e1eab6-7e60-403f-afc1-65532291bd06*0ABB3334F0E8A38E05EE5A43045BDD49A755781B581797EC63F0A48EB118AEAA",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store/artifactManifests/ubuntu-vm-sa-manifest-1-0-0",
-        "status": "Succeeded", "startTime": "2023-08-29T16:04:38.5945997Z", "endTime":
-        "2023-08-29T16:04:42.8673091Z", "properties": null}'
+        "status": "Succeeded", "startTime": "2023-09-05T09:57:30.0586046Z", "endTime":
+        "2023-09-05T09:57:31.7211245Z", "properties": null}'
     headers:
       cache-control:
       - no-cache
@@ -7510,9 +6921,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:05:09 GMT
+      - Tue, 05 Sep 2023 09:58:01 GMT
       etag:
-      - '"0300fae3-0000-0600-0000-64ee171a0000"'
+      - '"230c6336-0000-0800-0000-64f6fb8b0000"'
       expires:
       - '-1'
       pragma:
@@ -7544,8 +6955,8 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-acr-manifest-1-0-0?api-version=2023-04-01-preview
   response:
@@ -7553,7 +6964,7 @@ interactions:
       string: 'null'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/217f9262-1baa-4ead-8d54-ec2bb59887ca*6D4A88C4C492FF795DB9717A6CA26AF2F20572E19A448839FF1467472F8832B8?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/cf263fbe-43b9-4268-ba8f-8479e83ba25f*224068C861D17681C4B113D7459FFCC9AAFA781721900832CC84EBB27F1A0C07?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -7561,13 +6972,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:05:11 GMT
+      - Tue, 05 Sep 2023 09:58:03 GMT
       etag:
-      - '"00003610-0000-0600-0000-64ee17380000"'
+      - '"2500625a-0000-0800-0000-64f6fbab0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/217f9262-1baa-4ead-8d54-ec2bb59887ca*6D4A88C4C492FF795DB9717A6CA26AF2F20572E19A448839FF1467472F8832B8?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/cf263fbe-43b9-4268-ba8f-8479e83ba25f*224068C861D17681C4B113D7459FFCC9AAFA781721900832CC84EBB27F1A0C07?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -7597,33 +7008,33 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/217f9262-1baa-4ead-8d54-ec2bb59887ca*6D4A88C4C492FF795DB9717A6CA26AF2F20572E19A448839FF1467472F8832B8?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/cf263fbe-43b9-4268-ba8f-8479e83ba25f*224068C861D17681C4B113D7459FFCC9AAFA781721900832CC84EBB27F1A0C07?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/217f9262-1baa-4ead-8d54-ec2bb59887ca*6D4A88C4C492FF795DB9717A6CA26AF2F20572E19A448839FF1467472F8832B8",
-        "name": "217f9262-1baa-4ead-8d54-ec2bb59887ca*6D4A88C4C492FF795DB9717A6CA26AF2F20572E19A448839FF1467472F8832B8",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/cf263fbe-43b9-4268-ba8f-8479e83ba25f*224068C861D17681C4B113D7459FFCC9AAFA781721900832CC84EBB27F1A0C07",
+        "name": "cf263fbe-43b9-4268-ba8f-8479e83ba25f*224068C861D17681C4B113D7459FFCC9AAFA781721900832CC84EBB27F1A0C07",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-acr-manifest-1-0-0",
-        "status": "Deleting", "startTime": "2023-08-29T16:05:11.6158607Z"}'
+        "status": "Deleting", "startTime": "2023-09-05T09:58:02.644201Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/217f9262-1baa-4ead-8d54-ec2bb59887ca*6D4A88C4C492FF795DB9717A6CA26AF2F20572E19A448839FF1467472F8832B8?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/cf263fbe-43b9-4268-ba8f-8479e83ba25f*224068C861D17681C4B113D7459FFCC9AAFA781721900832CC84EBB27F1A0C07?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
-      - '610'
+      - '609'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:05:11 GMT
+      - Tue, 05 Sep 2023 09:58:03 GMT
       etag:
-      - '"030050e5-0000-0600-0000-64ee17370000"'
+      - '"52025f11-0000-0800-0000-64f6fbaa0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/217f9262-1baa-4ead-8d54-ec2bb59887ca*6D4A88C4C492FF795DB9717A6CA26AF2F20572E19A448839FF1467472F8832B8?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/cf263fbe-43b9-4268-ba8f-8479e83ba25f*224068C861D17681C4B113D7459FFCC9AAFA781721900832CC84EBB27F1A0C07?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -7647,28 +7058,28 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/217f9262-1baa-4ead-8d54-ec2bb59887ca*6D4A88C4C492FF795DB9717A6CA26AF2F20572E19A448839FF1467472F8832B8?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/cf263fbe-43b9-4268-ba8f-8479e83ba25f*224068C861D17681C4B113D7459FFCC9AAFA781721900832CC84EBB27F1A0C07?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/217f9262-1baa-4ead-8d54-ec2bb59887ca*6D4A88C4C492FF795DB9717A6CA26AF2F20572E19A448839FF1467472F8832B8",
-        "name": "217f9262-1baa-4ead-8d54-ec2bb59887ca*6D4A88C4C492FF795DB9717A6CA26AF2F20572E19A448839FF1467472F8832B8",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/cf263fbe-43b9-4268-ba8f-8479e83ba25f*224068C861D17681C4B113D7459FFCC9AAFA781721900832CC84EBB27F1A0C07",
+        "name": "cf263fbe-43b9-4268-ba8f-8479e83ba25f*224068C861D17681C4B113D7459FFCC9AAFA781721900832CC84EBB27F1A0C07",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-acr-manifest-1-0-0",
-        "status": "Succeeded", "startTime": "2023-08-29T16:05:11.6158607Z", "endTime":
-        "2023-08-29T16:05:29.9848076Z", "properties": null}'
+        "status": "Succeeded", "startTime": "2023-09-05T09:58:02.644201Z", "endTime":
+        "2023-09-05T09:58:17.1075565Z", "properties": null}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '674'
+      - '673'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:05:41 GMT
+      - Tue, 05 Sep 2023 09:58:33 GMT
       etag:
-      - '"03001ee6-0000-0600-0000-64ee17490000"'
+      - '"52025412-0000-0800-0000-64f6fbb90000"'
       expires:
       - '-1'
       pragma:
@@ -7698,28 +7109,28 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/217f9262-1baa-4ead-8d54-ec2bb59887ca*6D4A88C4C492FF795DB9717A6CA26AF2F20572E19A448839FF1467472F8832B8?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/cf263fbe-43b9-4268-ba8f-8479e83ba25f*224068C861D17681C4B113D7459FFCC9AAFA781721900832CC84EBB27F1A0C07?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/217f9262-1baa-4ead-8d54-ec2bb59887ca*6D4A88C4C492FF795DB9717A6CA26AF2F20572E19A448839FF1467472F8832B8",
-        "name": "217f9262-1baa-4ead-8d54-ec2bb59887ca*6D4A88C4C492FF795DB9717A6CA26AF2F20572E19A448839FF1467472F8832B8",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/cf263fbe-43b9-4268-ba8f-8479e83ba25f*224068C861D17681C4B113D7459FFCC9AAFA781721900832CC84EBB27F1A0C07",
+        "name": "cf263fbe-43b9-4268-ba8f-8479e83ba25f*224068C861D17681C4B113D7459FFCC9AAFA781721900832CC84EBB27F1A0C07",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-acr-manifest-1-0-0",
-        "status": "Succeeded", "startTime": "2023-08-29T16:05:11.6158607Z", "endTime":
-        "2023-08-29T16:05:29.9848076Z", "properties": null}'
+        "status": "Succeeded", "startTime": "2023-09-05T09:58:02.644201Z", "endTime":
+        "2023-09-05T09:58:17.1075565Z", "properties": null}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '674'
+      - '673'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:05:41 GMT
+      - Tue, 05 Sep 2023 09:58:33 GMT
       etag:
-      - '"03001ee6-0000-0600-0000-64ee17490000"'
+      - '"52025412-0000-0800-0000-64f6fbb90000"'
       expires:
       - '-1'
       pragma:
@@ -7751,8 +7162,8 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg?api-version=2023-04-01-preview
   response:
@@ -7760,7 +7171,7 @@ interactions:
       string: 'null'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/dd0d605e-746e-4866-9d02-bc2f992dfc59*F718B1F161EB7226E4EC39CC19770E9403ACD5E880A312391A01B8B8914A2268?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -7768,13 +7179,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:05:46 GMT
+      - Tue, 05 Sep 2023 09:58:37 GMT
       etag:
-      - '"00005304-0000-0600-0000-64ee175b0000"'
+      - '"9a0237f0-0000-0800-0000-64f6fbcd0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/dd0d605e-746e-4866-9d02-bc2f992dfc59*F718B1F161EB7226E4EC39CC19770E9403ACD5E880A312391A01B8B8914A2268?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -7804,19 +7215,19 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/dd0d605e-746e-4866-9d02-bc2f992dfc59*F718B1F161EB7226E4EC39CC19770E9403ACD5E880A312391A01B8B8914A2268?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890",
-        "name": "bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/dd0d605e-746e-4866-9d02-bc2f992dfc59*F718B1F161EB7226E4EC39CC19770E9403ACD5E880A312391A01B8B8914A2268",
+        "name": "dd0d605e-746e-4866-9d02-bc2f992dfc59*F718B1F161EB7226E4EC39CC19770E9403ACD5E880A312391A01B8B8914A2268",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg",
-        "status": "Deleting", "startTime": "2023-08-29T16:05:46.9649481Z"}'
+        "status": "Deleting", "startTime": "2023-09-05T09:58:37.5411148Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/dd0d605e-746e-4866-9d02-bc2f992dfc59*F718B1F161EB7226E4EC39CC19770E9403ACD5E880A312391A01B8B8914A2268?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -7824,13 +7235,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:05:46 GMT
+      - Tue, 05 Sep 2023 09:58:37 GMT
       etag:
-      - '"0300f3e6-0000-0600-0000-64ee175a0000"'
+      - '"230cb14b-0000-0800-0000-64f6fbcd0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/dd0d605e-746e-4866-9d02-bc2f992dfc59*F718B1F161EB7226E4EC39CC19770E9403ACD5E880A312391A01B8B8914A2268?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -7854,19 +7265,19 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/dd0d605e-746e-4866-9d02-bc2f992dfc59*F718B1F161EB7226E4EC39CC19770E9403ACD5E880A312391A01B8B8914A2268?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890",
-        "name": "bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/dd0d605e-746e-4866-9d02-bc2f992dfc59*F718B1F161EB7226E4EC39CC19770E9403ACD5E880A312391A01B8B8914A2268",
+        "name": "dd0d605e-746e-4866-9d02-bc2f992dfc59*F718B1F161EB7226E4EC39CC19770E9403ACD5E880A312391A01B8B8914A2268",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg",
-        "status": "Deleting", "startTime": "2023-08-29T16:05:46.9649481Z"}'
+        "status": "Deleting", "startTime": "2023-09-05T09:58:37.5411148Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/dd0d605e-746e-4866-9d02-bc2f992dfc59*F718B1F161EB7226E4EC39CC19770E9403ACD5E880A312391A01B8B8914A2268?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -7874,13 +7285,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:06:17 GMT
+      - Tue, 05 Sep 2023 09:59:07 GMT
       etag:
-      - '"0300f3e6-0000-0600-0000-64ee175a0000"'
+      - '"230cb14b-0000-0800-0000-64f6fbcd0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/dd0d605e-746e-4866-9d02-bc2f992dfc59*F718B1F161EB7226E4EC39CC19770E9403ACD5E880A312391A01B8B8914A2268?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -7904,19 +7315,19 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/dd0d605e-746e-4866-9d02-bc2f992dfc59*F718B1F161EB7226E4EC39CC19770E9403ACD5E880A312391A01B8B8914A2268?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890",
-        "name": "bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/dd0d605e-746e-4866-9d02-bc2f992dfc59*F718B1F161EB7226E4EC39CC19770E9403ACD5E880A312391A01B8B8914A2268",
+        "name": "dd0d605e-746e-4866-9d02-bc2f992dfc59*F718B1F161EB7226E4EC39CC19770E9403ACD5E880A312391A01B8B8914A2268",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg",
-        "status": "Deleting", "startTime": "2023-08-29T16:05:46.9649481Z"}'
+        "status": "Deleting", "startTime": "2023-09-05T09:58:37.5411148Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/dd0d605e-746e-4866-9d02-bc2f992dfc59*F718B1F161EB7226E4EC39CC19770E9403ACD5E880A312391A01B8B8914A2268?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -7924,13 +7335,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:06:46 GMT
+      - Tue, 05 Sep 2023 09:59:38 GMT
       etag:
-      - '"0300f3e6-0000-0600-0000-64ee175a0000"'
+      - '"230cb14b-0000-0800-0000-64f6fbcd0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/dd0d605e-746e-4866-9d02-bc2f992dfc59*F718B1F161EB7226E4EC39CC19770E9403ACD5E880A312391A01B8B8914A2268?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -7954,16 +7365,16 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/dd0d605e-746e-4866-9d02-bc2f992dfc59*F718B1F161EB7226E4EC39CC19770E9403ACD5E880A312391A01B8B8914A2268?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890",
-        "name": "bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/dd0d605e-746e-4866-9d02-bc2f992dfc59*F718B1F161EB7226E4EC39CC19770E9403ACD5E880A312391A01B8B8914A2268",
+        "name": "dd0d605e-746e-4866-9d02-bc2f992dfc59*F718B1F161EB7226E4EC39CC19770E9403ACD5E880A312391A01B8B8914A2268",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg",
-        "status": "Succeeded", "startTime": "2023-08-29T16:05:46.9649481Z", "properties":
+        "status": "Succeeded", "startTime": "2023-09-05T09:58:37.5411148Z", "properties":
         null}'
     headers:
       cache-control:
@@ -7973,9 +7384,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:07:17 GMT
+      - Tue, 05 Sep 2023 10:00:08 GMT
       etag:
-      - '"3a01a854-0000-0700-0000-64ee179d0000"'
+      - '"cc009a2e-0000-0700-0000-64f6fc100000"'
       expires:
       - '-1'
       pragma:
@@ -8005,16 +7416,16 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/dd0d605e-746e-4866-9d02-bc2f992dfc59*F718B1F161EB7226E4EC39CC19770E9403ACD5E880A312391A01B8B8914A2268?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890",
-        "name": "bd9455a4-332a-4388-bb8d-99bd77a07e3c*34B427E14DE04F9E01EC345CFC242026724C04F83B62981A24B26738B0658890",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/dd0d605e-746e-4866-9d02-bc2f992dfc59*F718B1F161EB7226E4EC39CC19770E9403ACD5E880A312391A01B8B8914A2268",
+        "name": "dd0d605e-746e-4866-9d02-bc2f992dfc59*F718B1F161EB7226E4EC39CC19770E9403ACD5E880A312391A01B8B8914A2268",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/networkFunctionDefinitionGroups/ubuntu-vm-nfdg",
-        "status": "Succeeded", "startTime": "2023-08-29T16:05:46.9649481Z", "properties":
+        "status": "Succeeded", "startTime": "2023-09-05T09:58:37.5411148Z", "properties":
         null}'
     headers:
       cache-control:
@@ -8024,9 +7435,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:07:18 GMT
+      - Tue, 05 Sep 2023 10:00:08 GMT
       etag:
-      - '"3a01a854-0000-0700-0000-64ee179d0000"'
+      - '"cc009a2e-0000-0700-0000-64f6fc100000"'
       expires:
       - '-1'
       pragma:
@@ -8058,8 +7469,8 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr?api-version=2023-04-01-preview
   response:
@@ -8067,7 +7478,7 @@ interactions:
       string: 'null'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -8075,13 +7486,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:07:19 GMT
+      - Tue, 05 Sep 2023 10:00:10 GMT
       etag:
-      - '"00000e32-0000-0600-0000-64ee17b70000"'
+      - '"7502b393-0000-0800-0000-64f6fc2a0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -8111,19 +7522,19 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
-        "name": "aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A",
+        "name": "32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr",
-        "status": "Deleting", "startTime": "2023-08-29T16:07:19.8256543Z"}'
+        "status": "Deleting", "startTime": "2023-09-05T10:00:10.5295516Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -8131,13 +7542,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:07:19 GMT
+      - Tue, 05 Sep 2023 10:00:10 GMT
       etag:
-      - '"00003c06-0000-0600-0000-64ee17b70000"'
+      - '"230cb369-0000-0800-0000-64f6fc2a0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -8161,19 +7572,19 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
-        "name": "aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A",
+        "name": "32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr",
-        "status": "Deleting", "startTime": "2023-08-29T16:07:19.8256543Z"}'
+        "status": "Deleting", "startTime": "2023-09-05T10:00:10.5295516Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -8181,13 +7592,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:07:50 GMT
+      - Tue, 05 Sep 2023 10:00:40 GMT
       etag:
-      - '"00003c06-0000-0600-0000-64ee17b70000"'
+      - '"230cb369-0000-0800-0000-64f6fc2a0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -8211,19 +7622,19 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
-        "name": "aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A",
+        "name": "32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr",
-        "status": "Deleting", "startTime": "2023-08-29T16:07:19.8256543Z"}'
+        "status": "Deleting", "startTime": "2023-09-05T10:00:10.5295516Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -8231,13 +7642,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:08:20 GMT
+      - Tue, 05 Sep 2023 10:01:10 GMT
       etag:
-      - '"00003c06-0000-0600-0000-64ee17b70000"'
+      - '"230cb369-0000-0800-0000-64f6fc2a0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -8261,19 +7672,19 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
-        "name": "aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A",
+        "name": "32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr",
-        "status": "Deleting", "startTime": "2023-08-29T16:07:19.8256543Z"}'
+        "status": "Deleting", "startTime": "2023-09-05T10:00:10.5295516Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -8281,13 +7692,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:08:49 GMT
+      - Tue, 05 Sep 2023 10:01:41 GMT
       etag:
-      - '"00003c06-0000-0600-0000-64ee17b70000"'
+      - '"230cb369-0000-0800-0000-64f6fc2a0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -8311,19 +7722,19 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
-        "name": "aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A",
+        "name": "32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr",
-        "status": "Deleting", "startTime": "2023-08-29T16:07:19.8256543Z"}'
+        "status": "Deleting", "startTime": "2023-09-05T10:00:10.5295516Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -8331,13 +7742,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:09:20 GMT
+      - Tue, 05 Sep 2023 10:02:11 GMT
       etag:
-      - '"00003c06-0000-0600-0000-64ee17b70000"'
+      - '"230cb369-0000-0800-0000-64f6fc2a0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -8361,19 +7772,19 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
-        "name": "aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A",
+        "name": "32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr",
-        "status": "Deleting", "startTime": "2023-08-29T16:07:19.8256543Z"}'
+        "status": "Deleting", "startTime": "2023-09-05T10:00:10.5295516Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -8381,13 +7792,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:09:51 GMT
+      - Tue, 05 Sep 2023 10:02:41 GMT
       etag:
-      - '"00003c06-0000-0600-0000-64ee17b70000"'
+      - '"230cb369-0000-0800-0000-64f6fc2a0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -8411,19 +7822,19 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
-        "name": "aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A",
+        "name": "32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr",
-        "status": "Deleting", "startTime": "2023-08-29T16:07:19.8256543Z"}'
+        "status": "Deleting", "startTime": "2023-09-05T10:00:10.5295516Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -8431,13 +7842,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:10:21 GMT
+      - Tue, 05 Sep 2023 10:03:11 GMT
       etag:
-      - '"00003c06-0000-0600-0000-64ee17b70000"'
+      - '"230cb369-0000-0800-0000-64f6fc2a0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -8461,16 +7872,16 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
-        "name": "aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A",
+        "name": "32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr",
-        "status": "Succeeded", "startTime": "2023-08-29T16:07:19.8256543Z", "properties":
+        "status": "Succeeded", "startTime": "2023-09-05T10:00:10.5295516Z", "properties":
         null}'
     headers:
       cache-control:
@@ -8480,9 +7891,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:10:51 GMT
+      - Tue, 05 Sep 2023 10:03:42 GMT
       etag:
-      - '"00004206-0000-0600-0000-64ee18730000"'
+      - '"000089e4-0000-0600-0000-64f6fce50000"'
       expires:
       - '-1'
       pragma:
@@ -8512,16 +7923,16 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
-        "name": "aa35a345-7239-43ff-a781-48eaf9546bac*842403C2D698915B1A40AB6D01D511CBFBB4711F0C80395109E20179A98D03A5",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A",
+        "name": "32a83b8f-4918-47f1-8fe4-eaea73c8f5a8*5E5951EA8F5EAA5CD7D4081E0F5A46140582596A0F3C82CB7EEE85130FE40E2A",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-acr",
-        "status": "Succeeded", "startTime": "2023-08-29T16:07:19.8256543Z", "properties":
+        "status": "Succeeded", "startTime": "2023-09-05T10:00:10.5295516Z", "properties":
         null}'
     headers:
       cache-control:
@@ -8531,9 +7942,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:10:52 GMT
+      - Tue, 05 Sep 2023 10:03:42 GMT
       etag:
-      - '"00004206-0000-0600-0000-64ee18730000"'
+      - '"000089e4-0000-0600-0000-64f6fce50000"'
       expires:
       - '-1'
       pragma:
@@ -8565,8 +7976,8 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store?api-version=2023-04-01-preview
   response:
@@ -8574,7 +7985,7 @@ interactions:
       string: 'null'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -8582,13 +7993,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:10:53 GMT
+      - Tue, 05 Sep 2023 10:03:44 GMT
       etag:
-      - '"00003033-0000-0600-0000-64ee188d0000"'
+      - '"7502b6a3-0000-0800-0000-64f6fd000000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -8618,19 +8029,19 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
-        "name": "faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8",
+        "name": "c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store",
-        "status": "Deleting", "startTime": "2023-08-29T16:10:53.6036813Z"}'
+        "status": "Deleting", "startTime": "2023-09-05T10:03:44.3077653Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -8638,13 +8049,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:10:53 GMT
+      - Tue, 05 Sep 2023 10:03:44 GMT
       etag:
-      - '"00004506-0000-0600-0000-64ee188d0000"'
+      - '"52025a24-0000-0800-0000-64f6fd000000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -8668,19 +8079,19 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
-        "name": "faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8",
+        "name": "c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store",
-        "status": "Deleting", "startTime": "2023-08-29T16:10:53.6036813Z"}'
+        "status": "Deleting", "startTime": "2023-09-05T10:03:44.3077653Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -8688,13 +8099,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:11:23 GMT
+      - Tue, 05 Sep 2023 10:04:14 GMT
       etag:
-      - '"00004506-0000-0600-0000-64ee188d0000"'
+      - '"52025a24-0000-0800-0000-64f6fd000000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -8718,19 +8129,19 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
-        "name": "faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8",
+        "name": "c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store",
-        "status": "Deleting", "startTime": "2023-08-29T16:10:53.6036813Z"}'
+        "status": "Deleting", "startTime": "2023-09-05T10:03:44.3077653Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -8738,13 +8149,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:11:53 GMT
+      - Tue, 05 Sep 2023 10:04:44 GMT
       etag:
-      - '"00004506-0000-0600-0000-64ee188d0000"'
+      - '"52025a24-0000-0800-0000-64f6fd000000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -8768,19 +8179,19 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
-        "name": "faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8",
+        "name": "c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store",
-        "status": "Deleting", "startTime": "2023-08-29T16:10:53.6036813Z"}'
+        "status": "Deleting", "startTime": "2023-09-05T10:03:44.3077653Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -8788,13 +8199,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:12:24 GMT
+      - Tue, 05 Sep 2023 10:05:14 GMT
       etag:
-      - '"00004506-0000-0600-0000-64ee188d0000"'
+      - '"52025a24-0000-0800-0000-64f6fd000000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -8818,19 +8229,19 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
-        "name": "faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8",
+        "name": "c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store",
-        "status": "Deleting", "startTime": "2023-08-29T16:10:53.6036813Z"}'
+        "status": "Deleting", "startTime": "2023-09-05T10:03:44.3077653Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -8838,13 +8249,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:12:53 GMT
+      - Tue, 05 Sep 2023 10:05:45 GMT
       etag:
-      - '"00004506-0000-0600-0000-64ee188d0000"'
+      - '"52025a24-0000-0800-0000-64f6fd000000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -8868,19 +8279,19 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
-        "name": "faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8",
+        "name": "c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store",
-        "status": "Deleting", "startTime": "2023-08-29T16:10:53.6036813Z"}'
+        "status": "Deleting", "startTime": "2023-09-05T10:03:44.3077653Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -8888,13 +8299,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:13:24 GMT
+      - Tue, 05 Sep 2023 10:06:15 GMT
       etag:
-      - '"00004506-0000-0600-0000-64ee188d0000"'
+      - '"52025a24-0000-0800-0000-64f6fd000000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -8918,19 +8329,19 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
-        "name": "faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8",
+        "name": "c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store",
-        "status": "Deleting", "startTime": "2023-08-29T16:10:53.6036813Z"}'
+        "status": "Deleting", "startTime": "2023-09-05T10:03:44.3077653Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -8938,13 +8349,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:13:54 GMT
+      - Tue, 05 Sep 2023 10:06:45 GMT
       etag:
-      - '"00004506-0000-0600-0000-64ee188d0000"'
+      - '"52025a24-0000-0800-0000-64f6fd000000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -8968,16 +8379,16 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
-        "name": "faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8",
+        "name": "c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store",
-        "status": "Succeeded", "startTime": "2023-08-29T16:10:53.6036813Z", "properties":
+        "status": "Succeeded", "startTime": "2023-09-05T10:03:44.3077653Z", "properties":
         null}'
     headers:
       cache-control:
@@ -8987,9 +8398,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:14:24 GMT
+      - Tue, 05 Sep 2023 10:07:16 GMT
       etag:
-      - '"00005106-0000-0600-0000-64ee19490000"'
+      - '"00001004-0000-0600-0000-64f6fdbd0000"'
       expires:
       - '-1'
       pragma:
@@ -9019,16 +8430,16 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
-        "name": "faab2d0b-ba75-4d24-b89c-14c8acf9355f*A3808BC884BD95AE15E56E8748664E7C3524F1EC592A9123E52D67500437CAA6",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8",
+        "name": "c7ced238-75d0-4061-958f-5debfa8170b3*F5877D1037F5CF29B2BF465C24ADC48BBD597373C5953C8DF88B18E3AE1E0DB8",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher/artifactStores/ubuntu-blob-store",
-        "status": "Succeeded", "startTime": "2023-08-29T16:10:53.6036813Z", "properties":
+        "status": "Succeeded", "startTime": "2023-09-05T10:03:44.3077653Z", "properties":
         null}'
     headers:
       cache-control:
@@ -9038,9 +8449,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:14:24 GMT
+      - Tue, 05 Sep 2023 10:07:16 GMT
       etag:
-      - '"00005106-0000-0600-0000-64ee19490000"'
+      - '"00001004-0000-0600-0000-64f6fdbd0000"'
       expires:
       - '-1'
       pragma:
@@ -9072,8 +8483,8 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher?api-version=2023-04-01-preview
   response:
@@ -9081,7 +8492,7 @@ interactions:
       string: 'null'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/7a41a661-8900-413d-93cb-2fe121902252*E0E8123B8C2940C6FB6A994A886BB852744C1D495D5F7020C52DC66D69A77085?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -9089,13 +8500,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:14:30 GMT
+      - Tue, 05 Sep 2023 10:07:23 GMT
       etag:
-      - '"00003f03-0000-0600-0000-64ee19660000"'
+      - '"2a004c93-0000-0800-0000-64f6fddb0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/7a41a661-8900-413d-93cb-2fe121902252*E0E8123B8C2940C6FB6A994A886BB852744C1D495D5F7020C52DC66D69A77085?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -9125,19 +8536,19 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/7a41a661-8900-413d-93cb-2fe121902252*E0E8123B8C2940C6FB6A994A886BB852744C1D495D5F7020C52DC66D69A77085?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E",
-        "name": "1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/7a41a661-8900-413d-93cb-2fe121902252*E0E8123B8C2940C6FB6A994A886BB852744C1D495D5F7020C52DC66D69A77085",
+        "name": "7a41a661-8900-413d-93cb-2fe121902252*E0E8123B8C2940C6FB6A994A886BB852744C1D495D5F7020C52DC66D69A77085",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher",
-        "status": "Deleting", "startTime": "2023-08-29T16:14:30.1589659Z"}'
+        "status": "Deleting", "startTime": "2023-09-05T10:07:23.2476271Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/7a41a661-8900-413d-93cb-2fe121902252*E0E8123B8C2940C6FB6A994A886BB852744C1D495D5F7020C52DC66D69A77085?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -9145,13 +8556,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:14:30 GMT
+      - Tue, 05 Sep 2023 10:07:23 GMT
       etag:
-      - '"0300ebfe-0000-0600-0000-64ee19660000"'
+      - '"5202e430-0000-0800-0000-64f6fddb0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/7a41a661-8900-413d-93cb-2fe121902252*E0E8123B8C2940C6FB6A994A886BB852744C1D495D5F7020C52DC66D69A77085?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -9175,19 +8586,19 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/7a41a661-8900-413d-93cb-2fe121902252*E0E8123B8C2940C6FB6A994A886BB852744C1D495D5F7020C52DC66D69A77085?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E",
-        "name": "1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/7a41a661-8900-413d-93cb-2fe121902252*E0E8123B8C2940C6FB6A994A886BB852744C1D495D5F7020C52DC66D69A77085",
+        "name": "7a41a661-8900-413d-93cb-2fe121902252*E0E8123B8C2940C6FB6A994A886BB852744C1D495D5F7020C52DC66D69A77085",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher",
-        "status": "Deleting", "startTime": "2023-08-29T16:14:30.1589659Z"}'
+        "status": "Deleting", "startTime": "2023-09-05T10:07:23.2476271Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/7a41a661-8900-413d-93cb-2fe121902252*E0E8123B8C2940C6FB6A994A886BB852744C1D495D5F7020C52DC66D69A77085?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -9195,13 +8606,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:15:00 GMT
+      - Tue, 05 Sep 2023 10:07:53 GMT
       etag:
-      - '"0300ebfe-0000-0600-0000-64ee19660000"'
+      - '"5202e430-0000-0800-0000-64f6fddb0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/7a41a661-8900-413d-93cb-2fe121902252*E0E8123B8C2940C6FB6A994A886BB852744C1D495D5F7020C52DC66D69A77085?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -9225,19 +8636,19 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/7a41a661-8900-413d-93cb-2fe121902252*E0E8123B8C2940C6FB6A994A886BB852744C1D495D5F7020C52DC66D69A77085?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E",
-        "name": "1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/7a41a661-8900-413d-93cb-2fe121902252*E0E8123B8C2940C6FB6A994A886BB852744C1D495D5F7020C52DC66D69A77085",
+        "name": "7a41a661-8900-413d-93cb-2fe121902252*E0E8123B8C2940C6FB6A994A886BB852744C1D495D5F7020C52DC66D69A77085",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher",
-        "status": "Deleting", "startTime": "2023-08-29T16:14:30.1589659Z"}'
+        "status": "Deleting", "startTime": "2023-09-05T10:07:23.2476271Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/7a41a661-8900-413d-93cb-2fe121902252*E0E8123B8C2940C6FB6A994A886BB852744C1D495D5F7020C52DC66D69A77085?api-version=2020-01-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -9245,13 +8656,13 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:15:30 GMT
+      - Tue, 05 Sep 2023 10:08:23 GMT
       etag:
-      - '"0300ebfe-0000-0600-0000-64ee19660000"'
+      - '"5202e430-0000-0800-0000-64f6fddb0000"'
       expires:
       - '-1'
       location:
-      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E?api-version=2020-01-01-preview
+      - https://management.azure.com/providers/Microsoft.HybridNetwork/locations/westcentralus/operationStatuses/7a41a661-8900-413d-93cb-2fe121902252*E0E8123B8C2940C6FB6A994A886BB852744C1D495D5F7020C52DC66D69A77085?api-version=2020-01-01-preview
       pragma:
       - no-cache
       strict-transport-security:
@@ -9275,16 +8686,16 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/7a41a661-8900-413d-93cb-2fe121902252*E0E8123B8C2940C6FB6A994A886BB852744C1D495D5F7020C52DC66D69A77085?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E",
-        "name": "1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/7a41a661-8900-413d-93cb-2fe121902252*E0E8123B8C2940C6FB6A994A886BB852744C1D495D5F7020C52DC66D69A77085",
+        "name": "7a41a661-8900-413d-93cb-2fe121902252*E0E8123B8C2940C6FB6A994A886BB852744C1D495D5F7020C52DC66D69A77085",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher",
-        "status": "Succeeded", "startTime": "2023-08-29T16:14:30.1589659Z", "properties":
+        "status": "Succeeded", "startTime": "2023-09-05T10:07:23.2476271Z", "properties":
         null}'
     headers:
       cache-control:
@@ -9294,9 +8705,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:16:00 GMT
+      - Tue, 05 Sep 2023 10:08:53 GMT
       etag:
-      - '"3a019872-0000-0700-0000-64ee19a90000"'
+      - '"52027334-0000-0800-0000-64f6fe1e0000"'
       expires:
       - '-1'
       pragma:
@@ -9326,16 +8737,16 @@ interactions:
       ParameterSetName:
       - --definition-type -f --clean --force
       User-Agent:
-      - AZURECLI/2.51.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
-        (Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.49.0 azsdk-python-hybridnetwork/2020-01-01-preview Python/3.8.10
+        (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E?api-version=2020-01-01-preview
+    uri: https://management.azure.com/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/7a41a661-8900-413d-93cb-2fe121902252*E0E8123B8C2940C6FB6A994A886BB852744C1D495D5F7020C52DC66D69A77085?api-version=2020-01-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E",
-        "name": "1fab29a6-416a-4e5f-90e4-41c0a4901685*F6DEDAD7F1E32D08F5303D47DA80D64D1BEF1079F6DA03768755401B08ACDB6E",
+      string: '{"id": "/providers/Microsoft.HybridNetwork/locations/WESTCENTRALUS/operationStatuses/7a41a661-8900-413d-93cb-2fe121902252*E0E8123B8C2940C6FB6A994A886BB852744C1D495D5F7020C52DC66D69A77085",
+        "name": "7a41a661-8900-413d-93cb-2fe121902252*E0E8123B8C2940C6FB6A994A886BB852744C1D495D5F7020C52DC66D69A77085",
         "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/ubuntuPublisher",
-        "status": "Succeeded", "startTime": "2023-08-29T16:14:30.1589659Z", "properties":
+        "status": "Succeeded", "startTime": "2023-09-05T10:07:23.2476271Z", "properties":
         null}'
     headers:
       cache-control:
@@ -9345,9 +8756,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 29 Aug 2023 16:16:01 GMT
+      - Tue, 05 Sep 2023 10:08:54 GMT
       etag:
-      - '"3a019872-0000-0700-0000-64ee19a90000"'
+      - '"52027334-0000-0800-0000-64f6fe1e0000"'
       expires:
       - '-1'
       pragma:

--- a/src/aosm/azext_aosm/tests/latest/scenario_test_mocks/mock_input_templates/cnf_input_template.json
+++ b/src/aosm/azext_aosm/tests/latest/scenario_test_mocks/mock_input_templates/cnf_input_template.json
@@ -5,8 +5,10 @@
     "version": "1.0.0",
     "acr_artifact_store_name": "nginx-nsd-acr",
     "location": "westcentralus",
-    "source_registry_id": "{{source_registry_id}}",
-    "source_registry_namespace": "",
+    "images":{
+        "source_registry": "{{source_registry_id}}",
+        "source_registry_namespace": ""
+    },
     "helm_packages": [
         {
             "name": "nginxdemo",

--- a/src/aosm/azext_aosm/tests/latest/scenario_test_mocks/mock_input_templates/cnf_nsd_input_template.json
+++ b/src/aosm/azext_aosm/tests/latest/scenario_test_mocks/mock_input_templates/cnf_nsd_input_template.json
@@ -11,6 +11,7 @@
             "type": "cnf",
             "multiple_instances": false,
             "publisher": "nginx-publisher",
+            "publisher_scope": "private",
             "publisher_resource_group": "{{publisher_resource_group_name}}"
         }
     ],

--- a/src/aosm/azext_aosm/tests/latest/scenario_test_mocks/mock_input_templates/vnf_nsd_input_template.json
+++ b/src/aosm/azext_aosm/tests/latest/scenario_test_mocks/mock_input_templates/vnf_nsd_input_template.json
@@ -11,6 +11,7 @@
             "type": "vnf",
             "multiple_instances": false,
             "publisher": "ubuntuPublisher",
+            "publisher_scope": "private",
             "publisher_resource_group": "{{publisher_resource_group_name}}"
         }
     ],

--- a/src/aosm/azext_aosm/tests/latest/test_aosm_cnf_publish_and_delete.py
+++ b/src/aosm/azext_aosm/tests/latest/test_aosm_cnf_publish_and_delete.py
@@ -61,8 +61,8 @@ class CnfNsdTest(LiveScenarioTest):
     """
     Integration tests for the aosm extension for cnf definition type.
 
-    This test uses Live Scenario Test because it depends on using the `az login` command which
-    does not work when playing back from the recording.
+    This test uses Live Scenario Test because it depends on using the `az login` command
+    which does not work when playing back from the recording.
     """
 
     @ResourceGroupPreparer(name_prefix="cli_test_cnf_nsd_", location="westcentralus")

--- a/src/aosm/azext_aosm/tests/latest/test_aosm_vnf_publish_and_delete.py
+++ b/src/aosm/azext_aosm/tests/latest/test_aosm_vnf_publish_and_delete.py
@@ -38,7 +38,8 @@ def update_resource_group_in_input_file(
     :param input_template_name: The name of the input template file.
     :param output_file_name: The name of the output file.
     :param resource_group: The name of the resource group to update the input template with.
-    :return: The path to the updated input template file."""
+    :return: The path to the updated input template file.
+    """
     code_dir = os.path.dirname(__file__)
     templates_dir = os.path.join(
         code_dir, "scenario_test_mocks", "mock_input_templates"
@@ -63,12 +64,11 @@ def update_resource_group_in_input_file(
 
 
 class VnfNsdTest(ScenarioTest):
-    """
-    This class contains the integration tests for the aosm extension for vnf definition type.
-    """
+    """This class contains the integration tests for the aosm extension for vnf definition type."""
+
     def __init__(self, method_name):
         """
-        This constructor initializes the class
+        This constructor initializes the class.
 
         :param method_name: The name of the test method.
         :param recording_processors: The recording processors to use for the test.
@@ -77,7 +77,11 @@ class VnfNsdTest(ScenarioTest):
         """
         super(VnfNsdTest, self).__init__(
             method_name,
-            recording_processors=[TokenReplacer(), SasUriReplacer(), BlobStoreUriReplacer()]
+            recording_processors=[
+                TokenReplacer(),
+                SasUriReplacer(),
+                BlobStoreUriReplacer(),
+            ],
         )
 
     @ResourceGroupPreparer(name_prefix="cli_test_vnf_nsd_", location="westcentralus")

--- a/src/aosm/azext_aosm/tests/latest/test_nsd.py
+++ b/src/aosm/azext_aosm/tests/latest/test_nsd.py
@@ -3,20 +3,32 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-import os
-from dataclasses import dataclass
-from distutils.dir_util import copy_tree
 import json
+import os
 import shutil
 import subprocess
+from dataclasses import dataclass
+from distutils.dir_util import copy_tree
 from filecmp import dircmp
 from pathlib import Path
-from unittest.mock import patch
 from tempfile import TemporaryDirectory
+from typing import Any
+from unittest.mock import Mock, patch
 
 import jsonschema
+import pytest
+from azure.cli.core.azclierror import CLIInternalError
+from azure.core import exceptions as azure_exceptions
+from azure.mgmt.resource.features.v2015_12_01.models import (
+    FeatureProperties,
+    FeatureResult,
+)
 
-from azext_aosm.custom import generate_design_config, build_design
+from azext_aosm.custom import (
+    _check_features_enabled,
+    build_design,
+    generate_design_config,
+)
 
 mock_nsd_folder = ((Path(__file__).parent) / "mock_nsd").resolve()
 output_folder = ((Path(__file__).parent) / "nsd_output").resolve()
@@ -123,6 +135,52 @@ class AOSMClient:
 
 
 mock_client = AOSMClient()
+
+
+class MockFeatures:
+    """Mock class for _check_features_enabled."""
+
+    def __init__(self) -> None:
+        """Mock init."""
+        self.mock_state = "NotRegistered"
+
+    def get(
+        self, resource_provider_namespace: str, feature_name: str, **kwargs: Any
+    ) -> FeatureResult:
+        """Mock Features get function."""
+        return FeatureResult(
+            name=feature_name, properties=FeatureProperties(state=self.mock_state)
+        )
+
+
+class MockMissingFeatures:
+    """Mock class for _check_features_enabled."""
+
+    def __init__(self) -> None:
+        """Fake init."""
+        pass
+
+    def get(
+        self, resource_provider_namespace: str, feature_name: str, **kwargs: Any
+    ) -> FeatureResult:
+        """Mock features get function that raises an exception."""
+        raise azure_exceptions.ResourceNotFoundError()
+
+
+class FeaturesClient:
+    """Mock class for _check_features_enabled."""
+
+    def __init__(self) -> None:
+        """Mock class for _check_features_enabled."""
+        self.features = MockFeatures()
+
+
+class MissingFeaturesClient:
+    """Mock class for _check_features_enabled."""
+
+    def __init__(self) -> None:
+        """Mock class for _check_features_enabled."""
+        self.features = MockMissingFeatures()
 
 
 class FakeCmd:
@@ -301,3 +359,32 @@ class TestNSDGenerator:
                 compare_to_expected_output("test_build_multiple_nfs")
             finally:
                 os.chdir(starting_directory)
+
+    def test_check_features(self, caplog):
+        """
+        Test the _check_features_enabled function.
+
+        Does not test the actual feature check, just that the function logs and raises
+        exceptions appropriately.
+        """
+        mock_features_client = FeaturesClient()
+        mock_missing_features_client = MissingFeaturesClient()
+        caplog.set_level("DEBUG")
+        with patch("azext_aosm.custom.cf_features", return_value=mock_features_client):
+            mock_features_client.features.mock_state = "NotRegistered"
+
+            with pytest.raises(CLIInternalError):
+                _check_features_enabled(mock_cmd)
+                assert "is not registered on the subscription" in caplog.text
+            mock_features_client.features.mock_state = "Registered"
+            _check_features_enabled(mock_cmd)
+
+        with patch(
+            "azext_aosm.custom.cf_features", return_value=mock_missing_features_client
+        ):
+            with pytest.raises(CLIInternalError):
+                _check_features_enabled(mock_cmd)
+                assert (
+                    "CLI encountered an error checking that your "
+                    "subscription has been onboarded to AOSM." in caplog.text
+                )

--- a/src/aosm/azext_aosm/tests/latest/test_nsd.py
+++ b/src/aosm/azext_aosm/tests/latest/test_nsd.py
@@ -131,7 +131,7 @@ class NFDVs:
 
 class AOSMClient:
     def __init__(self) -> None:
-        self.network_function_definition_versions = NFDVs()
+        self.proxy_network_function_definition_versions = NFDVs()
 
 
 mock_client = AOSMClient()

--- a/src/aosm/azext_aosm/util/constants.py
+++ b/src/aosm/azext_aosm/util/constants.py
@@ -98,3 +98,9 @@ SOURCE_ACR_REGEX = (
     r".*\/resourceGroups\/(?P<resource_group>[^\/]*)\/providers\/Microsoft."
     r"ContainerRegistry\/registries\/(?P<registry_name>[^\/]*)"
 )
+
+# Required features for AOSM publish aka deploy
+AOSM_FEATURE_NAMESPACE = "Microsoft.HybridNetwork"
+AOSM_REQUIRED_FEATURES = [
+    "Allow-2023-09-01",
+]

--- a/src/aosm/azext_aosm/util/constants.py
+++ b/src/aosm/azext_aosm/util/constants.py
@@ -90,15 +90,6 @@ IMAGE_NAME_AND_VERSION_REGEX = r"\/(?P<name>[^\s]*):(?P<version>[^\s)\"}]*)"
 
 DEPLOYMENT_PARAMETER_MAPPING_REGEX = r"\{deployParameters.(.+?)\}"
 
-# Assume that the registry id is of the form:
-# /subscriptions/<sub_id>/resourceGroups/<rg_name>/providers/
-#   Microsoft.ContainerRegistry/registries/<registry_name>
-# This returns groups for the resource group name and registry name
-SOURCE_ACR_REGEX = (
-    r".*\/resourceGroups\/(?P<resource_group>[^\/]*)\/providers\/Microsoft."
-    r"ContainerRegistry\/registries\/(?P<registry_name>[^\/]*)"
-)
-
 # Required features for AOSM publish aka deploy
 AOSM_FEATURE_NAMESPACE = "Microsoft.HybridNetwork"
 AOSM_REQUIRED_FEATURES = [

--- a/src/aosm/azext_aosm/util/management_clients.py
+++ b/src/aosm/azext_aosm/util/management_clients.py
@@ -5,9 +5,7 @@
 """Clients for the python SDK along with useful caches."""
 
 from dataclasses import dataclass
-from typing import Optional
 
-from azure.mgmt.containerregistry import ContainerRegistryManagementClient
 from azure.mgmt.resource import ResourceManagementClient
 from knack.log import get_logger
 

--- a/src/aosm/azext_aosm/util/management_clients.py
+++ b/src/aosm/azext_aosm/util/management_clients.py
@@ -22,4 +22,3 @@ class ApiClients:
 
     aosm_client: HybridNetworkManagementClient
     resource_client: ResourceManagementClient
-    container_registry_client: Optional[ContainerRegistryManagementClient] = None

--- a/src/service_name.json
+++ b/src/service_name.json
@@ -35,6 +35,11 @@
     "URL": ""
   },
   {
+    "Command": "az aosm",
+    "AzureServiceName": "Azure Operator Service Manager",
+    "URL": "https://learn.microsoft.com/azure/operator-service-manager"
+  },
+  {
     "Command": "az appservice",
     "AzureServiceName": "App Services",
     "URL": "https://learn.microsoft.com/azure/app-service"


### PR DESCRIPTION
The "GA" `add-aosm-extension` branch had got significantly out of sync with the `pre-release-add-aosm-extension` branch. This is a problem, as the latter is used to give other teams access, and e.g. quickstart guides no longer worked.

This PR re-syncs the two, excluding files that genuinely are different for GA (pipelines and README files).