### PR TITLE
Fix source_local_docker_image defaults to placeholder text

### DIFF
--- a/src/aosm/azext_aosm/_configuration.py
+++ b/src/aosm/azext_aosm/_configuration.py
@@ -293,6 +293,14 @@ class CNFImageConfig:
     source_registry_namespace: str = ""
     source_local_docker_image: str = ""
 
+    def __post_init__(self):
+        if self.source_registry == DESCRIPTION_MAP["source_registry"]:
+            self.source_registry = ""
+        if self.source_registry_namespace == DESCRIPTION_MAP["source_registry_namespace"]:
+            self.source_registry_namespace = ""
+        if self.source_local_docker_image == DESCRIPTION_MAP["source_local_docker_image"]:
+            self.source_local_docker_image = ""
+
 
 @dataclass
 class CNFConfiguration(NFConfiguration):
@@ -334,17 +342,16 @@ class CNFConfiguration(NFConfiguration):
         source_local_set = self.images.source_local_docker_image != ""
         source_reg_namespace_set = self.images.source_registry_namespace != ""
 
+        if source_reg_namespace_set and not source_reg_set:
+            raise ValidationError(
+                "Config validation error. The image source registry namespace should "
+                "only be configured if a source registry is configured."
+            )
         # If these are the same, either neither is set or both are, both of which are errors
         if source_reg_set == source_local_set:
             raise ValidationError(
                 "Config validation error. Images config must have either a local docker image"
                 " or a source registry, but not both."
-            )
-
-        if source_reg_namespace_set and not source_reg_set:
-            raise ValidationError(
-                "Config validation error. The image source registry namespace should "
-                "only be configured if a source registry is configured."
             )
 
 

--- a/src/aosm/azext_aosm/_configuration.py
+++ b/src/aosm/azext_aosm/_configuration.py
@@ -357,7 +357,7 @@ NFD_VERSION = (
 NFD_LOCATION = "The region that the NFDV is published to."
 PUBLISHER_RESOURCE_GROUP = "The resource group that the publisher is hosted in."
 PUBLISHER_NAME = "The name of the publisher that this NFDV is published under."
-PUBLISHER_SCOPE = "The scope that the publisher is published under. Currently, only 'private' is supported."
+PUBLISHER_SCOPE = "The scope that the publisher is published under. Only 'private' is supported."
 NFD_TYPE = "Type of Network Function. Valid values are 'cnf' or 'vnf'"
 MULTIPLE_INSTANCES = (
     "Set to true or false.  Whether the NSD should allow arbitrary numbers of this "
@@ -491,7 +491,11 @@ class NSConfiguration(Configuration):
             self.network_functions = nf_ret_list
 
     def validate(self):
-        # validate that all of the configuration parameters are set
+        """
+        Validate the configuration passed in.
+
+        :raises ValueError for any invalid config
+        """
 
         if self.location in (DESCRIPTION_MAP["location"], ""):
             raise ValueError("Location must be set")

--- a/src/aosm/azext_aosm/_configuration.py
+++ b/src/aosm/azext_aosm/_configuration.py
@@ -289,9 +289,9 @@ class HelmPackageConfig:
 class CNFImageConfig:
     """CNF Image config settings."""
 
-    source_registry: str = DESCRIPTION_MAP["source_registry"]
-    source_registry_namespace: str = DESCRIPTION_MAP["source_registry_namespace"]
-    source_local_docker_image: str = DESCRIPTION_MAP["source_local_docker_image"]
+    source_registry: str = ""
+    source_registry_namespace: str = ""
+    source_local_docker_image: str = ""
 
 
 @dataclass
@@ -329,20 +329,10 @@ class CNFConfiguration(NFConfiguration):
 
         :raises ValidationError: If source registry ID doesn't match the regex
         """
-        source_reg_set = (
-            self.images.source_registry
-            and self.images.source_registry != DESCRIPTION_MAP["source_registry"]
-        )
-        source_local_set = (
-            self.images.source_local_docker_image
-            and self.images.source_local_docker_image
-            != DESCRIPTION_MAP["source_local_docker_image"]
-        )
-        source_reg_namespace_set = (
-            self.images.source_registry_namespace
-            and self.images.source_registry_namespace
-            != DESCRIPTION_MAP["source_registry_namespace"]
-        )
+
+        source_reg_set = self.images.source_registry != ""
+        source_local_set = self.images.source_local_docker_image != ""
+        source_reg_namespace_set = self.images.source_registry_namespace != ""
 
         # If these are the same, either neither is set or both are, both of which are errors
         if source_reg_set == source_local_set:
@@ -423,9 +413,7 @@ class NFDRETConfiguration:  # pylint: disable=too-many-instance-attributes
 
         # Temporary validation while only private publishers exist
         if self.publisher_scope not in ["private", "Private"]:
-            raise ValidationError(
-                "Only private publishers are currently supported"
-            )
+            raise ValidationError("Only private publishers are currently supported")
 
         if self.type not in [CNF, VNF]:
             raise ValueError(

--- a/src/aosm/azext_aosm/_configuration.py
+++ b/src/aosm/azext_aosm/_configuration.py
@@ -294,11 +294,22 @@ class CNFImageConfig:
     source_local_docker_image: str = ""
 
     def __post_init__(self):
+        """
+        Cope with optional parameters being omitted in the loaded json config file.
+
+        If param is set to placeholder text, it is not in the config file and should be unset.
+        """
         if self.source_registry == DESCRIPTION_MAP["source_registry"]:
             self.source_registry = ""
-        if self.source_registry_namespace == DESCRIPTION_MAP["source_registry_namespace"]:
+        if (
+            self.source_registry_namespace
+            == DESCRIPTION_MAP["source_registry_namespace"]
+        ):
             self.source_registry_namespace = ""
-        if self.source_local_docker_image == DESCRIPTION_MAP["source_local_docker_image"]:
+        if (
+            self.source_local_docker_image
+            == DESCRIPTION_MAP["source_local_docker_image"]
+        ):
             self.source_local_docker_image = ""
 
 
@@ -364,7 +375,9 @@ NFD_VERSION = (
 NFD_LOCATION = "The region that the NFDV is published to."
 PUBLISHER_RESOURCE_GROUP = "The resource group that the publisher is hosted in."
 PUBLISHER_NAME = "The name of the publisher that this NFDV is published under."
-PUBLISHER_SCOPE = "The scope that the publisher is published under. Only 'private' is supported."
+PUBLISHER_SCOPE = (
+    "The scope that the publisher is published under. Only 'private' is supported."
+)
 NFD_TYPE = "Type of Network Function. Valid values are 'cnf' or 'vnf'"
 MULTIPLE_INSTANCES = (
     "Set to true or false.  Whether the NSD should allow arbitrary numbers of this "


### PR DESCRIPTION
---
Temporary fix for bug [919007 ](https://msazuredev.visualstudio.com/AzureForOperators/_workitems/edit/919007).
Follow on story raised to handle all optional inputs in cli

Behaviour remains the same for:
- Providing source_registry and source_local_docker_image
- Providing source_registry but not source_registry_namespace

Fixed error for:
- Providing both source_registry, source_registry_namespace but not source_local_docker_image

We should revisit this fix when we do proper refactor of optional parameters in CLI.

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

az aosm nfd build --config-file input.json --definition-type cnf

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
