### PR TITLE
Fix up helptext and validation to be a bit saner

### DIFF
--- a/src/aosm/azext_aosm/custom.py
+++ b/src/aosm/azext_aosm/custom.py
@@ -89,9 +89,14 @@ def generate_definition_config(definition_type: str, output_file: str = "input.j
 
     :param definition_type: CNF, VNF
     :param output_file: path to output config file, defaults to "input.json"
-    :type output_file: str, optional
     """
-    _generate_config(configuration_type=definition_type, output_file=output_file)
+    config: Configuration
+    if definition_type == CNF:
+        config = CNFConfiguration.helptext()
+    elif definition_type == VNF:
+        config = VNFConfiguration.helptext()
+
+    _generate_config(configuration=config, output_file=output_file)
 
 
 def _get_config_from_file(config_file: str, configuration_type: str) -> Configuration:
@@ -324,21 +329,21 @@ def generate_design_config(output_file: str = "input.json"):
     :param output_file: path to output config file, defaults to "input.json"
     :type output_file: str, optional
     """
-    _generate_config(NSD, output_file)
+    _generate_config(NSConfiguration.helptext(), output_file)
 
 
-def _generate_config(configuration_type: str, output_file: str = "input.json"):
+def _generate_config(configuration: Configuration, output_file: str = "input.json"):
     """
     Generic generate config function for NFDs and NSDs.
 
-    :param configuration_type: CNF, VNF or NSD
+    :param configuration: The Configuration object with helptext filled in for each of
+        the fields.
     :param output_file: path to output config file, defaults to "input.json"
-    :type output_file: str, optional
     """
     # Config file is a special parameter on the configuration objects.  It is the path
     # to the configuration file, rather than an input parameter.  It therefore shouldn't
     # be included here.
-    config = asdict(get_configuration(configuration_type))
+    config = asdict(configuration)
     config.pop("config_file")
 
     config_as_dict = json.dumps(config, indent=4)
@@ -353,10 +358,10 @@ def _generate_config(configuration_type: str, output_file: str = "input.json"):
 
     with open(output_file, "w", encoding="utf-8") as f:
         f.write(config_as_dict)
-        if configuration_type in (CNF, VNF):
-            prtName = "definition"
-        else:
+        if isinstance(configuration, NSConfiguration):
             prtName = "design"
+        else:
+            prtName = "definition"
         print(f"Empty {prtName} configuration has been written to {output_file}")
         logger.info(
             "Empty %s configuration has been written to %s", prtName, output_file

--- a/src/aosm/azext_aosm/deploy/pre_deploy.py
+++ b/src/aosm/azext_aosm/deploy/pre_deploy.py
@@ -418,9 +418,7 @@ class PreDeployerViaSDK:
             network_service_design_group_name=nsd_name,
             parameters=NetworkServiceDesignGroup(location=location),
         )
-        LongRunningOperation(self.cli_ctx, "Creating Network Service Design...")(
-            poller
-        )
+        LongRunningOperation(self.cli_ctx, "Creating Network Service Design...")(poller)
 
     def resource_exists_by_name(self, rg_name: str, resource_name: str) -> bool:
         """

--- a/src/aosm/azext_aosm/generate_nfd/cnf_nfd_generator.py
+++ b/src/aosm/azext_aosm/generate_nfd/cnf_nfd_generator.py
@@ -117,6 +117,8 @@ class CnfNfdGenerator(NFDGenerator):  # pylint: disable=too-many-instance-attrib
             try:
                 for helm_package in self.config.helm_packages:
                     # Unpack the chart into the tmp directory
+                    assert isinstance(helm_package, HelmPackageConfig)
+
                     self._extract_chart(Path(helm_package.path_to_chart))
 
                     # TODO: Validate charts

--- a/src/aosm/azext_aosm/generate_nfd/vnf_nfd_generator.py
+++ b/src/aosm/azext_aosm/generate_nfd/vnf_nfd_generator.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, Optional
 
 from knack.log import get_logger
 
-from azext_aosm._configuration import VNFConfiguration
+from azext_aosm._configuration import ArtifactConfig, VNFConfiguration
 from azext_aosm.generate_nfd.nfd_generator_base import NFDGenerator
 from azext_aosm.util.constants import (
     CONFIG_MAPPINGS_DIR_NAME,
@@ -63,6 +63,9 @@ class VnfNfdGenerator(NFDGenerator):
 
     def __init__(self, config: VNFConfiguration, order_params: bool, interactive: bool):
         self.config = config
+
+        assert isinstance(self.config.arm_template, ArtifactConfig)
+        assert self.config.arm_template.file_path
 
         self.arm_template_path = Path(self.config.arm_template.file_path)
         self.output_directory: Path = self.config.output_directory_for_build

--- a/src/aosm/azext_aosm/generate_nsd/nf_ret.py
+++ b/src/aosm/azext_aosm/generate_nsd/nf_ret.py
@@ -50,12 +50,14 @@ class NFRETGenerator:
             "Reading existing NFDV resource object "
             f"{config.version} from group {config.name}"
         )
-        nfdv_object = api_clients.aosm_client.proxy_network_function_definition_versions.get(
-            publisher_scope_name=config.publisher_scope,
-            publisher_location_name=config.publisher_offering_location,
-            proxy_publisher_name=config.publisher,
-            network_function_definition_group_name=config.name,
-            network_function_definition_version_name=config.version,
+        nfdv_object = (
+            api_clients.aosm_client.proxy_network_function_definition_versions.get(
+                publisher_scope_name=config.publisher_scope,
+                publisher_location_name=config.publisher_offering_location,
+                proxy_publisher_name=config.publisher,
+                network_function_definition_group_name=config.name,
+                network_function_definition_version_name=config.version,
+            )
         )
         return nfdv_object
 

--- a/src/aosm/azext_aosm/generate_nsd/nsd_generator.py
+++ b/src/aosm/azext_aosm/generate_nsd/nsd_generator.py
@@ -13,7 +13,7 @@ from typing import Any, Dict
 from jinja2 import Template
 from knack.log import get_logger
 
-from azext_aosm._configuration import NSConfiguration
+from azext_aosm._configuration import NFDRETConfiguration, NSConfiguration
 from azext_aosm.generate_nsd.nf_ret import NFRETGenerator
 from azext_aosm.util.constants import (
     CONFIG_MAPPINGS_DIR_NAME,
@@ -56,10 +56,14 @@ class NSDGenerator:  # pylint: disable=too-few-public-methods
         self.config = config
         self.nsd_bicep_template_name = NSD_DEFINITION_JINJA2_SOURCE_TEMPLATE
         self.nsd_bicep_output_name = NSD_BICEP_FILENAME
-        self.nf_ret_generators = [
-            NFRETGenerator(api_clients, nf_config, self.config.cg_schema_name)
-            for nf_config in self.config.network_functions
-        ]
+
+        self.nf_ret_generators = []
+
+        for nf_config in self.config.network_functions:
+            assert isinstance(nf_config, NFDRETConfiguration)
+            self.nf_ret_generators.append(
+                NFRETGenerator(api_clients, nf_config, self.config.cg_schema_name)
+            )
 
     def generate_nsd(self) -> None:
         """Generate a NSD templates which includes an Artifact Manifest, NFDV and NF templates."""

--- a/src/aosm/azext_aosm/tests/latest/mock_nsd/input.json
+++ b/src/aosm/azext_aosm/tests/latest/mock_nsd/input.json
@@ -15,7 +15,7 @@
             "publisher_scope": "private"
         }
     ],
-    "nsdg_name": "ubuntu",
+    "nsd_name": "ubuntu",
     "nsd_version": "1.0.0",
     "nsdv_description": "Plain ubuntu VM"
 }

--- a/src/aosm/azext_aosm/tests/latest/mock_nsd/input_multi_nf_nsd.json
+++ b/src/aosm/azext_aosm/tests/latest/mock_nsd/input_multi_nf_nsd.json
@@ -25,7 +25,7 @@
             "multiple_instances": false
         }
     ],
-    "nsdg_name": "multinf",
+    "nsd_name": "multinf",
     "nsd_version": "1.0.1",
     "nsdv_description": "Test deploying multiple NFs"
 }

--- a/src/aosm/azext_aosm/tests/latest/mock_nsd/input_multi_nf_nsd.json
+++ b/src/aosm/azext_aosm/tests/latest/mock_nsd/input_multi_nf_nsd.json
@@ -12,7 +12,7 @@
             "version": "1.0.0",
             "publisher_offering_location": "eastus",
             "type": "cnf",
-            "multiple_instances": false
+            "multiple_instances": "False"
         },
         {
             "publisher": "reference-publisher",

--- a/src/aosm/azext_aosm/tests/latest/mock_nsd/input_multiple_instances.json
+++ b/src/aosm/azext_aosm/tests/latest/mock_nsd/input_multiple_instances.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "publisher_offering_location": "eastus",
             "type": "vnf",
-            "multiple_instances": true,
+            "multiple_instances": "True",
             "publisher_scope": "private",
             "publisher": "jamie-mobile-publisher",
             "publisher_resource_group": "Jamie-publisher"

--- a/src/aosm/azext_aosm/tests/latest/mock_nsd/input_multiple_instances.json
+++ b/src/aosm/azext_aosm/tests/latest/mock_nsd/input_multiple_instances.json
@@ -15,7 +15,7 @@
             "publisher_resource_group": "Jamie-publisher"
         }
     ],
-    "nsdg_name": "ubuntu",
+    "nsd_name": "ubuntu",
     "nsd_version": "1.0.0",
     "nsdv_description": "Plain ubuntu VM"
 }

--- a/src/aosm/azext_aosm/tests/latest/scenario_test_mocks/mock_input_templates/cnf_nsd_input_template.json
+++ b/src/aosm/azext_aosm/tests/latest/scenario_test_mocks/mock_input_templates/cnf_nsd_input_template.json
@@ -15,7 +15,7 @@
             "publisher_resource_group": "{{publisher_resource_group_name}}"
         }
     ],
-    "nsdg_name": "nginx",
+    "nsd_name": "nginx",
     "nsd_version": "1.0.0",
     "nsdv_description": "Deploys a basic NGINX CNF"
 }

--- a/src/aosm/azext_aosm/tests/latest/scenario_test_mocks/mock_input_templates/vnf_nsd_input_template.json
+++ b/src/aosm/azext_aosm/tests/latest/scenario_test_mocks/mock_input_templates/vnf_nsd_input_template.json
@@ -15,7 +15,7 @@
             "publisher_resource_group": "{{publisher_resource_group_name}}"
         }
     ],
-    "nsdg_name": "ubuntu",
+    "nsd_name": "ubuntu",
     "nsd_version": "1.0.0",
     "nsdv_description": "Plain ubuntu VM"
 }


### PR DESCRIPTION
I've created explicit helptext commands on each of the configuration objects.  That means that we don't have to use the defaults for the helptext anymore, so can set actual defaults if we want to.  That also means that none of the validation/__post_init__ functions have to worry about fields being set to helptext strings.

I've also tidied up validation, such that all the validation commands are called in a cascading manner when we are ready, rather than in an adhoc manner from other functions.

The live publisher test is failing, but it is something to do with not finding a proxy publisher resource.  This is unrelated to this change and we are just about to remove the proxy publisher stuff, so I'm not going to worry about it for now.