### PR TITLE
Return True if _all_ required artifact manifests exist, not just the last one checked.

### DIFF
--- a/src/aosm/azext_aosm/deploy/pre_deploy.py
+++ b/src/aosm/azext_aosm/deploy/pre_deploy.py
@@ -384,7 +384,7 @@ class PreDeployerViaSDK:
                 )
             return False
 
-        return acr_manny_exists
+        return all_acr_mannys_exist
 
     def ensure_nsd_exists(
         self,


### PR DESCRIPTION
One line fix to return True if all required artifact manifests exist, not just the last one checked.