### PR TITLE
Check pre release ff not ga

### DIFF
--- a/src/aosm/README.md
+++ b/src/aosm/README.md
@@ -88,6 +88,10 @@ When filling in the input.json file, you must list helm packages in the order th
 #### NSDs
 For NSDs, you will need to have a Resource Group with a deployed Publisher, Artifact Store, Network Function Definition and Network Function Definition Version. You can use the `az aosm nfd` commands to create all of these resources.
 
+#### Subscription Feature Flags
+For this pre-release version of the CLI, your subscription needs to have enabled the following Feature Flags:
+- `Microsoft.HybridNetwork/AllowPreReleaseFeatures`
+- `Microsoft.HybridNetwork/Allow-2023-04-01-preview`
 
 ### Command examples
 

--- a/src/aosm/azext_aosm/util/constants.py
+++ b/src/aosm/azext_aosm/util/constants.py
@@ -93,5 +93,7 @@ DEPLOYMENT_PARAMETER_MAPPING_REGEX = r"\{deployParameters.(.+?)\}"
 # Required features for AOSM publish aka deploy
 AOSM_FEATURE_NAMESPACE = "Microsoft.HybridNetwork"
 AOSM_REQUIRED_FEATURES = [
-    "Allow-2023-09-01",
+    "AllowPreReleaseFeatures",
+    "Allow-2023-04-01-preview",
+    # "Allow-2023-09-01", Not done on pre-release AOSM
 ]


### PR DESCRIPTION
Revert accidental pre-release merge of https://github.com/jddarby/azure-cli-extensions/pull/71 but change it to check for the FF you need for pre-release. https://eng.ms/docs/strategic-missions-and-technologies/strategic-missions-and-technologies-organization/azure-for-operators/aiops/aiops-orchestration/aosm-product-docs/shared_infrastructure/ansm_onboarding 

Anand told me that the MsiForResourceEnabled one isn't required any more, so I am not checking for that one.

The GA release deliberately doesn't have the FF names listed in the README.md as Peter told me they are somehow "hidden" FF, and the customer shouldn't know their names, just to follow the onboarding docs.  The Pre-release ones I think are useful though.

I've tested this on our UK subscription. 