### PR TITLE
Don't log out ACR passwords when artifact commands fail

### DIFF
--- a/src/aosm/azext_aosm/deploy/artifact.py
+++ b/src/aosm/azext_aosm/deploy/artifact.py
@@ -88,33 +88,33 @@ class Artifact:
         :param cmd: command to run, in list format
         :raise CLIError: if the subprocess fails
         """
+        log_cmd = cmd.copy()
+        if "--password" in log_cmd:
+            # Do not log out passwords.
+            log_cmd[log_cmd.index("--password") + 1] = "[REDACTED]"
+
         try:
             called_process = subprocess.run(
                 cmd, encoding="utf-8", capture_output=True, text=True, check=True
             )
             logger.debug(
                 "Output from %s: %s. Error: %s",
-                cmd,
+                log_cmd,
                 called_process.stdout,
                 called_process.stderr,
             )
         except subprocess.CalledProcessError as error:
-            logger.debug("Failed to run %s with %s", cmd, error)
-
-            if "--password" in cmd:
-                # Do not log out passwords.
-                log_cmd = cmd.copy()
-                log_cmd[log_cmd.index("--password") + 1] = "[REDACTED]"
+            logger.debug("Failed to run %s with %s", log_cmd, error)
 
             all_output: str = (
-                f"Command: {'' ''.join(cmd)}\n"
+                f"Command: {'' ''.join(log_cmd)}\n"
                 f"Output: {error.stdout}\n"
                 f"Error output: {error.stderr}\n"
                 f"Return code: {error.returncode}"
             )
             logger.debug("All the output %s", all_output)
 
-            raise CLIError(all_output) from error
+            raise CLIError(all_output) from None
 
     def _upload_helm_to_acr(
         self, artifact_config: HelmPackageConfig, use_manifest_permissions: bool

--- a/src/aosm/azext_aosm/deploy/artifact.py
+++ b/src/aosm/azext_aosm/deploy/artifact.py
@@ -114,6 +114,7 @@ class Artifact:
             )
             logger.debug("All the output %s", all_output)
 
+            # Raise the error without the original exception, which may contain secrets.
             raise CLIError(all_output) from None
 
     def _upload_helm_to_acr(

--- a/src/aosm/azext_aosm/deploy/artifact.py
+++ b/src/aosm/azext_aosm/deploy/artifact.py
@@ -101,6 +101,11 @@ class Artifact:
         except subprocess.CalledProcessError as error:
             logger.debug("Failed to run %s with %s", cmd, error)
 
+            if "--password" in cmd:
+                # Do not log out passwords.
+                log_cmd = cmd.copy()
+                log_cmd[log_cmd.index("--password") + 1] = "[REDACTED]"
+
             all_output: str = (
                 f"Command: {'' ''.join(cmd)}\n"
                 f"Output: {error.stdout}\n"


### PR DESCRIPTION
Fix for ADO bug 922085.

If a publish command fails to push to an ACR, the error is logged out including the command used - which also includes the password in-line. It feels like a security hole waiting to happen to do this and not adequately warn customers that it will happen should they want to send out their logs to somewhere, which would inevitably lead to plaintext transmission of secrets and possible scope for leaks.

Therefore, remove the password from the log before outputting.
