### PR TITLE
Fix CNF image copy to work cross subscription

### DIFF
--- a/src/aosm/azext_aosm/deploy/deploy_with_arm.py
+++ b/src/aosm/azext_aosm/deploy/deploy_with_arm.py
@@ -226,7 +226,7 @@ class DeployerViaArm:  # pylint: disable=too-many-instance-attributes
 
         for helm_package in self.config.helm_packages:
             # Go through the helm packages in the config that the user has provided
-            helm_package_name = helm_package.name
+            helm_package_name = helm_package.name  # type: ignore
 
             if helm_package_name not in artifact_dictionary:
                 # Helm package in the config file but not in the artifact manifest
@@ -267,7 +267,7 @@ class DeployerViaArm:  # pylint: disable=too-many-instance-attributes
             )
         for artifact in artifact_dictionary.values():
             assert isinstance(artifact, Artifact)
-            artifact.upload(self.config.images, self.use_manifest_permissions)
+            artifact.upload(self.config.images, self.use_manifest_permissions)  # type: ignore
 
     def nfd_predeploy(self) -> bool:
         """

--- a/src/aosm/azext_aosm/util/constants.py
+++ b/src/aosm/azext_aosm/util/constants.py
@@ -95,7 +95,7 @@ DEPLOYMENT_PARAMETER_MAPPING_REGEX = r"\{deployParameters.(.+?)\}"
 #   Microsoft.ContainerRegistry/registries/<registry_name>
 # This returns groups for the resource group name and registry name
 SOURCE_ACR_REGEX = (
-    r".*\/resourceGroups\/(?P<resource_group>[^\/]*)\/providers\/Microsoft."
+    r".*\/resource[G|g]roups\/(?P<resource_group>[^\/]*)\/providers\/Microsoft."
     r"ContainerRegistry\/registries\/(?P<registry_name>[^\/]*)"
 )
 


### PR DESCRIPTION
CLOSING THIS PR because decided to do it a different way.

https://github.com/jddarby/azure-cli-extensions/pull/72/ introduced a bug for CNF image copy, where it only worked if the source and target ACR were in the same subscription. 

https://learn.microsoft.com/en-us/azure/container-registry/container-registry-import-images?tabs=azure-cli#import-from-a-registry-in-a-different-subscription explains the syntax for `az acr import` cross subscription and explains that this also works in the same subscription.

This fixes that by using --registry in the command and having the image name as just repo/image:tag rather than containing the registry name as well.

Tested cross subscription with all three ways of image tranfser:
- copy
- docker pull and push
- docker push from local image