### PR TITLE
Move live tests to uaenorth

### DIFF
--- a/src/aosm/azext_aosm/tests/latest/scenario_test_mocks/mock_input_templates/cnf_input_template.json
+++ b/src/aosm/azext_aosm/tests/latest/scenario_test_mocks/mock_input_templates/cnf_input_template.json
@@ -4,7 +4,7 @@
     "nf_name": "nginx",
     "version": "1.0.0",
     "acr_artifact_store_name": "nginx-nsd-acr",
-    "location": "swedensouth",
+    "location": "uaenorth",
     "images":{
         "source_registry": "{{source_registry_id}}",
         "source_registry_namespace": ""

--- a/src/aosm/azext_aosm/tests/latest/scenario_test_mocks/mock_input_templates/cnf_input_template.json
+++ b/src/aosm/azext_aosm/tests/latest/scenario_test_mocks/mock_input_templates/cnf_input_template.json
@@ -4,7 +4,7 @@
     "nf_name": "nginx",
     "version": "1.0.0",
     "acr_artifact_store_name": "nginx-nsd-acr",
-    "location": "westcentralus",
+    "location": "swedensouth",
     "images":{
         "source_registry": "{{source_registry_id}}",
         "source_registry_namespace": ""

--- a/src/aosm/azext_aosm/tests/latest/scenario_test_mocks/mock_input_templates/cnf_nsd_input_template.json
+++ b/src/aosm/azext_aosm/tests/latest/scenario_test_mocks/mock_input_templates/cnf_nsd_input_template.json
@@ -1,5 +1,5 @@
 {
-    "location": "swedensouth",
+    "location": "uaenorth",
     "publisher_name": "nginx-publisher",
     "publisher_resource_group_name": "{{publisher_resource_group_name}}",
     "acr_artifact_store_name": "nginx-nsd-acr",
@@ -7,7 +7,7 @@
         {
             "name": "nginx-nfdg",
             "version": "1.0.0",
-            "publisher_offering_location": "swedensouth",
+            "publisher_offering_location": "uaenorth",
             "type": "cnf",
             "multiple_instances": false,
             "publisher": "nginx-publisher",

--- a/src/aosm/azext_aosm/tests/latest/scenario_test_mocks/mock_input_templates/cnf_nsd_input_template.json
+++ b/src/aosm/azext_aosm/tests/latest/scenario_test_mocks/mock_input_templates/cnf_nsd_input_template.json
@@ -1,5 +1,5 @@
 {
-    "location": "westcentralus",
+    "location": "swedensouth",
     "publisher_name": "nginx-publisher",
     "publisher_resource_group_name": "{{publisher_resource_group_name}}",
     "acr_artifact_store_name": "nginx-nsd-acr",
@@ -7,7 +7,7 @@
         {
             "name": "nginx-nfdg",
             "version": "1.0.0",
-            "publisher_offering_location": "westcentralus",
+            "publisher_offering_location": "swedensouth",
             "type": "cnf",
             "multiple_instances": false,
             "publisher": "nginx-publisher",

--- a/src/aosm/azext_aosm/tests/latest/scenario_test_mocks/mock_input_templates/vnf_input_template.json
+++ b/src/aosm/azext_aosm/tests/latest/scenario_test_mocks/mock_input_templates/vnf_input_template.json
@@ -2,7 +2,7 @@
     "publisher_name": "ubuntuPublisher",
     "publisher_resource_group_name": "{{publisher_resource_group_name}}",
     "acr_artifact_store_name": "ubuntu-acr",
-    "location": "westcentralus",
+    "location": "swedensouth",
     "nf_name": "ubuntu-vm",
     "version": "1.0.0",
     "blob_artifact_store_name": "ubuntu-blob-store",

--- a/src/aosm/azext_aosm/tests/latest/scenario_test_mocks/mock_input_templates/vnf_input_template.json
+++ b/src/aosm/azext_aosm/tests/latest/scenario_test_mocks/mock_input_templates/vnf_input_template.json
@@ -2,7 +2,7 @@
     "publisher_name": "ubuntuPublisher",
     "publisher_resource_group_name": "{{publisher_resource_group_name}}",
     "acr_artifact_store_name": "ubuntu-acr",
-    "location": "swedensouth",
+    "location": "uaenorth",
     "nf_name": "ubuntu-vm",
     "version": "1.0.0",
     "blob_artifact_store_name": "ubuntu-blob-store",

--- a/src/aosm/azext_aosm/tests/latest/scenario_test_mocks/mock_input_templates/vnf_nsd_input_template.json
+++ b/src/aosm/azext_aosm/tests/latest/scenario_test_mocks/mock_input_templates/vnf_nsd_input_template.json
@@ -1,5 +1,5 @@
 {
-    "location": "swedensouth",
+    "location": "uaenorth",
     "publisher_name": "ubuntuPublisher",
     "publisher_resource_group_name": "{{publisher_resource_group_name}}",
     "acr_artifact_store_name": "ubuntu-acr",
@@ -7,7 +7,7 @@
         {
             "name": "ubuntu-vm-nfdg",
             "version": "1.0.0",
-            "publisher_offering_location": "swedensouth",
+            "publisher_offering_location": "uaenorth",
             "type": "vnf",
             "multiple_instances": false,
             "publisher": "ubuntuPublisher",

--- a/src/aosm/azext_aosm/tests/latest/scenario_test_mocks/mock_input_templates/vnf_nsd_input_template.json
+++ b/src/aosm/azext_aosm/tests/latest/scenario_test_mocks/mock_input_templates/vnf_nsd_input_template.json
@@ -1,5 +1,5 @@
 {
-    "location": "westcentralus",
+    "location": "swedensouth",
     "publisher_name": "ubuntuPublisher",
     "publisher_resource_group_name": "{{publisher_resource_group_name}}",
     "acr_artifact_store_name": "ubuntu-acr",
@@ -7,7 +7,7 @@
         {
             "name": "ubuntu-vm-nfdg",
             "version": "1.0.0",
-            "publisher_offering_location": "westcentralus",
+            "publisher_offering_location": "swedensouth",
             "type": "vnf",
             "multiple_instances": false,
             "publisher": "ubuntuPublisher",

--- a/src/aosm/azext_aosm/tests/latest/test_aosm_cnf_publish_and_delete.py
+++ b/src/aosm/azext_aosm/tests/latest/test_aosm_cnf_publish_and_delete.py
@@ -65,7 +65,7 @@ class CnfNsdTest(LiveScenarioTest):
     which does not work when playing back from the recording.
     """
 
-    @ResourceGroupPreparer(name_prefix="cli_test_cnf_nsd_", location="westcentralus")
+    @ResourceGroupPreparer(name_prefix="cli_test_cnf_nsd_", location="swedensouth")
     def test_cnf_nsd_publish_and_delete(self, resource_group):
         """
         This test creates a cnf nfd and nsd, publishes them, and then deletes them.

--- a/src/aosm/azext_aosm/tests/latest/test_aosm_cnf_publish_and_delete.py
+++ b/src/aosm/azext_aosm/tests/latest/test_aosm_cnf_publish_and_delete.py
@@ -65,7 +65,7 @@ class CnfNsdTest(LiveScenarioTest):
     which does not work when playing back from the recording.
     """
 
-    @ResourceGroupPreparer(name_prefix="cli_test_cnf_nsd_", location="swedensouth")
+    @ResourceGroupPreparer(name_prefix="cli_test_cnf_nsd_", location="uaenorth")
     def test_cnf_nsd_publish_and_delete(self, resource_group):
         """
         This test creates a cnf nfd and nsd, publishes them, and then deletes them.

--- a/src/aosm/azext_aosm/tests/latest/test_aosm_vnf_publish_and_delete.py
+++ b/src/aosm/azext_aosm/tests/latest/test_aosm_vnf_publish_and_delete.py
@@ -84,7 +84,7 @@ class VnfNsdTest(ScenarioTest):
             ],
         )
 
-    @ResourceGroupPreparer(name_prefix="cli_test_vnf_nsd_", location="swedensouth")
+    @ResourceGroupPreparer(name_prefix="cli_test_vnf_nsd_", location="uaenorth")
     def test_vnf_nsd_publish_and_delete(self, resource_group):
         """
         This test creates a vnf nfd and nsd, publishes them, and then deletes them.

--- a/src/aosm/azext_aosm/tests/latest/test_aosm_vnf_publish_and_delete.py
+++ b/src/aosm/azext_aosm/tests/latest/test_aosm_vnf_publish_and_delete.py
@@ -84,7 +84,7 @@ class VnfNsdTest(ScenarioTest):
             ],
         )
 
-    @ResourceGroupPreparer(name_prefix="cli_test_vnf_nsd_", location="westcentralus")
+    @ResourceGroupPreparer(name_prefix="cli_test_vnf_nsd_", location="swedensouth")
     def test_vnf_nsd_publish_and_delete(self, resource_group):
         """
         This test creates a vnf nfd and nsd, publishes them, and then deletes them.


### PR DESCRIPTION
Our live tests were using westcentralus. 

This region has been reserved for billing tests, and no one else should be deploying to it.

This PR moves our live tests to use uaenorth. This is intentionally _not_ uksouth, as developers often do their manual testing there, and this provides a little more regional coverage.