### PR TITLE
Fix cnf image take 2

### DIFF
--- a/src/aosm/azext_aosm/deploy/artifact.py
+++ b/src/aosm/azext_aosm/deploy/artifact.py
@@ -598,6 +598,20 @@ class Artifact:
                     " only to the store. This requires Docker to be installed"
                     " locally."
                 ) from error
+        except subprocess.CalledProcessError as get_token_err:
+            # This error is thrown from the az account get-access-token command
+            # If it errored we can log the output as it doesn't contain the token
+            logger.debug(get_token_err, exc_info=True)
+            raise CLIError(  # pylint: disable=raise-missing-from
+                "Failed to import image: could not get an access token from your"
+                " Azure account. Try logging in again with `az login` and then re-run"
+                " the command. If it fails again, please raise an issue and try"
+                " repeating the command using the --no-subscription-permissions"
+                " flag to pull the image to your local machine and then"
+                " push it to the Artifact Store using manifest credentials scoped"
+                " only to the store. This requires Docker to be installed"
+                " locally."
+            )
 
             # The most likely failure is that the image already exists in the artifact
             # store, so don't fail at this stage, log the error.

--- a/src/aosm/azext_aosm/deploy/artifact.py
+++ b/src/aosm/azext_aosm/deploy/artifact.py
@@ -121,10 +121,10 @@ class Artifact:
         Requires helm to be installed.
 
         :param artifact_config: configuration for the artifact being uploaded
-        :param use_manifest_permissions: whether to use the manifest credentials
-               for the upload. If False, the CLI user credentials will be used, which
-               does not require Docker to be installed. If True, the manifest creds will
-               be used, which requires Docker.
+        :param use_manifest_permissions: whether to use the manifest credentials for the
+            upload. If False, the CLI user credentials will be used, which does not
+            require Docker to be installed. If True, the manifest creds will be used,
+            which requires Docker.
         """
         self._check_tool_installed("helm")
         assert isinstance(self.artifact_client, OrasClient)
@@ -296,7 +296,7 @@ class Artifact:
 
     def _get_acr(self) -> str:
         """
-        Get the name of the ACR
+        Get the name of the ACR.
 
         :return: The name of the ACR
         """
@@ -387,7 +387,7 @@ class Artifact:
         Push image to target registry using docker push. Requires docker.
 
         :param local_docker_image: name and tag of the source image on local registry
-                                    e.g. uploadacr.azurecr.io/samples/nginx:stable
+            e.g. uploadacr.azurecr.io/samples/nginx:stable
         :type local_docker_image: str
         :param target_username: The username to use for the az acr login attempt
         :type target_username: str
@@ -461,8 +461,8 @@ class Artifact:
         Uses the CLI user's context to log in to the source registry.
 
         :param: source_registry_login_server: e.g. uploadacr.azurecr.io
-        :param: source_image: source docker image name
-                              e.g. uploadacr.azurecr.io/samples/nginx:stable
+        :param: source_image: source docker image name e.g.
+            uploadacr.azurecr.io/samples/nginx:stable
         """
         try:
             # Login to the source registry with the CLI user credentials. This requires
@@ -543,15 +543,15 @@ class Artifact:
             # least for public ACRs).  It probably won't work cross-tenant as the token
             # is retrieved from the CLI user's context which will be in the target
             # tenant.
-            get_token_cmd = [
-                str(shutil.which("az")),
-                "account",
-                "get-access-token"
-            ]
+            get_token_cmd = [str(shutil.which("az")), "account", "get-access-token"]
             # Dont use _call_subprocess_raise_output here as we don't want to log the
             # output
             called_process = subprocess.run(
-                get_token_cmd, encoding="utf-8", capture_output=True, text=True, check=True
+                get_token_cmd,
+                encoding="utf-8",
+                capture_output=True,
+                text=True,
+                check=True,
             )
             access_token_json = json.loads(called_process.stdout)
             access_token = access_token_json["accessToken"]
@@ -568,7 +568,7 @@ class Artifact:
                 "--image",
                 self._get_acr_target_image(include_hostname=False),
                 "--password",
-                access_token
+                access_token,
             ]
             self._call_subprocess_raise_output(acr_import_image_cmd)
         except CLIError as error:

--- a/src/aosm/azext_aosm/deploy/artifact.py
+++ b/src/aosm/azext_aosm/deploy/artifact.py
@@ -598,6 +598,19 @@ class Artifact:
                     " only to the store. This requires Docker to be installed"
                     " locally."
                 ) from error
+
+            # The most likely failure is that the image already exists in the artifact
+            # store, so don't fail at this stage, log the error.
+            logger.error(
+                (
+                    "Failed to import %s to %s. Check if this image exists in the"
+                    " source registry or is already present in the target registry.\n"
+                    "%s"
+                ),
+                source_image,
+                target_acr,
+                error,
+            )
         except subprocess.CalledProcessError as get_token_err:
             # This error is thrown from the az account get-access-token command
             # If it errored we can log the output as it doesn't contain the token
@@ -611,17 +624,4 @@ class Artifact:
                 " push it to the Artifact Store using manifest credentials scoped"
                 " only to the store. This requires Docker to be installed"
                 " locally."
-            )
-
-            # The most likely failure is that the image already exists in the artifact
-            # store, so don't fail at this stage, log the error.
-            logger.error(
-                (
-                    "Failed to import %s to %s. Check if this image exists in the"
-                    " source registry or is already present in the target registry.\n"
-                    "%s"
-                ),
-                source_image,
-                target_acr,
-                error,
             )

--- a/src/aosm/azext_aosm/deploy/deploy_with_arm.py
+++ b/src/aosm/azext_aosm/deploy/deploy_with_arm.py
@@ -226,7 +226,7 @@ class DeployerViaArm:  # pylint: disable=too-many-instance-attributes
 
         for helm_package in self.config.helm_packages:
             # Go through the helm packages in the config that the user has provided
-            helm_package_name = helm_package.name
+            helm_package_name = helm_package.name  # type: ignore
 
             if helm_package_name not in artifact_dictionary:
                 # Helm package in the config file but not in the artifact manifest
@@ -240,7 +240,7 @@ class DeployerViaArm:  # pylint: disable=too-many-instance-attributes
 
             # The artifact object will use the correct client (ORAS) to upload the
             # artifact
-            manifest_artifact.upload(helm_package, self.use_manifest_permissions)
+            manifest_artifact.upload(helm_package, self.use_manifest_permissions)  # type: ignore
 
             print(f"Finished uploading Helm package: {helm_package_name}")
 
@@ -258,7 +258,7 @@ class DeployerViaArm:  # pylint: disable=too-many-instance-attributes
         # so we validate the config file here.
         if (
             len(artifact_dictionary.values()) > 1
-            and self.config.images.source_local_docker_image
+            and self.config.images.source_local_docker_image  # type: ignore
         ):
             raise ValidationError(
                 "Multiple image artifacts found to upload and a local docker image"
@@ -267,7 +267,7 @@ class DeployerViaArm:  # pylint: disable=too-many-instance-attributes
             )
         for artifact in artifact_dictionary.values():
             assert isinstance(artifact, Artifact)
-            artifact.upload(self.config.images, self.use_manifest_permissions)
+            artifact.upload(self.config.images, self.use_manifest_permissions)  # type: ignore
 
     def nfd_predeploy(self) -> bool:
         """


### PR DESCRIPTION
https://github.com/jddarby/azure-cli-extensions/pull/72 introduced a bug for CNF image copy, where it only worked if the source and target ACR were in the same subscription.

Attempt 2 to fix this. Rejected attempt 1 was here: https://github.com/jddarby/azure-cli-extensions/pull/98

https://learn.microsoft.com/en-us/azure/container-registry/container-registry-import-images?tabs=azure-cli#import-from-a-registry-in-a-different-subscription explains the syntax for az acr import cross subscription and explains that this also works in the same subscription.

This fixes that by getting an access token for the current CLI user and using that as the password on the az acr import command.  This is documented as the way to access an ACR from a different tenant, but I've tested it and it also works for an ACR on a different subscription

Tested:
- cross subscription, same tenant 
- same subscription
- same subscription - private ACR.   This fails with 
`Message: Operation registries-98e5b0d2-6139-11ee-89fc-00155d83a358 failed. Resource /subscriptions/602a6b57-fb02-4c3d-bc44-5f8852be10ee/resourceGroups/sunny-smf-cli-acr2-hostedresources-50fc284b/providers/Microsoft.ContainerRegistry/registries/sunnysmfclipubsunnysmfcliacr28d7b1c689e Invalid message Forbidden Forbidden {"errors":[{"code":"DENIED","message":"client with IP \u002720.62.128.25\u0027 is not allowed access. Refer https://aka.ms/acr/firewall to grant access."}]}`
After thinking about this, decided this is ok.  Using a private ACR is beyond the scope of this fix, and from looking at the docs, I don't think it would require a change to input.json - just more documentation on how to set up your private endpoint / private link etc, and testing. So leaving this for the future.
- Error on az acr import hits the right branch of error logging and screen reporting. 
- Error on az account get-access-token hits the right branch of error logging
- I have not tested on a different tenant as a) it's problematic to sort one, b) I don't think it will work anyway c) I don't think we have a lot of use-case for it.