### PR TITLE
Default RG and ACR Values with Publisher Name

### DIFF
--- a/src/aosm/azext_aosm/_configuration.py
+++ b/src/aosm/azext_aosm/_configuration.py
@@ -57,7 +57,7 @@ class ArtifactConfig:
         Validate the configuration.
         """
         if not self.version:
-            raise ValidationError("version must be set.")
+            raise ValidationError("Version must be set.")
         if self.blob_sas_url and self.file_path:
             raise ValidationError("Only one of file_path or blob_sas_url may be set.")
         if not (self.blob_sas_url or self.file_path):
@@ -72,6 +72,16 @@ class Configuration(abc.ABC):
     acr_artifact_store_name: str = ""
     location: str = ""
 
+    def __post_init__(self):
+        """
+        Set defaults for resource group and ACR as the publisher name tagged with -rg or -acr
+        """
+        if self.publisher_name:
+            if not self.publisher_resource_group_name:
+                self.publisher_resource_group_name = f"{self.publisher_name}-rg"
+            if not self.acr_artifact_store_name:
+                self.acr_artifact_store_name = f"{self.publisher_name}-acr"
+
     @classmethod
     def helptext(cls):
         """
@@ -83,11 +93,12 @@ class Configuration(abc.ABC):
                 "Will be created if it does not exist."
             ),
             publisher_resource_group_name=(
-                "Resource group for the Publisher resource. "
-                "Will be created if it does not exist."
+                "Optional. Resource group for the Publisher resource. "
+                "Will be created if it does not exist (with a default name if none is supplied)."
             ),
             acr_artifact_store_name=(
-                "Name of the ACR Artifact Store resource. Will be created if it does not exist."
+                "Optional. Name of the ACR Artifact Store resource. "
+                "Will be created if it does not exist (with a default name if none is supplied)."
             ),
             location="Azure location to use when creating resources.",
         )
@@ -203,8 +214,8 @@ class VNFConfiguration(NFConfiguration):
         """
         return VNFConfiguration(
             blob_artifact_store_name=(
-                "Name of the storage account Artifact Store resource. Will be created if it "
-                "does not exist."
+                "Optional. Name of the storage account Artifact Store resource. Will be created if it "
+                "does not exist (with a default name if none is supplied)."
             ),
             image_name_parameter=(
                 "The parameter name in the VM ARM template which specifies the name of the "
@@ -221,6 +232,10 @@ class VNFConfiguration(NFConfiguration):
 
         Used when creating VNFConfiguration object from a loaded json config file.
         """
+        super().__post_init__()
+        if self.publisher_name and not self.blob_artifact_store_name:
+            self.blob_artifact_store_name = f"{self.publisher_name}-sa"
+
         if isinstance(self.arm_template, dict):
             self.arm_template["file_path"] = self.path_from_cli_dir(
                 self.arm_template["file_path"]
@@ -383,6 +398,7 @@ class CNFConfiguration(NFConfiguration):
 
         Used when creating CNFConfiguration object from a loaded json config file.
         """
+        super().__post_init__()
         for package_index, package in enumerate(self.helm_packages):
             if isinstance(package, dict):
                 package["path_to_chart"] = self.path_from_cli_dir(
@@ -580,6 +596,7 @@ class NSConfiguration(Configuration):
 
     def __post_init__(self):
         """Covert things to the correct format."""
+        super().__post_init__()
         if self.network_functions and isinstance(self.network_functions[0], dict):
             nf_ret_list = [
                 NFDRETConfiguration(**config) for config in self.network_functions

--- a/src/aosm/azext_aosm/_configuration.py
+++ b/src/aosm/azext_aosm/_configuration.py
@@ -57,7 +57,7 @@ class ArtifactConfig:
         Validate the configuration.
         """
         if not self.version:
-            raise ValidationError("Version must be set.")
+            raise ValidationError("version must be set.")
         if self.blob_sas_url and self.file_path:
             raise ValidationError("Only one of file_path or blob_sas_url may be set.")
         if not (self.blob_sas_url or self.file_path):

--- a/src/aosm/azext_aosm/generate_nfd/cnf_nfd_generator.py
+++ b/src/aosm/azext_aosm/generate_nfd/cnf_nfd_generator.py
@@ -709,12 +709,12 @@ class CnfNfdGenerator(NFDGenerator):  # pylint: disable=too-many-instance-attrib
                         final_values_mapping_dict[k].append(
                             self._replace_values_with_deploy_params(item, param_name)
                         )
-                    elif isinstance(v, (str, int, bool)) or not v:
+                    elif isinstance(item, (str, int, bool)) or not v:
                         replacement_value = f"{{deployParameters.{param_name}}}"
                         final_values_mapping_dict[k].append(replacement_value)
                     else:
                         raise ValueError(
-                            f"Found an unexpected type {type(v)} of key {k} in "
+                            f"Found an unexpected type {type(item)} of key {k} in "
                             "values.yaml, cannot generate values mapping file."
                         )
             elif not v:


### PR DESCRIPTION
- Added default rg and acr values for nf + nsd based on publisher name
- Added blob_url default for VNF based on publisher name
- Updated helptext 
- Added fix for bug https://dev.azure.com/msazuredev/AzureForOperators/_workitems/edit/920284, as very minor change

Testing when no RG or ACR given:
- VNF no errors on build (did not try to test further)
- CNF no errors on build, successful publish of publisher, RG and ACR
- NSD: no errors on build, successful publish of all resources

Testing with both RG and ACR given:
- Tested with CNF and NSD, behaviour as before
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
