### PR TITLE
Fix unexpected additional symbol when parsing a list in values.yaml

### DIFF
--- a/src/aosm/azext_aosm/generate_nfd/cnf_nfd_generator.py
+++ b/src/aosm/azext_aosm/generate_nfd/cnf_nfd_generator.py
@@ -703,7 +703,7 @@ class CnfNfdGenerator(NFDGenerator):  # pylint: disable=too-many-instance-attrib
                     param_name = (
                         f"{param_prefix}_{k}_{index}"
                         if param_prefix
-                        else f"{k})_{index}"
+                        else f"{k}_{index}"
                     )
                     if isinstance(item, dict):
                         final_values_mapping_dict[k].append(


### PR DESCRIPTION
Let me know if I should be doing any testing here. 

When parsing a `values.yaml` file in the following format:
```
sasDiscovery:
  - discovery: "<sas-value>"
```
In the `mappyings.yaml` file this was becoming the invalid:
```
sasDiscovery:
- discovery: '{deployParameters.sasDiscovery)_0_discovery}'
```