### PR TITLE
Lower case acr names

### DIFF
--- a/src/aosm/azext_aosm/_configuration.py
+++ b/src/aosm/azext_aosm/_configuration.py
@@ -337,11 +337,11 @@ class CNFImageConfig:
     source_registry: str = ""
     source_registry_namespace: str = ""
     source_local_docker_image: str = ""
-    
+
     def __post_init__(self):
         """
         Ensure that all config is lower case.
-        
+
         ACR names can be uppercase but the login server is always lower case and docker
         and az acr import commands require lower case. Might as well do the namespace
         and docker image too although much less likely that the user has accidentally

--- a/src/aosm/azext_aosm/_configuration.py
+++ b/src/aosm/azext_aosm/_configuration.py
@@ -337,6 +337,19 @@ class CNFImageConfig:
     source_registry: str = ""
     source_registry_namespace: str = ""
     source_local_docker_image: str = ""
+    
+    def __post_init__(self):
+        """
+        Ensure that all config is lower case.
+        
+        ACR names can be uppercase but the login server is always lower case and docker
+        and az acr import commands require lower case. Might as well do the namespace
+        and docker image too although much less likely that the user has accidentally
+        pasted these with upper case.
+        """
+        self.source_registry = self.source_registry.lower()
+        self.source_registry_namespace = self.source_registry_namespace.lower()
+        self.source_local_docker_image = self.source_local_docker_image.lower()
 
     @classmethod
     def helptext(cls) -> "CNFImageConfig":

--- a/src/aosm/azext_aosm/generate_nfd/cnf_nfd_generator.py
+++ b/src/aosm/azext_aosm/generate_nfd/cnf_nfd_generator.py
@@ -764,7 +764,15 @@ class CnfNfdGenerator(NFDGenerator):  # pylint: disable=too-many-instance-attrib
                         final_values_mapping_dict[k].append(
                             self._replace_values_with_deploy_params(item, param_name)
                         )
-                    elif isinstance(item, (str, int, bool)) or not v:
+                    elif isinstance(item, (str, int, bool)) or not item:
+                        if self.interactive:
+                            if not input_ack(
+                                "y",
+                                f"Expose parameter {param_name}? y/n "
+                            ):
+                                logger.debug("Excluding parameter %s", param_name)
+                                final_values_mapping_dict[k].append(item)
+                                continue
                         replacement_value = f"{{deployParameters.{param_name}}}"
                         final_values_mapping_dict[k].append(replacement_value)
                     else:

--- a/src/aosm/azext_aosm/generate_nfd/cnf_nfd_generator.py
+++ b/src/aosm/azext_aosm/generate_nfd/cnf_nfd_generator.py
@@ -731,7 +731,7 @@ class CnfNfdGenerator(NFDGenerator):  # pylint: disable=too-many-instance-attrib
         """
         logger.debug("Replacing values with deploy parameters")
         final_values_mapping_dict: Dict[Any, Any] = {}
-        for k, v in values_yaml_dict.items():
+        for k, v in values_yaml_dict.items():  # pylint: disable=too-many-nested-blocks
             # if value is a string and contains deployParameters.
             logger.debug("Processing key %s", k)
             param_name = k if param_prefix is None else f"{param_prefix}_{k}"
@@ -767,8 +767,7 @@ class CnfNfdGenerator(NFDGenerator):  # pylint: disable=too-many-instance-attrib
                     elif isinstance(item, (str, int, bool)) or not item:
                         if self.interactive:
                             if not input_ack(
-                                "y",
-                                f"Expose parameter {param_name}? y/n "
+                                "y", f"Expose parameter {param_name}? y/n "
                             ):
                                 logger.debug("Excluding parameter %s", param_name)
                                 final_values_mapping_dict[k].append(item)


### PR DESCRIPTION
Two things in this PR:
- Ensure that we use ACR names that are lower-case, as it is easy to paste in the name of the ACR from the portal which can have upper case characters in it, and these are not supported by docker / az acr import
- I've thrown in another fix for interactive mode deployment parameter mapping, as there had been a bad partial fix before and I noticed in fixing this we had missed an interactive bit from this branch.