### PR TITLE
Image value mappings fixes

### DIFF
--- a/src/aosm/azext_aosm/_configuration.py
+++ b/src/aosm/azext_aosm/_configuration.py
@@ -11,7 +11,10 @@ from dataclasses import dataclass, field, asdict
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
-from azure.cli.core.azclierror import InvalidArgumentValueError, ValidationError
+from azure.cli.core.azclierror import (
+    InvalidArgumentValueError,
+    ValidationError,
+)
 from azext_aosm.util.constants import (
     CNF,
     NF_DEFINITION_OUTPUT_BICEP_PREFIX,
@@ -59,9 +62,59 @@ class ArtifactConfig:
         if not self.version:
             raise ValidationError("version must be set.")
         if self.blob_sas_url and self.file_path:
-            raise ValidationError("Only one of file_path or blob_sas_url may be set.")
+            raise ValidationError(
+                "Only one of file_path or blob_sas_url may be set."
+            )
         if not (self.blob_sas_url or self.file_path):
-            raise ValidationError("One of file_path or sas_blob_url must be set.")
+            raise ValidationError(
+                "One of file_path or sas_blob_url must be set."
+            )
+
+
+@dataclass
+class VhdArtifactConfig(ArtifactConfig):
+    image_disk_size_GB: Optional[Union[str, int]] = None
+    image_os_state: Optional[str] = None
+    image_os_type: Optional[str] = None
+    image_hyper_v_generation: Optional[str] = None
+    image_api_version: Optional[str] = None
+
+    def __post_init__(self):
+        """
+        Convert parameters to the correct types.
+        """
+        if (
+            isinstance(self.image_disk_size_GB, str)
+            and self.image_disk_size_GB.isdigit()
+        ):
+            self.image_disk_size_GB = int(self.image_disk_size_GB)
+
+    @classmethod
+    def helptext(cls) -> "VhdArtifactConfig":
+        """
+        Build an object where each value is helptext for that field.
+        """
+        return VhdArtifactConfig(
+            image_disk_size_GB=(
+                "Optional. Specifies the size of empty data disks in gigabytes. "
+                "This value cannot be larger than 1023 GB."
+            ),
+            image_os_state=(
+                "Optional. The OS State. For managed images, use Generalized."
+            ),
+            image_os_type=(
+                "Optional. This property allows you to specify the type of the "
+                "OS that is included in the disk if creating a VM from a custom image."
+            ),
+            image_hyper_v_generation=(
+                "Optional. Specifies the HyperVGenerationType of the VirtualMachine "
+                "created from the image."
+            ),
+            image_api_version=(
+                "Optional. The ARM API version used to create the image resource."
+            ),
+            **asdict(ArtifactConfig.helptext()),
+        )
 
 
 @dataclass
@@ -78,7 +131,9 @@ class Configuration(abc.ABC):
         """
         if self.publisher_name:
             if not self.publisher_resource_group_name:
-                self.publisher_resource_group_name = f"{self.publisher_name}-rg"
+                self.publisher_resource_group_name = (
+                    f"{self.publisher_name}-rg"
+                )
             if not self.acr_artifact_store_name:
                 self.acr_artifact_store_name = f"{self.publisher_name}-acr"
 
@@ -197,7 +252,9 @@ class NFConfiguration(Configuration):
         can be multiple ACR manifests.
         """
         sanitized_nf_name = self.nf_name.lower().replace("_", "-")
-        return [f"{sanitized_nf_name}-acr-manifest-{self.version.replace('.', '-')}"]
+        return [
+            f"{sanitized_nf_name}-acr-manifest-{self.version.replace('.', '-')}"
+        ]
 
 
 @dataclass
@@ -205,7 +262,7 @@ class VNFConfiguration(NFConfiguration):
     blob_artifact_store_name: str = ""
     image_name_parameter: str = ""
     arm_template: Union[Dict[str, str], ArtifactConfig] = ArtifactConfig()
-    vhd: Union[Dict[str, str], ArtifactConfig] = ArtifactConfig()
+    vhd: Union[Dict[str, str], VhdArtifactConfig] = VhdArtifactConfig()
 
     @classmethod
     def helptext(cls) -> "VNFConfiguration":
@@ -222,7 +279,7 @@ class VNFConfiguration(NFConfiguration):
                 "image to use for the VM."
             ),
             arm_template=ArtifactConfig.helptext(),
-            vhd=ArtifactConfig.helptext(),
+            vhd=VhdArtifactConfig.helptext(),
             **asdict(NFConfiguration.helptext()),
         )
 
@@ -244,8 +301,10 @@ class VNFConfiguration(NFConfiguration):
 
         if isinstance(self.vhd, dict):
             if self.vhd.get("file_path"):
-                self.vhd["file_path"] = self.path_from_cli_dir(self.vhd["file_path"])
-            self.vhd = ArtifactConfig(**self.vhd)
+                self.vhd["file_path"] = self.path_from_cli_dir(
+                    self.vhd["file_path"]
+                )
+            self.vhd = VhdArtifactConfig(**self.vhd)
 
     def validate(self) -> None:
         """
@@ -255,7 +314,7 @@ class VNFConfiguration(NFConfiguration):
         """
         super().validate()
 
-        assert isinstance(self.vhd, ArtifactConfig)
+        assert isinstance(self.vhd, VhdArtifactConfig)
         assert isinstance(self.arm_template, ArtifactConfig)
         self.vhd.validate()
         self.arm_template.validate()
@@ -268,7 +327,10 @@ class VNFConfiguration(NFConfiguration):
                 "Config validation error. VHD artifact version should be in format"
                 " A-B-C"
             )
-        if "." not in self.arm_template.version or "-" in self.arm_template.version:
+        if (
+            "." not in self.arm_template.version
+            or "-" in self.arm_template.version
+        ):
             raise ValidationError(
                 "Config validation error. ARM template artifact version should be in"
                 " format A.B.C"
@@ -278,7 +340,9 @@ class VNFConfiguration(NFConfiguration):
     def sa_manifest_name(self) -> str:
         """Return the Storage account manifest name from the NFD name."""
         sanitized_nf_name = self.nf_name.lower().replace("_", "-")
-        return f"{sanitized_nf_name}-sa-manifest-{self.version.replace('.', '-')}"
+        return (
+            f"{sanitized_nf_name}-sa-manifest-{self.version.replace('.', '-')}"
+        )
 
     @property
     def output_directory_for_build(self) -> Path:
@@ -420,7 +484,9 @@ class CNFConfiguration(NFConfiguration):
                 package["path_to_mappings"] = self.path_from_cli_dir(
                     package["path_to_mappings"]
                 )
-                self.helm_packages[package_index] = HelmPackageConfig(**dict(package))
+                self.helm_packages[package_index] = HelmPackageConfig(
+                    **dict(package)
+                )
         if isinstance(self.images, dict):
             self.images = CNFImageConfig(**self.images)
 
@@ -513,10 +579,14 @@ class NFDRETConfiguration:  # pylint: disable=too-many-instance-attributes
         :raises ValidationError for any invalid config
         """
         if not self.name:
-            raise ValidationError("Network function definition name must be set")
+            raise ValidationError(
+                "Network function definition name must be set"
+            )
 
         if not self.publisher:
-            raise ValidationError(f"Publisher name must be set for {self.name}")
+            raise ValidationError(
+                f"Publisher name must be set for {self.name}"
+            )
 
         if not self.publisher_resource_group:
             raise ValidationError(
@@ -540,7 +610,9 @@ class NFDRETConfiguration:  # pylint: disable=too-many-instance-attributes
 
         # Temporary validation while only private publishers exist
         if self.publisher_scope not in ["private", "Private"]:
-            raise ValidationError("Only private publishers are currently supported")
+            raise ValidationError(
+                "Only private publishers are currently supported"
+            )
 
         if self.type not in [CNF, VNF]:
             raise ValueError(
@@ -600,9 +672,9 @@ class NFDRETConfiguration:  # pylint: disable=too-many-instance-attributes
 
 @dataclass
 class NSConfiguration(Configuration):
-    network_functions: List[Union[NFDRETConfiguration, Dict[str, Any]]] = field(
-        default_factory=lambda: []
-    )
+    network_functions: List[
+        Union[NFDRETConfiguration, Dict[str, Any]]
+    ] = field(default_factory=lambda: [])
     nsd_name: str = ""
     nsd_version: str = ""
     nsdv_description: str = ""
@@ -610,9 +682,12 @@ class NSConfiguration(Configuration):
     def __post_init__(self):
         """Covert things to the correct format."""
         super().__post_init__()
-        if self.network_functions and isinstance(self.network_functions[0], dict):
+        if self.network_functions and isinstance(
+            self.network_functions[0], dict
+        ):
             nf_ret_list = [
-                NFDRETConfiguration(**config) for config in self.network_functions
+                NFDRETConfiguration(**config)
+                for config in self.network_functions
             ]
             self.network_functions = nf_ret_list
 
@@ -644,7 +719,9 @@ class NSConfiguration(Configuration):
         """
         super().validate()
         if not self.network_functions:
-            raise ValueError(("At least one network function must be included."))
+            raise ValueError(
+                ("At least one network function must be included.")
+            )
 
         for configuration in self.network_functions:
             configuration.validate()
@@ -681,7 +758,9 @@ class NSConfiguration(Configuration):
         return acr_manifest_names
 
 
-def get_configuration(configuration_type: str, config_file: str) -> Configuration:
+def get_configuration(
+    configuration_type: str, config_file: str
+) -> Configuration:
     """
     Return the correct configuration object based on the type.
 
@@ -700,9 +779,13 @@ def get_configuration(configuration_type: str, config_file: str) -> Configuratio
     config: Configuration
     try:
         if configuration_type == VNF:
-            config = VNFConfiguration(config_file=config_file, **config_as_dict)
+            config = VNFConfiguration(
+                config_file=config_file, **config_as_dict
+            )
         elif configuration_type == CNF:
-            config = CNFConfiguration(config_file=config_file, **config_as_dict)
+            config = CNFConfiguration(
+                config_file=config_file, **config_as_dict
+            )
         elif configuration_type == NSD:
             config = NSConfiguration(config_file=config_file, **config_as_dict)
         else:

--- a/src/aosm/azext_aosm/_configuration.py
+++ b/src/aosm/azext_aosm/_configuration.py
@@ -73,6 +73,8 @@ class ArtifactConfig:
 
 @dataclass
 class VhdArtifactConfig(ArtifactConfig):
+    # If you add a new propert to this class, you must also update
+    # VHD_EXTRA_PARAMETERS in constants.py
     image_disk_size_GB: Optional[Union[str, int]] = None
     image_hyper_v_generation: Optional[str] = None
     image_api_version: Optional[str] = None

--- a/src/aosm/azext_aosm/_configuration.py
+++ b/src/aosm/azext_aosm/_configuration.py
@@ -74,8 +74,6 @@ class ArtifactConfig:
 @dataclass
 class VhdArtifactConfig(ArtifactConfig):
     image_disk_size_GB: Optional[Union[str, int]] = None
-    image_os_state: Optional[str] = None
-    image_os_type: Optional[str] = None
     image_hyper_v_generation: Optional[str] = None
     image_api_version: Optional[str] = None
 
@@ -99,19 +97,13 @@ class VhdArtifactConfig(ArtifactConfig):
                 "Optional. Specifies the size of empty data disks in gigabytes. "
                 "This value cannot be larger than 1023 GB."
             ),
-            image_os_state=(
-                "Optional. The OS State. For managed images, use Generalized."
-            ),
-            image_os_type=(
-                "Optional. This property allows you to specify the type of the "
-                "OS that is included in the disk if creating a VM from a custom image."
-            ),
             image_hyper_v_generation=(
                 "Optional. Specifies the HyperVGenerationType of the VirtualMachine "
-                "created from the image."
+                "created from the image. Valid values are V1 and V2. V1 is the default if "
+                "not specified."
             ),
             image_api_version=(
-                "Optional. The ARM API version used to create the image resource."
+                "Optional. The ARM API version used to create the Microsoft.Compute/images resource."
             ),
             **asdict(ArtifactConfig.helptext()),
         )

--- a/src/aosm/azext_aosm/generate_nfd/vnf_nfd_generator.py
+++ b/src/aosm/azext_aosm/generate_nfd/vnf_nfd_generator.py
@@ -280,18 +280,9 @@ class VnfNfdGenerator(NFDGenerator):
 
         :param directory: The directory to put this file in.
         """
-        azureDeployLocation: str
-        if self.vm_parameters.get("location"):
-            # Location can be passed in as deploy parameter
-            azureDeployLocation = "{deployParameters.location}"
-        else:
-            # Couldn't find a location parameter in the source template, so hard code to
-            # the location we are deploying the publisher to.
-            azureDeployLocation = self.config.location
-
         vhd_parameters = {
             "imageName": self.image_name,
-            "azureDeployLocation": azureDeployLocation,
+            "azureDeployLocation": "{deployParameters.location}",
         }
 
         vhd_parameters_path = directory / VHD_PARAMETERS_FILENAME

--- a/src/aosm/azext_aosm/generate_nfd/vnf_nfd_generator.py
+++ b/src/aosm/azext_aosm/generate_nfd/vnf_nfd_generator.py
@@ -294,6 +294,10 @@ class VnfNfdGenerator(NFDGenerator):
         :param directory: The directory to put this file in.
         """
         vhd_config = self.config.vhd
+        # vhdImageMappingRuleProfile userConfiguration within the NFDV API accepts azureDeployLocation
+        # as the location where the image resource should be created from the VHD. The CLI does not
+        # expose this as it defaults to the NF deploy location, and we can't think of situations where
+        # it should be different.
         vhd_parameters = {
             "imageName": self.image_name,
             **{

--- a/src/aosm/azext_aosm/generate_nfd/vnf_nfd_generator.py
+++ b/src/aosm/azext_aosm/generate_nfd/vnf_nfd_generator.py
@@ -18,6 +18,7 @@ from azext_aosm.generate_nfd.nfd_generator_base import NFDGenerator
 from azext_aosm.util.constants import (
     CONFIG_MAPPINGS_DIR_NAME,
     DEPLOYMENT_PARAMETERS_FILENAME,
+    EXTRA_VHD_PARAMETERS,
     OPTIONAL_DEPLOYMENT_PARAMETERS_FILENAME,
     OPTIONAL_DEPLOYMENT_PARAMETERS_HEADING,
     SCHEMA_PREFIX,
@@ -299,7 +300,7 @@ class VnfNfdGenerator(NFDGenerator):
             **{
                 snake_case_to_camel_case(key): value
                 for key, value in vhd_config.__dict__.items()
-                if key.startswith("image") and value is not None
+                if key in EXTRA_VHD_PARAMETERS and value is not None
             },
         }
 

--- a/src/aosm/azext_aosm/generate_nfd/vnf_nfd_generator.py
+++ b/src/aosm/azext_aosm/generate_nfd/vnf_nfd_generator.py
@@ -27,7 +27,7 @@ from azext_aosm.util.constants import (
     VNF_DEFINITION_BICEP_TEMPLATE_FILENAME,
     VNF_MANIFEST_BICEP_TEMPLATE_FILENAME,
 )
-from azext_aosm.util.utils import input_ack
+from azext_aosm.util.utils import input_ack, snake_case_to_camel_case
 
 logger = get_logger(__name__)
 
@@ -61,7 +61,9 @@ class VnfNfdGenerator(NFDGenerator):
                          exposed.
     """
 
-    def __init__(self, config: VNFConfiguration, order_params: bool, interactive: bool):
+    def __init__(
+        self, config: VNFConfiguration, order_params: bool, interactive: bool
+    ):
         self.config = config
 
         assert isinstance(self.config.arm_template, ArtifactConfig)
@@ -93,7 +95,9 @@ class VnfNfdGenerator(NFDGenerator):
 
             self._create_parameter_files()
             self._copy_to_output_directory()
-            print(f"Generated NFD bicep templates created in {self.output_directory}")
+            print(
+                f"Generated NFD bicep templates created in {self.output_directory}"
+            )
             print(
                 "Please review these templates. When you are happy with them run "
                 "`az aosm nfd publish` with the same arguments."
@@ -141,7 +145,8 @@ class VnfNfdGenerator(NFDGenerator):
             # Order parameters into those with and without defaults
             has_default_field = "defaultValue" in self.vm_parameters[key]
             has_default = (
-                has_default_field and not self.vm_parameters[key]["defaultValue"] == ""
+                has_default_field
+                and not self.vm_parameters[key]["defaultValue"] == ""
             )
 
             if has_default:
@@ -176,7 +181,9 @@ class VnfNfdGenerator(NFDGenerator):
         vm_parameters_to_exclude = []
 
         vm_parameters = (
-            self.vm_parameters_ordered if self.order_params else self.vm_parameters
+            self.vm_parameters_ordered
+            if self.order_params
+            else self.vm_parameters
         )
 
         for key in vm_parameters:
@@ -188,7 +195,8 @@ class VnfNfdGenerator(NFDGenerator):
             # Order parameters into those without and then with defaults
             has_default_field = "defaultValue" in self.vm_parameters[key]
             has_default = (
-                has_default_field and not self.vm_parameters[key]["defaultValue"] == ""
+                has_default_field
+                and not self.vm_parameters[key]["defaultValue"] == ""
             )
 
             if self.interactive and has_default:
@@ -240,7 +248,9 @@ class VnfNfdGenerator(NFDGenerator):
                     optional_deployment_parameters_path, "w", encoding="utf-8"
                 ) as _file:
                     _file.write(OPTIONAL_DEPLOYMENT_PARAMETERS_HEADING)
-                    _file.write(json.dumps(nfd_parameters_with_default, indent=4))
+                    _file.write(
+                        json.dumps(nfd_parameters_with_default, indent=4)
+                    )
                 print(
                     "Optional ARM parameters detected. Created "
                     f"{OPTIONAL_DEPLOYMENT_PARAMETERS_FILENAME} to help you choose which "
@@ -255,7 +265,9 @@ class VnfNfdGenerator(NFDGenerator):
         """
         logger.debug("Create %s", TEMPLATE_PARAMETERS_FILENAME)
         vm_parameters = (
-            self.vm_parameters_ordered if self.order_params else self.vm_parameters
+            self.vm_parameters_ordered
+            if self.order_params
+            else self.vm_parameters
         )
 
         template_parameters = {}
@@ -280,9 +292,15 @@ class VnfNfdGenerator(NFDGenerator):
 
         :param directory: The directory to put this file in.
         """
+        vhd_config = self.config.vhd
         vhd_parameters = {
             "imageName": self.image_name,
             "azureDeployLocation": "{deployParameters.location}",
+            **{
+                snake_case_to_camel_case(key): value
+                for key, value in vhd_config.__dict__.items()
+                if key.startswith("image") and value is not None
+            },
         }
 
         vhd_parameters_path = directory / VHD_PARAMETERS_FILENAME

--- a/src/aosm/azext_aosm/generate_nfd/vnf_nfd_generator.py
+++ b/src/aosm/azext_aosm/generate_nfd/vnf_nfd_generator.py
@@ -296,7 +296,6 @@ class VnfNfdGenerator(NFDGenerator):
         vhd_config = self.config.vhd
         vhd_parameters = {
             "imageName": self.image_name,
-            "azureDeployLocation": "{deployParameters.location}",
             **{
                 snake_case_to_camel_case(key): value
                 for key, value in vhd_config.__dict__.items()

--- a/src/aosm/azext_aosm/tests/latest/mock_vnf/input_with_sas.json
+++ b/src/aosm/azext_aosm/tests/latest/mock_vnf/input_with_sas.json
@@ -15,8 +15,6 @@
         "blob_sas_url": "https://a/dummy/sas-url",
         "version": "1-0-0",
         "image_disk_size_GB": 30,
-        "image_os_state": "Generalized",
-        "image_os_type": "Linux",
         "image_hyper_v_generation": "V1",
         "image_api_version": "2023-03-01"
     }

--- a/src/aosm/azext_aosm/tests/latest/mock_vnf/input_with_sas.json
+++ b/src/aosm/azext_aosm/tests/latest/mock_vnf/input_with_sas.json
@@ -13,6 +13,11 @@
     },
     "vhd": {
         "blob_sas_url": "https://a/dummy/sas-url",
-        "version": "1-0-0"
+        "version": "1-0-0",
+        "image_disk_size_GB": 30,
+        "image_os_state": "Generalized",
+        "image_os_type": "Linux",
+        "image_hyper_v_generation": "V1",
+        "image_api_version": "2023-03-01"
     }
 }

--- a/src/aosm/azext_aosm/tests/latest/test_aosm_vnf_publish_and_delete.py
+++ b/src/aosm/azext_aosm/tests/latest/test_aosm_vnf_publish_and_delete.py
@@ -13,10 +13,9 @@
 # --------------------------------------------------------------------------------------------
 
 import os
-from azure.cli.testsdk import ScenarioTest, ResourceGroupPreparer
+from azure.cli.testsdk import LiveScenarioTest, ResourceGroupPreparer
 from knack.log import get_logger
 from jinja2 import Template
-from .recording_processors import TokenReplacer, SasUriReplacer, BlobStoreUriReplacer
 
 
 logger = get_logger(__name__)
@@ -25,7 +24,9 @@ NFD_INPUT_TEMPLATE_NAME = "vnf_input_template.json"
 NFD_INPUT_FILE_NAME = "vnf_input.json"
 NSD_INPUT_TEMPLATE_NAME = "vnf_nsd_input_template.json"
 NSD_INPUT_FILE_NAME = "nsd_input.json"
-ARM_TEMPLATE_RELATIVE_PATH = "scenario_test_mocks/vnf_mocks/ubuntu_template.json"
+ARM_TEMPLATE_RELATIVE_PATH = (
+    "scenario_test_mocks/vnf_mocks/ubuntu_template.json"
+)
 
 
 def update_resource_group_in_input_file(
@@ -63,28 +64,12 @@ def update_resource_group_in_input_file(
     return output_path
 
 
-class VnfNsdTest(ScenarioTest):
+class VnfNsdTest(LiveScenarioTest):
     """This class contains the integration tests for the aosm extension for vnf definition type."""
 
-    def __init__(self, method_name):
-        """
-        This constructor initializes the class.
-
-        :param method_name: The name of the test method.
-        :param recording_processors: The recording processors to use for the test.
-        These recording processors modify the recording of a test before it is saved,
-        helping to remove sensitive information from the recording.
-        """
-        super(VnfNsdTest, self).__init__(
-            method_name,
-            recording_processors=[
-                TokenReplacer(),
-                SasUriReplacer(),
-                BlobStoreUriReplacer(),
-            ],
-        )
-
-    @ResourceGroupPreparer(name_prefix="cli_test_vnf_nsd_", location="uaenorth")
+    @ResourceGroupPreparer(
+        name_prefix="cli_test_vnf_nsd_", location="uaenorth"
+    )
     def test_vnf_nsd_publish_and_delete(self, resource_group):
         """
         This test creates a vnf nfd and nsd, publishes them, and then deletes them.
@@ -123,7 +108,9 @@ class VnfNsdTest(ScenarioTest):
         finally:
             # If the command fails, then the test should fail.
             # We still need to clean up the resources, so we run the delete command.
-            self.cmd(f'az aosm nsd delete -f "{nsd_input_file_path}" --clean --force')
+            self.cmd(
+                f'az aosm nsd delete -f "{nsd_input_file_path}" --clean --force'
+            )
             self.cmd(
                 f'az aosm nfd delete --definition-type vnf -f "{nfd_input_file_path}" --clean --force'
             )

--- a/src/aosm/azext_aosm/tests/latest/test_vnf.py
+++ b/src/aosm/azext_aosm/tests/latest/test_vnf.py
@@ -15,10 +15,7 @@ mock_vnf_folder = ((Path(__file__).parent) / "mock_vnf").resolve()
 
 INPUT_WITH_SAS_VHD_PARAMS = {
     "imageName": "ubuntu-vmImage",
-    "azureDeployLocation": "{deployParameters.location}",
     "imageDiskSizeGB": 30,
-    "imageOsState": "Generalized",
-    "imageOsType": "Linux",
     "imageHyperVGeneration": "V1",
     "imageApiVersion": "2023-03-01",
 }

--- a/src/aosm/azext_aosm/tests/latest/test_vnf.py
+++ b/src/aosm/azext_aosm/tests/latest/test_vnf.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+import json
 import os
 import unittest
 from pathlib import Path
@@ -11,6 +12,24 @@ from tempfile import TemporaryDirectory
 from azext_aosm.custom import build_definition, generate_definition_config
 
 mock_vnf_folder = ((Path(__file__).parent) / "mock_vnf").resolve()
+
+INPUT_WITH_SAS_VHD_PARAMS = {
+    "imageName": "ubuntu-vmImage",
+    "azureDeployLocation": "{deployParameters.location}",
+    "imageDiskSizeGB": 30,
+    "imageOsState": "Generalized",
+    "imageOsType": "Linux",
+    "imageHyperVGeneration": "V1",
+    "imageApiVersion": "2023-03-01",
+}
+
+
+def validate_vhd_parameters(expected_params, vhd_params_file_path):
+    """Validate that the expected parameters are in the actual parameters."""
+    assert os.path.exists(vhd_params_file_path)
+    with open(vhd_params_file_path) as f:
+        actual_params = json.load(f)
+    assert expected_params == actual_params
 
 
 class TestVNF(unittest.TestCase):
@@ -33,7 +52,9 @@ class TestVNF(unittest.TestCase):
             os.chdir(test_dir)
 
             try:
-                build_definition("vnf", str(mock_vnf_folder / "input_with_fp.json"))
+                build_definition(
+                    "vnf", str(mock_vnf_folder / "input_with_fp.json")
+                )
                 assert os.path.exists("nfd-bicep-ubuntu-template")
             finally:
                 os.chdir(starting_directory)
@@ -42,8 +63,15 @@ class TestVNF(unittest.TestCase):
             os.chdir(test_dir)
 
             try:
-                build_definition("vnf", str(mock_vnf_folder / "input_with_sas.json"))
+                build_definition(
+                    "vnf", str(mock_vnf_folder / "input_with_sas.json")
+                )
                 assert os.path.exists("nfd-bicep-ubuntu-template")
+                print(os.listdir("nfd-bicep-ubuntu-template"))
+                validate_vhd_parameters(
+                    INPUT_WITH_SAS_VHD_PARAMS,
+                    "nfd-bicep-ubuntu-template/configMappings/vhdParameters.json",
+                )
             finally:
                 os.chdir(starting_directory)
 

--- a/src/aosm/azext_aosm/util/constants.py
+++ b/src/aosm/azext_aosm/util/constants.py
@@ -38,7 +38,9 @@ NSD_DEFINITION_JINJA2_SOURCE_TEMPLATE = "nsd_template.bicep.j2"
 NSD_BICEP_FILENAME = "nsd_definition.bicep"
 NSD_OUTPUT_BICEP_PREFIX = "nsd-bicep-templates"
 NSD_ARTIFACT_MANIFEST_BICEP_FILENAME = "artifact_manifest.bicep"
-NSD_ARTIFACT_MANIFEST_SOURCE_TEMPLATE_FILENAME = "artifact_manifest_template.bicep"
+NSD_ARTIFACT_MANIFEST_SOURCE_TEMPLATE_FILENAME = (
+    "artifact_manifest_template.bicep"
+)
 
 VNF_DEFINITION_BICEP_TEMPLATE_FILENAME = "vnfdefinition.bicep"
 VNF_MANIFEST_BICEP_TEMPLATE_FILENAME = "vnfartifactmanifests.bicep"
@@ -78,6 +80,14 @@ SCHEMA_PREFIX = {
     "type": "object",
     "properties": {},
 }
+
+# For VNF NFD Generator
+# To check whether extra VHD parameters have been provided
+EXTRA_VHD_PARAMETERS = [
+    "image_disk_size_GB",
+    "image_hyper_v_generation",
+    "image_api_version",
+]
 
 # For CNF NFD Generator
 # To match the image path if image: is present in the yaml file

--- a/src/aosm/azext_aosm/util/utils.py
+++ b/src/aosm/azext_aosm/util/utils.py
@@ -15,3 +15,11 @@ def input_ack(ack: str, request_to_user: str) -> bool:
     """
     unsanitised_ans = input(request_to_user)
     return str(unsanitised_ans.strip().replace(" ", "").lower()) == ack
+
+
+def snake_case_to_camel_case(text):
+    """Converts snake case to camel case."""
+    components = text.split("_")
+    return components[0] + "".join(
+        x[0].upper() + x[1:] for x in components[1:]
+    )


### PR DESCRIPTION
This PR is to address two issues around the generated VHD parameters for the VNF build path:
1. Stop hard coding the value of `azureDeployLocation`. This value should always be configurable.
2. Add the following optional parameters to the VHD artifact configuration:
    -  imageDiskSizeGB
    - imageOsState
    - imageOsType
    - imageHyperVGeneration
    - imageApiVersion

These values are set to defaults by NFM when they are not provided but it is necessary that we give publishers the option to configure them

I have also made the VNF publish and delete test a live test only. This is because it was causing issues for people when running the UTs doe to an underlying issue with the test framework. Please chat to Patryk for more context.

I am planning to merge this into the `add-aosm-extension` branch and then have a separate PR to add this to the pre-release branch.