### PR TITLE
Correctly get array item types in CNF deployment parameter schemas

### DIFF
--- a/src/aosm/azext_aosm/tests/latest/mock_cnf/helm-charts/nfconfigchart/nfconfigchartvalues.mappings.yaml
+++ b/src/aosm/azext_aosm/tests/latest/mock_cnf/helm-charts/nfconfigchart/nfconfigchartvalues.mappings.yaml
@@ -9,7 +9,7 @@ image:
   tag: stable
   pullPolicy: IfNotPresent
 
-imagePullSecrets: []
+imagePullSecrets: ['{deployParameters.imagePullSecrets_0}']
 nameOverride: ""
 fullnameOverride: ""
 

--- a/src/aosm/azext_aosm/tests/latest/test_cnf.py
+++ b/src/aosm/azext_aosm/tests/latest/test_cnf.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 import unittest
+import json
 import os
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -37,6 +38,11 @@ class TestCNF(unittest.TestCase):
                     "cnf", str(mock_cnf_folder / "input-nfconfigchart.json")
                 )
                 assert os.path.exists("nfd-bicep-nginx-basic-test")
+                # Confirm that the generated schema file correctly handles array deployment params.
+                assert os.path.exists("nfd-bicep-nginx-basic-test/schemas/deploymentParameters.json")
+                with open("nfd-bicep-nginx-basic-test/schemas/deploymentParameters.json") as f:
+                    schema = json.load(f)
+                    assert schema["properties"]["imagePullSecrets_0"]["type"] == "string"
             finally:
                 os.chdir(starting_directory)
 


### PR DESCRIPTION
When grabbing the types of deployment parameters from the values.schema.json, we retrieve the overall array object where there is an array, and thus get "array" as the type. This fix checks for an "items" entry in the schema and extracts the type from that (defaulting to string if not provided, as with objects).

For now this only supports cases where all values have the same type - where there are multiple values, we default to string and display the usual warning.

Also, extend the basic CNF test's example mapping file to include a deployment parameter in an array and test that the resultant schema correctly includes the type.