### PR TITLE
Remove Blob_SAS_URL Option from ArmTemplate in input file

### DIFF
--- a/src/aosm/azext_aosm/_configuration.py
+++ b/src/aosm/azext_aosm/_configuration.py
@@ -32,8 +32,8 @@ class ArtifactConfig:
     # artifact.py checks for the presence of the default descriptions, change
     # there if you change the descriptions.
     artifact_name: str = ""
-    file_path: Optional[str] = None
     version: Optional[str] = ""
+    file_path: Optional[str] = None
 
     @classmethod
     def helptext(cls) -> "ArtifactConfig":
@@ -42,12 +42,13 @@ class ArtifactConfig:
         """
         return ArtifactConfig(
             artifact_name="Optional. Name of the artifact.",
+            version="Version of the artifact in A.B.C format.",
             file_path=(
-                "Optional. File path of the artifact you wish to upload from your local disk. "
-                "Delete if not required. Relative paths are relative to the configuration file."
+                "File path of the artifact you wish to upload from your local disk. "
+                "Relative paths are relative to the configuration file. "
                 "On Windows escape any backslash with another backslash."
             ),
-            version="Version of the artifact in A.B.C format.",
+
         )
 
     def validate(self):
@@ -64,10 +65,10 @@ class ArtifactConfig:
 class VhdArtifactConfig(ArtifactConfig):
     # If you add a new property to this class, you must also update
     # EXTRA_VHD_PARAMETERS in constants.py
+    blob_sas_url: Optional[str] = None
     image_disk_size_GB: Optional[Union[str, int]] = None
     image_hyper_v_generation: Optional[str] = None
     image_api_version: Optional[str] = None
-    blob_sas_url: Optional[str] = None
 
     def __post_init__(self):
         """
@@ -84,7 +85,18 @@ class VhdArtifactConfig(ArtifactConfig):
         """
         Build an object where each value is helptext for that field.
         """
+
+        artifact_config = ArtifactConfig.helptext()
+        artifact_config.file_path = (
+            "Optional. File path of the artifact you wish to upload from your local disk. "
+            "Delete if not required. Relative paths are relative to the configuration file."
+            "On Windows escape any backslash with another backslash."
+        )
         return VhdArtifactConfig(
+            blob_sas_url=(
+                "Optional. SAS URL of the blob artifact you wish to copy to your Artifact"
+                " Store. Delete if not required."
+            ),
             image_disk_size_GB=(
                 "Optional. Specifies the size of empty data disks in gigabytes. "
                 "This value cannot be larger than 1023 GB."
@@ -97,26 +109,17 @@ class VhdArtifactConfig(ArtifactConfig):
             image_api_version=(
                 "Optional. The ARM API version used to create the Microsoft.Compute/images resource."
             ),
-            blob_sas_url=(
-                "Optional. SAS URL of the blob artifact you wish to copy to your Artifact"
-                " Store. Delete if not required."
-            ),
-            **asdict(ArtifactConfig.helptext()),
+            **asdict(artifact_config),
         )
-    # will this work? not sure if you get blob and filepath in this class
 
     def validate(self):
         """
         Validate the configuration.
         """
         if self.blob_sas_url and self.file_path:
-            raise ValidationError(
-                "Only one of file_path or blob_sas_url may be set."
-            )
+            raise ValidationError("Only one of file_path or blob_sas_url may be set.")
         if not (self.blob_sas_url or self.file_path):
-            raise ValidationError(
-                "One of file_path or sas_blob_url must be set."
-            )
+            raise ValidationError("One of file_path or sas_blob_url must be set.")
 
 
 @dataclass

--- a/src/aosm/azext_aosm/_configuration.py
+++ b/src/aosm/azext_aosm/_configuration.py
@@ -63,8 +63,8 @@ class ArtifactConfig:
 
 @dataclass
 class VhdArtifactConfig(ArtifactConfig):
-    # If you add a new property to this class, you must also update
-    # EXTRA_VHD_PARAMETERS in constants.py
+    # If you add a new property to this class, consider updating EXTRA_VHD_PARAMETERS in
+    # constants.py - see comment there for details.
     blob_sas_url: Optional[str] = None
     image_disk_size_GB: Optional[Union[str, int]] = None
     image_hyper_v_generation: Optional[str] = None
@@ -92,6 +92,9 @@ class VhdArtifactConfig(ArtifactConfig):
             "Delete if not required. Relative paths are relative to the configuration file."
             "On Windows escape any backslash with another backslash."
         )
+        artifact_config.version = (
+            "Version of the artifact in A-B-C format."
+        )
         return VhdArtifactConfig(
             blob_sas_url=(
                 "Optional. SAS URL of the blob artifact you wish to copy to your Artifact"
@@ -99,15 +102,16 @@ class VhdArtifactConfig(ArtifactConfig):
             ),
             image_disk_size_GB=(
                 "Optional. Specifies the size of empty data disks in gigabytes. "
-                "This value cannot be larger than 1023 GB."
+                "This value cannot be larger than 1023 GB. Delete if not required."
             ),
             image_hyper_v_generation=(
                 "Optional. Specifies the HyperVGenerationType of the VirtualMachine "
                 "created from the image. Valid values are V1 and V2. V1 is the default if "
-                "not specified."
+                "not specified. Delete if not required."
             ),
             image_api_version=(
-                "Optional. The ARM API version used to create the Microsoft.Compute/images resource."
+                "Optional. The ARM API version used to create the "
+                "Microsoft.Compute/images resource. Delete if not required."
             ),
             **asdict(artifact_config),
         )
@@ -116,10 +120,12 @@ class VhdArtifactConfig(ArtifactConfig):
         """
         Validate the configuration.
         """
+        if not self.version:
+            raise ValidationError("version must be set for vhd.")
         if self.blob_sas_url and self.file_path:
-            raise ValidationError("Only one of file_path or blob_sas_url may be set.")
+            raise ValidationError("Only one of file_path or blob_sas_url may be set for vhd.")
         if not (self.blob_sas_url or self.file_path):
-            raise ValidationError("One of file_path or sas_blob_url must be set.")
+            raise ValidationError("One of file_path or sas_blob_url must be set for vhd.")
 
 
 @dataclass

--- a/src/aosm/azext_aosm/_configuration.py
+++ b/src/aosm/azext_aosm/_configuration.py
@@ -292,9 +292,10 @@ class VNFConfiguration(NFConfiguration):
             self.blob_artifact_store_name = f"{self.publisher_name}-sa"
 
         if isinstance(self.arm_template, dict):
-            self.arm_template["file_path"] = self.path_from_cli_dir(
-                self.arm_template["file_path"]
-            )
+            if self.arm_template.get("file_path"):
+                self.arm_template["file_path"] = self.path_from_cli_dir(
+                    self.arm_template["file_path"]
+                )
             self.arm_template = ArtifactConfig(**self.arm_template)
 
         if isinstance(self.vhd, dict):

--- a/src/aosm/azext_aosm/_configuration.py
+++ b/src/aosm/azext_aosm/_configuration.py
@@ -33,7 +33,6 @@ class ArtifactConfig:
     # there if you change the descriptions.
     artifact_name: str = ""
     file_path: Optional[str] = None
-    blob_sas_url: Optional[str] = None
     version: Optional[str] = ""
 
     @classmethod
@@ -48,10 +47,6 @@ class ArtifactConfig:
                 "Delete if not required. Relative paths are relative to the configuration file."
                 "On Windows escape any backslash with another backslash."
             ),
-            blob_sas_url=(
-                "Optional. SAS URL of the blob artifact you wish to copy to your Artifact"
-                " Store. Delete if not required."
-            ),
             version="Version of the artifact in A.B.C format.",
         )
 
@@ -61,23 +56,18 @@ class ArtifactConfig:
         """
         if not self.version:
             raise ValidationError("version must be set.")
-        if self.blob_sas_url and self.file_path:
-            raise ValidationError(
-                "Only one of file_path or blob_sas_url may be set."
-            )
-        if not (self.blob_sas_url or self.file_path):
-            raise ValidationError(
-                "One of file_path or sas_blob_url must be set."
-            )
+        if not self.file_path:
+            raise ValidationError("file_path must be set.")
 
 
 @dataclass
 class VhdArtifactConfig(ArtifactConfig):
-    # If you add a new propert to this class, you must also update
-    # VHD_EXTRA_PARAMETERS in constants.py
+    # If you add a new property to this class, you must also update
+    # EXTRA_VHD_PARAMETERS in constants.py
     image_disk_size_GB: Optional[Union[str, int]] = None
     image_hyper_v_generation: Optional[str] = None
     image_api_version: Optional[str] = None
+    blob_sas_url: Optional[str] = None
 
     def __post_init__(self):
         """
@@ -107,8 +97,26 @@ class VhdArtifactConfig(ArtifactConfig):
             image_api_version=(
                 "Optional. The ARM API version used to create the Microsoft.Compute/images resource."
             ),
+            blob_sas_url=(
+                "Optional. SAS URL of the blob artifact you wish to copy to your Artifact"
+                " Store. Delete if not required."
+            ),
             **asdict(ArtifactConfig.helptext()),
         )
+    # will this work? not sure if you get blob and filepath in this class
+
+    def validate(self):
+        """
+        Validate the configuration.
+        """
+        if self.blob_sas_url and self.file_path:
+            raise ValidationError(
+                "Only one of file_path or blob_sas_url may be set."
+            )
+        if not (self.blob_sas_url or self.file_path):
+            raise ValidationError(
+                "One of file_path or sas_blob_url must be set."
+            )
 
 
 @dataclass
@@ -125,9 +133,7 @@ class Configuration(abc.ABC):
         """
         if self.publisher_name:
             if not self.publisher_resource_group_name:
-                self.publisher_resource_group_name = (
-                    f"{self.publisher_name}-rg"
-                )
+                self.publisher_resource_group_name = f"{self.publisher_name}-rg"
             if not self.acr_artifact_store_name:
                 self.acr_artifact_store_name = f"{self.publisher_name}-acr"
 
@@ -246,9 +252,7 @@ class NFConfiguration(Configuration):
         can be multiple ACR manifests.
         """
         sanitized_nf_name = self.nf_name.lower().replace("_", "-")
-        return [
-            f"{sanitized_nf_name}-acr-manifest-{self.version.replace('.', '-')}"
-        ]
+        return [f"{sanitized_nf_name}-acr-manifest-{self.version.replace('.', '-')}"]
 
 
 @dataclass
@@ -295,9 +299,7 @@ class VNFConfiguration(NFConfiguration):
 
         if isinstance(self.vhd, dict):
             if self.vhd.get("file_path"):
-                self.vhd["file_path"] = self.path_from_cli_dir(
-                    self.vhd["file_path"]
-                )
+                self.vhd["file_path"] = self.path_from_cli_dir(self.vhd["file_path"])
             self.vhd = VhdArtifactConfig(**self.vhd)
 
     def validate(self) -> None:
@@ -321,10 +323,7 @@ class VNFConfiguration(NFConfiguration):
                 "Config validation error. VHD artifact version should be in format"
                 " A-B-C"
             )
-        if (
-            "." not in self.arm_template.version
-            or "-" in self.arm_template.version
-        ):
+        if "." not in self.arm_template.version or "-" in self.arm_template.version:
             raise ValidationError(
                 "Config validation error. ARM template artifact version should be in"
                 " format A.B.C"
@@ -334,9 +333,7 @@ class VNFConfiguration(NFConfiguration):
     def sa_manifest_name(self) -> str:
         """Return the Storage account manifest name from the NFD name."""
         sanitized_nf_name = self.nf_name.lower().replace("_", "-")
-        return (
-            f"{sanitized_nf_name}-sa-manifest-{self.version.replace('.', '-')}"
-        )
+        return f"{sanitized_nf_name}-sa-manifest-{self.version.replace('.', '-')}"
 
     @property
     def output_directory_for_build(self) -> Path:
@@ -478,9 +475,7 @@ class CNFConfiguration(NFConfiguration):
                 package["path_to_mappings"] = self.path_from_cli_dir(
                     package["path_to_mappings"]
                 )
-                self.helm_packages[package_index] = HelmPackageConfig(
-                    **dict(package)
-                )
+                self.helm_packages[package_index] = HelmPackageConfig(**dict(package))
         if isinstance(self.images, dict):
             self.images = CNFImageConfig(**self.images)
 
@@ -569,14 +564,10 @@ class NFDRETConfiguration:  # pylint: disable=too-many-instance-attributes
         :raises ValidationError for any invalid config
         """
         if not self.name:
-            raise ValidationError(
-                "Network function definition name must be set"
-            )
+            raise ValidationError("Network function definition name must be set")
 
         if not self.publisher:
-            raise ValidationError(
-                f"Publisher name must be set for {self.name}"
-            )
+            raise ValidationError(f"Publisher name must be set for {self.name}")
 
         if not self.publisher_resource_group:
             raise ValidationError(
@@ -651,9 +642,9 @@ class NFDRETConfiguration:  # pylint: disable=too-many-instance-attributes
 
 @dataclass
 class NSConfiguration(Configuration):
-    network_functions: List[
-        Union[NFDRETConfiguration, Dict[str, Any]]
-    ] = field(default_factory=lambda: [])
+    network_functions: List[Union[NFDRETConfiguration, Dict[str, Any]]] = field(
+        default_factory=lambda: []
+    )
     nsd_name: str = ""
     nsd_version: str = ""
     nsdv_description: str = ""
@@ -661,12 +652,9 @@ class NSConfiguration(Configuration):
     def __post_init__(self):
         """Covert things to the correct format."""
         super().__post_init__()
-        if self.network_functions and isinstance(
-            self.network_functions[0], dict
-        ):
+        if self.network_functions and isinstance(self.network_functions[0], dict):
             nf_ret_list = [
-                NFDRETConfiguration(**config)
-                for config in self.network_functions
+                NFDRETConfiguration(**config) for config in self.network_functions
             ]
             self.network_functions = nf_ret_list
 
@@ -698,9 +686,7 @@ class NSConfiguration(Configuration):
         """
         super().validate()
         if not self.network_functions:
-            raise ValueError(
-                ("At least one network function must be included.")
-            )
+            raise ValueError(("At least one network function must be included."))
 
         for configuration in self.network_functions:
             configuration.validate()
@@ -737,9 +723,7 @@ class NSConfiguration(Configuration):
         return acr_manifest_names
 
 
-def get_configuration(
-    configuration_type: str, config_file: str
-) -> Configuration:
+def get_configuration(configuration_type: str, config_file: str) -> Configuration:
     """
     Return the correct configuration object based on the type.
 
@@ -758,13 +742,9 @@ def get_configuration(
     config: Configuration
     try:
         if configuration_type == VNF:
-            config = VNFConfiguration(
-                config_file=config_file, **config_as_dict
-            )
+            config = VNFConfiguration(config_file=config_file, **config_as_dict)
         elif configuration_type == CNF:
-            config = CNFConfiguration(
-                config_file=config_file, **config_as_dict
-            )
+            config = CNFConfiguration(config_file=config_file, **config_as_dict)
         elif configuration_type == NSD:
             config = NSConfiguration(config_file=config_file, **config_as_dict)
         else:

--- a/src/aosm/azext_aosm/deploy/artifact.py
+++ b/src/aosm/azext_aosm/deploy/artifact.py
@@ -17,7 +17,12 @@ from knack.log import get_logger
 from knack.util import CLIError
 from oras.client import OrasClient
 
-from azext_aosm._configuration import ArtifactConfig, HelmPackageConfig, CNFImageConfig
+from azext_aosm._configuration import (
+    ArtifactConfig,
+    CNFImageConfig,
+    HelmPackageConfig,
+    VhdArtifactConfig,
+)
 
 logger = get_logger(__name__)
 
@@ -289,6 +294,7 @@ class Artifact:
             )
         else:
             # Config Validation will raise error if not true
+            assert isinstance(artifact_config, VhdArtifactConfig)
             assert artifact_config.blob_sas_url
             logger.info("Copy from SAS URL to blob store")
             source_blob = BlobClient.from_blob_url(artifact_config.blob_sas_url)

--- a/src/aosm/azext_aosm/util/constants.py
+++ b/src/aosm/azext_aosm/util/constants.py
@@ -82,12 +82,18 @@ SCHEMA_PREFIX = {
 }
 
 # For VNF NFD Generator
-# To check whether extra VHD parameters have been provided
+# Additional config fields from VHD artifact config in input.json that are
+# converted to camel case and end up within configMappings/vhdParameters.json
+# These become part of the vnfdefinition.bicep, namely:
+#   deployParametersMappingRuleProfile: {
+#     vhdImageMappingRuleProfile: {
+#       userConfiguration: string(loadJsonContent('configMappings/vhdParameters.json'))
+#     }
+# Add new config fields to this list if they should also end up there.
 EXTRA_VHD_PARAMETERS = [
     "image_disk_size_GB",
     "image_hyper_v_generation",
-    "image_api_version",
-    "blob_sas_url"
+    "image_api_version"
 ]
 
 # For CNF NFD Generator

--- a/src/aosm/azext_aosm/util/constants.py
+++ b/src/aosm/azext_aosm/util/constants.py
@@ -87,6 +87,7 @@ EXTRA_VHD_PARAMETERS = [
     "image_disk_size_GB",
     "image_hyper_v_generation",
     "image_api_version",
+    "blob_sas_url"
 ]
 
 # For CNF NFD Generator


### PR DESCRIPTION
---
Fixes for:
1) The input.json file created by running "az aosm nfd generate-config --definition-type vnf" says vhd version field should be in A.B.C format, but sample input-vnf-nfd.json and the variable/description talbe in the quickstart say A-B-C format.

2) The input file above also has blob_sas_uri for the arm template artifact, which is not relevant and doesn't work. 

Both these used to work so have been broken by something in the last few weeks. 

This PR:
- Removed blob_sas_url option + amended validation 
- Changed placeholder text (separated file_path under arm_template and vhd)
- Fixed help text for artifact versions
- Fixed validation for artifacts (arm vs vhd)
- Fixed minor comment typos
- minor formatting

NOT DONE - refactored ArtifactConfig to have a general ABC superclass with two subclasses.

<img width="856" alt="image" src="https://github.com/jddarby/azure-cli-extensions/assets/72226943/ee334533-9736-4dbf-8f68-906544a9a5f9">

TESTS:
- Various tests with playing around with vnf input.json to check output
- Built a vnf nfd and published using blob_sas_url
- Built a vnf nsd and published

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
