### PR TITLE
Refactor artifact configuration to distinct classes

### DIFF
--- a/src/aosm/azext_aosm/deploy/artifact.py
+++ b/src/aosm/azext_aosm/deploy/artifact.py
@@ -18,7 +18,7 @@ from knack.util import CLIError
 from oras.client import OrasClient
 
 from azext_aosm._configuration import (
-    ArtifactConfig,
+    ArmArtifactConfig,
     CNFImageConfig,
     HelmPackageConfig,
     VhdArtifactConfig,
@@ -39,7 +39,7 @@ class Artifact:
 
     def upload(
         self,
-        artifact_config: Union[ArtifactConfig, HelmPackageConfig],
+        artifact_config: Union[ArmArtifactConfig, CNFImageConfig, VhdArtifactConfig, HelmPackageConfig],
         use_manifest_permissions: bool = False,
     ) -> None:
         """
@@ -50,7 +50,7 @@ class Artifact:
         if isinstance(self.artifact_client, OrasClient):
             if isinstance(artifact_config, HelmPackageConfig):
                 self._upload_helm_to_acr(artifact_config, use_manifest_permissions)
-            elif isinstance(artifact_config, ArtifactConfig):
+            elif isinstance(artifact_config, ArmArtifactConfig):
                 self._upload_arm_to_acr(artifact_config)
             elif isinstance(artifact_config, CNFImageConfig):
                 self._upload_or_copy_image_to_acr(
@@ -59,10 +59,10 @@ class Artifact:
             else:
                 raise ValueError(f"Unsupported artifact type: {type(artifact_config)}.")
         else:
-            assert isinstance(artifact_config, ArtifactConfig)
+            assert isinstance(artifact_config, VhdArtifactConfig)
             self._upload_to_storage_account(artifact_config)
 
-    def _upload_arm_to_acr(self, artifact_config: ArtifactConfig) -> None:
+    def _upload_arm_to_acr(self, artifact_config: ArmArtifactConfig) -> None:
         """
         Upload ARM artifact to ACR.
 
@@ -268,14 +268,14 @@ class Artifact:
         logger.info(message)
         print(message)
 
-    def _upload_to_storage_account(self, artifact_config: ArtifactConfig) -> None:
+    def _upload_to_storage_account(self, artifact_config: VhdArtifactConfig) -> None:
         """
         Upload artifact to storage account.
 
         :param artifact_config: configuration for the artifact being uploaded
         """
         assert isinstance(self.artifact_client, BlobClient)
-        assert isinstance(artifact_config, ArtifactConfig)
+        assert isinstance(artifact_config, VhdArtifactConfig)
 
         # If the file path is given, upload the artifact, else, copy it from an existing blob.
         if artifact_config.file_path:
@@ -294,7 +294,6 @@ class Artifact:
             )
         else:
             # Config Validation will raise error if not true
-            assert isinstance(artifact_config, VhdArtifactConfig)
             assert artifact_config.blob_sas_url
             logger.info("Copy from SAS URL to blob store")
             source_blob = BlobClient.from_blob_url(artifact_config.blob_sas_url)

--- a/src/aosm/azext_aosm/deploy/deploy_with_arm.py
+++ b/src/aosm/azext_aosm/deploy/deploy_with_arm.py
@@ -18,12 +18,13 @@ from knack.log import get_logger
 from knack.util import CLIError
 
 from azext_aosm._configuration import (
-    ArtifactConfig,
+    ArmArtifactConfig,
     CNFConfiguration,
     Configuration,
     NFConfiguration,
     NFDRETConfiguration,
     NSConfiguration,
+    VhdArtifactConfig,
     VNFConfiguration,
 )
 from azext_aosm.deploy.artifact import Artifact
@@ -184,8 +185,8 @@ class DeployerViaArm:  # pylint: disable=too-many-instance-attributes
         vhd_config = self.config.vhd
         arm_template_config = self.config.arm_template
 
-        assert isinstance(vhd_config, ArtifactConfig)
-        assert isinstance(arm_template_config, ArtifactConfig)
+        assert isinstance(vhd_config, VhdArtifactConfig)
+        assert isinstance(arm_template_config, ArmArtifactConfig)
 
         if self.skip == IMAGE_UPLOAD:
             print("Skipping VHD artifact upload")
@@ -310,8 +311,8 @@ class DeployerViaArm:  # pylint: disable=too-many-instance-attributes
         """
         if self.resource_type == VNF:
             assert isinstance(self.config, VNFConfiguration)
-            assert isinstance(self.config.vhd, ArtifactConfig)
-            assert isinstance(self.config.arm_template, ArtifactConfig)
+            assert isinstance(self.config.vhd, VhdArtifactConfig)
+            assert isinstance(self.config.arm_template, ArmArtifactConfig)
             return {
                 "location": {"value": self.config.location},
                 "publisherName": {"value": self.config.publisher_name},
@@ -351,8 +352,8 @@ class DeployerViaArm:  # pylint: disable=too-many-instance-attributes
         """Create the parmeters dictionary for VNF, CNF or NSD."""
         if self.resource_type == VNF:
             assert isinstance(self.config, VNFConfiguration)
-            assert isinstance(self.config.vhd, ArtifactConfig)
-            assert isinstance(self.config.arm_template, ArtifactConfig)
+            assert isinstance(self.config.vhd, VhdArtifactConfig)
+            assert isinstance(self.config.arm_template, ArmArtifactConfig)
             return {
                 "location": {"value": self.config.location},
                 "publisherName": {"value": self.config.publisher_name},

--- a/src/aosm/azext_aosm/generate_nfd/vnf_nfd_generator.py
+++ b/src/aosm/azext_aosm/generate_nfd/vnf_nfd_generator.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, Optional
 
 from knack.log import get_logger
 
-from azext_aosm._configuration import ArtifactConfig, VNFConfiguration
+from azext_aosm._configuration import ArmArtifactConfig, VNFConfiguration
 from azext_aosm.generate_nfd.nfd_generator_base import NFDGenerator
 from azext_aosm.util.constants import (
     CONFIG_MAPPINGS_DIR_NAME,
@@ -67,7 +67,7 @@ class VnfNfdGenerator(NFDGenerator):
     ):
         self.config = config
 
-        assert isinstance(self.config.arm_template, ArtifactConfig)
+        assert isinstance(self.config.arm_template, ArmArtifactConfig)
         assert self.config.arm_template.file_path
 
         self.arm_template_path = Path(self.config.arm_template.file_path)


### PR DESCRIPTION
Refactor artifact code into subclasses where the superclass is an abstract class of abc.ABC - this is in line with Chaos' review comments on [Remove Blob_SAS_URL Option from ArmTemplate in input file by jordlay · Pull Request #119 · jddarby/azure-cli-extensions (github.com)](https://github.com/jddarby/azure-cli-extensions/pull/119/files), which I decided not to implement due to it being GA release day and it was a bit bigger than I was comfortable with.

This PR needs to be merged post-GA into "wherever it is we are merging PRs after that", with a change to History.rst.  

There is no change to the interface of input.json so no version bump required.