### PR TITLE
WIP: Bug 1001395 Create manifest names in correct format

### DIFF
--- a/src/aosm/azext_aosm/_configuration.py
+++ b/src/aosm/azext_aosm/_configuration.py
@@ -116,10 +116,7 @@ class NSArmArtifactConfig(ArmArtifactConfig):
 
     def acr_manifest_name(self, nsd_version: str) -> str:
         """Return the ACR manifest name from the artifact name."""
-        return (
-            f"{self.artifact_name.lower().replace('_', '-')}"
-            f"-acr-manifest-{nsd_version.replace('.', '-')}"
-        )
+        return format_manifest_name(f"{self.artifact_name}-mf-{nsd_version}")
 
 
 @dataclass
@@ -277,6 +274,26 @@ class Configuration(abc.ABC):
         """The list of ACR manifest names."""
         raise NotImplementedError("Subclass must define property")
 
+    @staticmethod
+    def format_acr_artifact_name_for_manifest(artifact_name: str) -> str:
+        """
+        Format artifact name to allowed chars and length.
+
+        Note this is the artifact name not the artifact manifest name.
+
+        Rules for CGS name are up to 256 lowercase alphanumeric characters, - or _. Must
+        begin with an alphanumeric character.
+
+        Return the reformatted name.
+        """
+        # Replace any non-allowed characters with '_'
+        artifact_name = artifact_name.lower()
+        artifact_name = re.sub("[^0-9a-z_.-]+", "_", artifact_name)
+        # Strip leading or trailing _
+        artifact_name = artifact_name.strip("_")
+        artifact_name = artifact_name[:256]
+        return artifact_name
+
 
 @dataclass
 class NFConfiguration(Configuration):
@@ -314,9 +331,12 @@ class NFConfiguration(Configuration):
 
         This is returned in a list for consistency with the NSConfiguration, where there
         can be multiple ACR manifests.
+        
+        Artifact manifest resource name must be between 5 and 50 characters long, and
+        must start with a letter and contain only alphanumeric characters optionally
+        separated by a '-'.";
         """
-        sanitized_nf_name = self.nf_name.lower().replace("_", "-")
-        return [f"{sanitized_nf_name}-acr-manifest-{self.version.replace('.', '-')}"]
+        return [format_manifest_name(f"{self.nf_name}-acr-mf-{self.version.replace('.', '-')}")]
 
 
 @dataclass
@@ -384,8 +404,7 @@ class VNFConfiguration(NFConfiguration):
     @property
     def sa_manifest_name(self) -> str:
         """Return the Storage account manifest name from the NFD name."""
-        sanitized_nf_name = self.nf_name.lower().replace("_", "-")
-        return f"{sanitized_nf_name}-sa-manifest-{self.version.replace('.', '-')}"
+        return format_manifest_name(f"{self.nf_name}-sa-mf-{self.version}")
 
     @property
     def output_directory_for_build(self) -> Path:
@@ -676,10 +695,7 @@ class NFDRETConfiguration:  # pylint: disable=too-many-instance-attributes
 
     def acr_manifest_name(self, nsd_version: str) -> str:
         """Return the ACR manifest name from the NFD name."""
-        return (
-            f"{self.name.lower().replace('_', '-')}"
-            f"-nf-acr-manifest-{nsd_version.replace('.', '-')}"
-        )
+        return format_manifest_name(f"{self.name}-nf-mf-{nsd_version}")
 
 
 @dataclass
@@ -734,7 +750,7 @@ class NSConfiguration(Configuration):
                     if not artifact.artifact_name:
                         artifact.artifact_name = Path(artifact.file_path).stem
                     # Make sure the artifact name is in the correct format for the manifest
-                    artifact.artifact_name = self.format_artifact_name_for_manifest(
+                    artifact.artifact_name = self.format_acr_artifact_name_for_manifest(
                         artifact.artifact_name
                     )
             # self.arm_templates will be sorted in the order added in input.json
@@ -928,34 +944,16 @@ class NSConfiguration(Configuration):
         for nf in self.network_functions:
             assert isinstance(nf, NFDRETConfiguration)
             arm_template_names.append(
-                self.format_artifact_name_for_manifest(nf.arm_template.artifact_name)
+                self.format_acr_artifact_name_for_manifest(nf.arm_template.artifact_name)
             )
         for arm_template in self.arm_templates:
             assert isinstance(arm_template, NSArmArtifactConfig)
             arm_template_names.append(
-                self.format_artifact_name_for_manifest(arm_template.artifact_name)
+                self.format_acr_artifact_name_for_manifest(arm_template.artifact_name)
             )
         return sorted(arm_template_names)
 
-    @staticmethod
-    def format_artifact_name_for_manifest(artifact_name: str) -> str:
-        """
-        Format artifact name to allowed chars and length.
 
-        Note this is the artifact name not the artifact manifest name.
-
-        Rules for CGS name are up to 256 lowercase alphanumeric characters, - or _. Must
-        begin with an alphanumeric character.
-
-        Return the reformatted name.
-        """
-        # Replace any non-allowed characters with '_'
-        artifact_name = artifact_name.lower()
-        artifact_name = re.sub("[^0-9a-z_.-]+", "_", artifact_name)
-        # Strip leading or trailing _
-        artifact_name = artifact_name.strip("_")
-        artifact_name = artifact_name[:256]
-        return artifact_name
 
 
 def get_configuration(configuration_type: str, config_file: str) -> Configuration:
@@ -994,3 +992,32 @@ def get_configuration(configuration_type: str, config_file: str) -> Configuratio
     config.validate()
 
     return config
+
+
+def format_manifest_name(manifest_name: str) -> str:
+    """
+    Format artifact manifest name to allowed chars and length.
+
+    Note this is the artifact manifest name not the artifact name.
+
+    Artifact manifest resource name must be between 5 and 50 characters long, and
+    must start with a letter and contain only alphanumeric characters optionally
+    separated by a '-'. It must not end with a hyphen. (see
+    ArtifactManifestCreationValidator.cs in pez)
+    
+    We lower the name as well
+
+    Return the reformatted name.
+    """
+    manifest_name = manifest_name.lower()
+    # Replace any non-allowed characters with '-'    
+    manifest_name = re.sub("[^0-9A-Za-z-]+", "-", manifest_name)
+    # Strip leading or trailing -
+    manifest_name = manifest_name.strip("-")
+    if len(manifest_name) > 50:
+        raise ValidationError(
+            f"Manifest name {manifest_name} is too long. Must be 50 characters or less."
+            "Please shorten the items in your config file that contribute to this name."
+        )
+    manifest_name = manifest_name[:50]
+    return manifest_name


### PR DESCRIPTION
Work in progress bugfix for https://dev.azure.com/msazuredev/AzureForOperators/_workitems/edit/1001395

-Raised by: Graeme Robertson (HE/HIM): How are artifact manifests used?   Specifically I'm c...
posted in AFO Technical Team / AOSM Help on 30 October 2023 17:32

**Context**
Mountain-lake couldn't use nsd publish as normal because the CLI had created a manifest name that is over the 50 character limit.  

(AOSM has a wide range of requirements for validation that are not documented in the API.  One thing that was supposed to be happening at documentation time was that these were documented. I don't believe they were. See rambly discussion here: 
[Jacob Darby: Allow list for ARM resources deployed by an NF](https://teams.microsoft.com/l/message/19:e9924bd3d8604ba0be7d062da30036c2@thread.tacv2/1695805174240?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=936e9161-6b66-4757-b534-b890ffedb274&parentMessageId=1695805174240&teamName=A40%20LCM%20Team&channelName=UK%20-%20General&createdTime=1695805174240)
posted in A40 LCM Team / UK - General on 27 September 2023 09:59)

The particular problem here are the validation requirements on artifact manifest names:
https://dev.azure.com/msazuredev/AzureForOperators/_git/pez?path=/src/MultiaccessEdgeCompute/ArtifactManifest/Errors/ArtifactManifestValidationErrorMessages.cs&_a=contents&version=GBmain for error messages and https://dev.azure.com/msazuredev/AzureForOperators/_git/pez?path=/src/MultiaccessEdgeCompute/ArtifactManifest/Validators/ArtifactManifestCreationValidator.cs&_a=contents&version=GBmain for strings.

Jacob argues that the CLI should not repeat the Validation that AOSM does, as it is the job of the RP.  However the CLI creates a whole load of stuff at once and it's annoying to get half way through and then fail.  In this case, it doesn't fail until deploy time.

In the particular case of manifest names, the CLI creates those out of combinations of values from the input.json file, versions and constants, e.g. 
ubuntu-vm-nfdg-nf-acr-manifest-1-0-0

With a 50 character limit, you don't need a long nf name to exceed the requirement

Sunny started work on this but had these worries:
 1) Can we change manifest names in the CLI without it being a breaking change?  I think it would only break `delete` functionality, not anything to do with publish - if you tried to delete a NSD/NFD created by an old version of the CLI and it had different names
2) Should we raise an exception if the manifest name is too long, or truncate it?  If truncating, we'd chop the version off the end, which wouldn't be good as having unique manifest name per version is important for publishing new NFDs / NSDs
3) See linked bug - what do we do about option to pass in --manifest-params-file argument?