### PR TITLE
Fix two minor CLI bugs

### DIFF
--- a/src/aosm/azext_aosm/cli_handlers/onboarding_cnf_handler.py
+++ b/src/aosm/azext_aosm/cli_handlers/onboarding_cnf_handler.py
@@ -9,25 +9,34 @@ from pathlib import Path
 from azure.cli.core.azclierror import UnclassifiedUserFault
 from azext_aosm.build_processors.helm_chart_processor import HelmChartProcessor
 from azext_aosm.inputs.helm_chart_input import HelmChartInput
-from azext_aosm.common.constants import (ARTIFACT_LIST_FILENAME,
-                                         CNF_DEFINITION_TEMPLATE_FILENAME,
-                                         CNF_MANIFEST_TEMPLATE_FILENAME,
-                                         CNF_BASE_TEMPLATE_FILENAME,
-                                         CNF_DEFINITION_FOLDER_NAME,
-                                         CNF_OUTPUT_FOLDER_FILENAME,
-                                         CNF_INPUT_FILENAME,
-                                         MANIFEST_FOLDER_NAME,
-                                         NF_DEFINITION_FOLDER_NAME,
-                                         BASE_FOLDER_NAME)
+from azext_aosm.common.constants import (
+    ARTIFACT_LIST_FILENAME,
+    CNF_DEFINITION_TEMPLATE_FILENAME,
+    CNF_MANIFEST_TEMPLATE_FILENAME,
+    CNF_BASE_TEMPLATE_FILENAME,
+    CNF_DEFINITION_FOLDER_NAME,
+    CNF_OUTPUT_FOLDER_FILENAME,
+    CNF_INPUT_FILENAME,
+    MANIFEST_FOLDER_NAME,
+    NF_DEFINITION_FOLDER_NAME,
+    BASE_FOLDER_NAME,
+)
 from azext_aosm.common.local_file_builder import LocalFileBuilder
-from azext_aosm.configuration_models.onboarding_cnf_input_config import \
-    OnboardingCNFInputConfig
-from azext_aosm.configuration_models.common_parameters_config import CNFCommonParametersConfig
-from azext_aosm.definition_folder.builder.artifact_builder import \
-    ArtifactDefinitionElementBuilder
-from azext_aosm.definition_folder.builder.bicep_builder import \
-    BicepDefinitionElementBuilder
-from azext_aosm.definition_folder.builder.json_builder import JSONDefinitionElementBuilder
+from azext_aosm.configuration_models.onboarding_cnf_input_config import (
+    OnboardingCNFInputConfig,
+)
+from azext_aosm.configuration_models.common_parameters_config import (
+    CNFCommonParametersConfig,
+)
+from azext_aosm.definition_folder.builder.artifact_builder import (
+    ArtifactDefinitionElementBuilder,
+)
+from azext_aosm.definition_folder.builder.bicep_builder import (
+    BicepDefinitionElementBuilder,
+)
+from azext_aosm.definition_folder.builder.json_builder import (
+    JSONDefinitionElementBuilder,
+)
 from .onboarding_nfd_base_handler import OnboardingNFDBaseCLIHandler
 
 
@@ -50,20 +59,22 @@ class OnboardingCNFCLIHandler(OnboardingNFDBaseCLIHandler):
             input_config = {}
         return OnboardingCNFInputConfig(**input_config)
 
-    def _get_params_config(self, params_config: dict = None) -> CNFCommonParametersConfig:
+    def _get_params_config(
+        self, params_config: dict = None
+    ) -> CNFCommonParametersConfig:
         """Get the configuration for the command."""
         if params_config is None:
             params_config = {}
         return CNFCommonParametersConfig(**params_config)
 
     def build_base_bicep(self):
-        """ Build the base bicep file."""
+        """Build the base bicep file."""
 
         # Build manifest bicep contents, with j2 template
-        template_path = self._get_template_path(CNF_DEFINITION_FOLDER_NAME, CNF_BASE_TEMPLATE_FILENAME)
-        bicep_contents = self._render_base_bicep_contents(
-            template_path
+        template_path = self._get_template_path(
+            CNF_DEFINITION_FOLDER_NAME, CNF_BASE_TEMPLATE_FILENAME
         )
+        bicep_contents = self._render_base_bicep_contents(template_path)
         # Create Bicep element with manifest contents
         bicep_file = BicepDefinitionElementBuilder(
             Path(CNF_OUTPUT_FOLDER_FILENAME, BASE_FOLDER_NAME), bicep_contents
@@ -82,26 +93,32 @@ class OnboardingCNFCLIHandler(OnboardingNFDBaseCLIHandler):
                 if Path.exists(Path(helm_package.path_to_mappings)):
                     provided_config = json.load(open(helm_package.path_to_mappings))
                 else:
-                    raise UnclassifiedUserFault("There is no file at the path provided for the mappings file.")
+                    raise UnclassifiedUserFault(
+                        "There is no file at the path provided for the mappings file."
+                    )
             else:
                 provided_config = None
 
-            helm_input = HelmChartInput.from_chart_path(Path(helm_package.path_to_chart), default_config=provided_config)
+            helm_input = HelmChartInput.from_chart_path(
+                Path(helm_package.path_to_chart), default_config=provided_config
+            )
             processed_helm = HelmChartProcessor(
                 helm_package.name,
                 helm_input,
                 self.config.images.source_registry,
-                self.config.images.source_registry_namespace
+                self.config.images.source_registry_namespace,
             )
             artifacts = processed_helm.get_artifact_manifest_list()
-        # TODO: future work: make artifact_list a set, then convert back to list
-        # TODO: future work: add to util, compare properly the artifacts
-        # Add artifacts to a list of unique artifacts
+            # TODO: future work: make artifact_list a set, then convert back to list
+            # TODO: future work: add to util, compare properly the artifacts
+            # Add artifacts to a list of unique artifacts
             if artifacts not in artifact_list:
                 artifact_list.extend(artifacts)
 
         # Build manifest bicep contents, with j2 template
-        template_path = self._get_template_path(CNF_DEFINITION_FOLDER_NAME, CNF_MANIFEST_TEMPLATE_FILENAME)
+        template_path = self._get_template_path(
+            CNF_DEFINITION_FOLDER_NAME, CNF_MANIFEST_TEMPLATE_FILENAME
+        )
         bicep_contents = self._render_manifest_bicep_contents(
             template_path, artifact_list
         )
@@ -117,13 +134,15 @@ class OnboardingCNFCLIHandler(OnboardingNFDBaseCLIHandler):
         artifact_list = []
         # For each helm package, get list of artifacts and combine
         for helm_package in self.config.helm_packages:
-            helm_input = HelmChartInput.from_chart_path(Path(helm_package.path_to_chart), default_config=None)
+            helm_input = HelmChartInput.from_chart_path(
+                Path(helm_package.path_to_chart), default_config=None
+            )
 
             processed_helm = HelmChartProcessor(
                 helm_package.name,
                 helm_input,
                 self.config.images.source_registry,
-                self.config.images.source_registry_namespace
+                self.config.images.source_registry_namespace,
             )
             (artifacts, files) = processed_helm.get_artifact_details()
             if artifacts not in artifact_list:
@@ -146,19 +165,23 @@ class OnboardingCNFCLIHandler(OnboardingNFDBaseCLIHandler):
                 if Path.exists(Path(helm_package.path_to_mappings)):
                     provided_config = json.load(open(helm_package.path_to_mappings))
                 else:
-                    raise UnclassifiedUserFault("There is no file at the path provided for the mappings file.")
+                    raise UnclassifiedUserFault(
+                        "There is no file at the path provided for the mappings file."
+                    )
             else:
                 provided_config = None
 
             # Create HelmChartInput object from chart path provided in input file
-            helm_input = HelmChartInput.from_chart_path(Path(helm_package.path_to_chart), default_config=provided_config)
+            helm_input = HelmChartInput.from_chart_path(
+                Path(helm_package.path_to_chart), default_config=provided_config
+            )
 
             # Create HelmChartProcessor object from HelmChartInput object
             processed_helm = HelmChartProcessor(
                 helm_package.name,
                 helm_input,
                 self.config.images.source_registry,
-                self.config.images.source_registry_namespace
+                self.config.images.source_registry_namespace,
             )
 
             # Generate nf application
@@ -179,11 +202,13 @@ class OnboardingCNFCLIHandler(OnboardingNFDBaseCLIHandler):
                     NF_DEFINITION_FOLDER_NAME,
                     nf_application.name + "-mappings.json",
                 ),
-                deploy_values,
+                json.dumps(json.loads(deploy_values), indent=4),
             )
             mappings_files.append(mapping_file)
 
-        template_path = self._get_template_path(CNF_DEFINITION_FOLDER_NAME, CNF_DEFINITION_TEMPLATE_FILENAME)
+        template_path = self._get_template_path(
+            CNF_DEFINITION_FOLDER_NAME, CNF_DEFINITION_TEMPLATE_FILENAME
+        )
         bicep_contents = self._render_definition_bicep_contents(
             template_path, nf_application_list
         )
@@ -197,7 +222,9 @@ class OnboardingCNFCLIHandler(OnboardingNFDBaseCLIHandler):
 
         # Add the deploymentParameters schema file
         bicep_file.add_supporting_file(
-            self._render_deployment_params_schema(schema_properties, CNF_OUTPUT_FOLDER_FILENAME, NF_DEFINITION_FOLDER_NAME)
+            self._render_deployment_params_schema(
+                schema_properties, CNF_OUTPUT_FOLDER_FILENAME, NF_DEFINITION_FOLDER_NAME
+            )
         )
         return bicep_file
 

--- a/src/aosm/azext_aosm/cli_handlers/onboarding_vnf_handler.py
+++ b/src/aosm/azext_aosm/cli_handlers/onboarding_vnf_handler.py
@@ -206,7 +206,7 @@ class OnboardingVNFCLIHandler(OnboardingNFDBaseCLIHandler):
                         NF_DEFINITION_FOLDER_NAME,
                         TEMPLATE_PARAMETERS_FILENAME,
                     ),
-                    json.dumps(template_params, indent=4),
+                    json.dumps(json.loads(template_params), indent=4),
                 )
                 supporting_files.append(template_parameters_file)
                 logger.info(

--- a/src/aosm/azext_aosm/cli_handlers/onboarding_vnf_handler.py
+++ b/src/aosm/azext_aosm/cli_handlers/onboarding_vnf_handler.py
@@ -23,7 +23,9 @@ from azext_aosm.common.local_file_builder import LocalFileBuilder
 from azext_aosm.configuration_models.onboarding_vnf_input_config import (
     OnboardingVNFInputConfig,
 )
-from azext_aosm.configuration_models.common_parameters_config import VNFCommonParametersConfig
+from azext_aosm.configuration_models.common_parameters_config import (
+    VNFCommonParametersConfig,
+)
 from azext_aosm.definition_folder.builder.artifact_builder import (
     ArtifactDefinitionElementBuilder,
 )
@@ -62,7 +64,9 @@ class OnboardingVNFCLIHandler(OnboardingNFDBaseCLIHandler):
             input_config = {}
         return OnboardingVNFInputConfig(**input_config)
 
-    def _get_params_config(self, params_config: dict = None) -> VNFCommonParametersConfig:
+    def _get_params_config(
+        self, params_config: dict = None
+    ) -> VNFCommonParametersConfig:
         """Get the configuration for the command."""
         if params_config is None:
             params_config = {}
@@ -230,7 +234,7 @@ class OnboardingVNFCLIHandler(OnboardingNFDBaseCLIHandler):
                     NF_DEFINITION_FOLDER_NAME,
                     "templateParameters.json",
                 ),
-                json.dumps(template_params, indent=4),
+                json.dumps(json.loads(template_params), indent=4),
             )
             supporting_files.append(template_parameters_file)
             logger.info(

--- a/src/aosm/azext_aosm/definition_folder/builder/definition_folder_builder.py
+++ b/src/aosm/azext_aosm/definition_folder/builder/definition_folder_builder.py
@@ -5,15 +5,16 @@
 
 import json
 from pathlib import Path
+import shutil
 from azure.cli.core.azclierror import UnclassifiedUserFault
 from azext_aosm.definition_folder.builder.base_builder import (
     BaseDefinitionElementBuilder,
 )
 from azext_aosm.definition_folder.builder.bicep_builder import (
-    BicepDefinitionElementBuilder
+    BicepDefinitionElementBuilder,
 )
 from azext_aosm.definition_folder.builder.json_builder import (
-    JSONDefinitionElementBuilder
+    JSONDefinitionElementBuilder,
 )
 
 from typing import List
@@ -36,7 +37,9 @@ class DefinitionFolderBuilder:
     def write(self):
         """Write the definition folder."""
         self._check_for_overwrite()
-        self.path.mkdir(exist_ok=True)
+        if self.path.exists():
+            shutil.rmtree(self.path)
+        self.path.mkdir()
         for element in self.elements:
             element.write()
         index_json = []


### PR DESCRIPTION
1. There was a bug in the CLI where the JSON output was not formatted correctly for CNFs and for VNFs the output was escaped JSON:
![image](https://github.com/jddarby/azure-cli-extensions/assets/116072282/283976c4-fb97-485d-8d1f-f5401401ee8e)
![image](https://github.com/jddarby/azure-cli-extensions/assets/116072282/87a828f2-ec1c-4f69-ba06-60bf30a092d8)

This happened because in the first case we were just writing the string into a JSON file without any formatting, and in the other case we were trying to do formatting using `json.dumps` but on a string instead of a Python object. I added a `json.loads` call to change the string into a valid JSON object and then output that into the JSON file. 

2. Second bug was that we were never deleting our build file when telling the user we will overwrite it but instead we just overwrote individual files in that folder. I added a delete call. to make sure no temporary files are left in the folder. 

This PR includes some formatting changes. I think they are correct as I am using Black formatter but please shout if I set it up wrong.
