### PR TITLE
moved blob sa name to validate to fix bug

### DIFF
--- a/src/aosm/azext_aosm/configuration_models/onboarding_vnf_input_config.py
+++ b/src/aosm/azext_aosm/configuration_models/onboarding_vnf_input_config.py
@@ -147,10 +147,6 @@ class OnboardingCoreVNFInputConfig(OnboardingNFDBaseInputConfig):
         if self.vhd and isinstance(self.vhd, dict):
             self.vhd = VhdImageConfig(**self.vhd)
 
-        sanitized_nf_name = self.nf_name.lower().replace("_", "-")
-        if not self.blob_artifact_store_name:
-            self.blob_artifact_store_name = sanitized_nf_name + "-sa"
-
     @property
     def sa_manifest_name(self) -> str:
         """Return the Storage account manifest name from the NFD name and version."""
@@ -171,6 +167,11 @@ class OnboardingCoreVNFInputConfig(OnboardingNFDBaseInputConfig):
         for arm_template in self.arm_templates:
             arm_template.validate()
         self.vhd.validate()
+
+        # We have to do this in validate, otherwise it created the input file with "-sa"
+        sanitized_nf_name = self.nf_name.lower().replace("_", "-")
+        if not self.blob_artifact_store_name:
+            self.blob_artifact_store_name = sanitized_nf_name + "-sa"
 
 
 @dataclass


### PR DESCRIPTION
---
If no blob name is provided, we take the nf name (sanitised) and append -sa to it. This implementation meant that -sa was being put into the empty input.jsonc file on generate config. To fix this, we move the logic from the post innit to the validate (which is only called on build)

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
