### PR TITLE
Use common.utils function to check if docker/helm is installed (code …

### DIFF
--- a/src/aosm/azext_aosm/common/artifact.py
+++ b/src/aosm/azext_aosm/common/artifact.py
@@ -25,7 +25,7 @@ from azext_aosm.vendored_sdks.azure_storagev2.blob.v2022_11_02 import (
 from azext_aosm.vendored_sdks.models import ArtifactType
 from azext_aosm.vendored_sdks import HybridNetworkManagementClient
 from azext_aosm.common.command_context import CommandContext
-from azext_aosm.common.utils import convert_bicep_to_arm
+from azext_aosm.common.utils import check_tool_installed, convert_bicep_to_arm
 from knack.util import CLIError
 from knack.log import get_logger
 from oras.client import OrasClient
@@ -63,16 +63,6 @@ class BaseACRArtifact(BaseArtifact):
         self, config: BaseCommonParametersConfig, command_context: CommandContext
     ):
         """Upload the artifact."""
-
-    @staticmethod
-    def _check_tool_installed(tool_name: str) -> None:
-        """
-        Check whether a tool such as docker or helm is installed.
-
-        :param tool_name: name of the tool to check, e.g. docker
-        """
-        if shutil.which(tool_name) is None:
-            raise CLIError(f"You must install {tool_name} to use this command.")
 
     @staticmethod
     def _clean_name(registry_name: str) -> str:
@@ -225,8 +215,8 @@ class LocalFileACRArtifact(BaseACRArtifact):
             username = manifest_credentials["username"]
             password = manifest_credentials["acr_token"]
 
-            self._check_tool_installed("docker")
-            self._check_tool_installed("helm")
+            check_tool_installed("docker")
+            check_tool_installed("helm")
 
             # tmpdir is only used if file_path is dir, but `with` context manager is cleaner to use, so we always
             # set up the tmpdir, even if it doesn't end up being used.
@@ -592,7 +582,7 @@ class RemoteACRArtifact(BaseACRArtifact):
             print(
                 f"Using docker pull and push to copy image artifact: {self.artifact_name}"
             )
-            self._check_tool_installed("docker")
+            check_tool_installed("docker")
             image_name = (
                 f"{self._clean_name(self.source_registry)}/"
                 f"{self.namespace_with_slash}{self.artifact_name}"


### PR DESCRIPTION
At some point the check_tool_installed method was moved to common.utils as a function, but it looks like the existing code wasn't deleted from artifact.py.

This PR fixes that. The code diff should be fairly self-explanatory.

The exception type raised changes from CLIError to MissingDependency, but as none of the code as try/except for this function, I think that's fine.