### PR TITLE
Add docker dependency option to oras in setup.py

### DIFF
--- a/src/aosm/HISTORY.rst
+++ b/src/aosm/HISTORY.rst
@@ -5,9 +5,10 @@ Release History
 
 Unreleased
 ++++++++
-* Added: Users can specify multiple image sources from all types of registries (not just ACRs). General improvements in how CNF image sources are handled. 
+* Added: Users can specify multiple image sources from all types of registries (not just ACRs). General improvements in how CNF image sources are handled.
 * Fixed: Namespace appeared twice in the `artifacts.json` file, leading to errors in the publish step of the CLI.
 * Changed configurationType for NF Resources from Secret to Open
+* Added docker dependency for Oras client library to setup.py.
 
 1.0.0b10
 ++++++++

--- a/src/aosm/setup.py
+++ b/src/aosm/setup.py
@@ -34,7 +34,7 @@ CLASSIFIERS = [
 ]
 
 DEPENDENCIES = [
-    "oras~=0.1.19",
+    "oras[docker]~=0.1.19",
     "azure-storage-blob>=12.15.0",
     "jinja2>=3.1.2",
     "genson>=1.2.2",


### PR DESCRIPTION
The Oras library we use has the Python docker module as an optional requirement. We do use that branch of Oras's code, so need the module.  We didn't have the optional requirement turned on, so if you didn't already have the Python docker module installed, the AOSM CLI broke.

This PR adds the docker option into setup.py.

## Testing
Tobias Weiserth hit this. Confirmed fixed after this change.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
