### PR TITLE
Fix null as default in deployParams

### DIFF
--- a/src/aosm/azext_aosm/build_processors/base_processor.py
+++ b/src/aosm/azext_aosm/build_processors/base_processor.py
@@ -201,11 +201,10 @@ class BaseInputProcessor(ABC):
                     )
                 else:
                     if prop in default_values:
-                        # AOSM wants null as a string
-                        # TODO: Flag with RP that this is a bug?
+                        # If default is None, make param required
                         if default_values[prop] is None:
-                            default_values[prop] = "null"
-                        details["default"] = default_values[prop]
+                            deploy_params_schema["required"].append(param_name)
+
                     # If there is a default of '[resourceGroup().location]'
                     # which is not allowed to be passed into CGVs
                     if "default" in details and details["default"] == '[resourceGroup().location]':

--- a/src/aosm/azext_aosm/build_processors/base_processor.py
+++ b/src/aosm/azext_aosm/build_processors/base_processor.py
@@ -201,10 +201,13 @@ class BaseInputProcessor(ABC):
                     )
                 else:
                     if prop in default_values:
-                        # If default is None, make param required
+                        # RP does not accept null values as defaults,
+                        # which will fail the NFDV publish
+                        # So if there is null default, add to required
                         if default_values[prop] is None:
                             deploy_params_schema["required"].append(param_name)
-
+                        else:
+                            details["default"] = default_values[prop]
                     # If there is a default of '[resourceGroup().location]'
                     # which is not allowed to be passed into CGVs
                     if "default" in details and details["default"] == '[resourceGroup().location]':


### PR DESCRIPTION
---
If there is a null type, the default is null. AOSM doesnt allow this at nfdv publish stage. To workaround this, we check if the default is none, and add it to required if not.

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
