### PR TITLE
Add quotes to the CNF input config image sources comment

### DIFF
--- a/src/aosm/azext_aosm/configuration_models/onboarding_cnf_input_config.py
+++ b/src/aosm/azext_aosm/configuration_models/onboarding_cnf_input_config.py
@@ -68,7 +68,7 @@ class OnboardingCNFInputConfig(OnboardingNFDBaseInputConfig):
         metadata={
             "comment": (
                 "List of registries from which to pull the image(s).\n"
-                "For example [sourceacr.azurecr.io/test, myacr2.azurecr.io, ghcr.io/path].\n"
+                'For example ["sourceacr.azurecr.io/test", "myacr2.azurecr.io", "ghcr.io/path"].\n'
                 "For non Azure Container Registries, ensure you have run a docker login command before running build.\n"
             )
         },


### PR DESCRIPTION
Jordan pointed out that one of the customers did not have quotes around their images sources in the screenshot of the config for their CNFs. This should result in a "invalid JSON" error which should be easy to fix. The problem is that we were actually not including quotes in the config comments which would mean that if the user does what we tell them to do, it will result in an error. That is not good. This PR fixes this minor omission. 

**I pointed this at the main branch because I don't think there is any risk to it. Let me know if you disagree.** 