### PR TITLE
Fix Multi-NF failure

### DIFF
--- a/src/aosm/HISTORY.rst
+++ b/src/aosm/HISTORY.rst
@@ -4,7 +4,9 @@ Release History
 ===============
 2.0.0b2
 ++++++++
-* added a check to make sure resource type used in ARM template are in allowed list
+* Added check to make sure resource type used in ARM template are in allowed list
+* Fixed multi NF RETs issue in nsdvs
+
 2.0.0b1
 ++++++++
 * Renamed nfdvName to nfdv in CGVs

--- a/src/aosm/azext_aosm/cli_handlers/onboarding_nsd_handler.py
+++ b/src/aosm/azext_aosm/cli_handlers/onboarding_nsd_handler.py
@@ -106,7 +106,6 @@ class OnboardingNSDCLIHandler(OnboardingBaseCLIHandler):
                         resource_element.properties.file_path
                     ).absolute(),
                 )
-                # TODO: generalise for nexus in nexus ready stories
                 # For NSDs, we don't have the option to expose ARM template parameters. This could be supported by
                 # adding an 'expose_all_parameters' option to NSD input.jsonc file, as we have for NFD input files.
                 # For now, we prefer this simpler interface for NSDs, but we might need to revisit in the future.
@@ -115,14 +114,6 @@ class OnboardingNSDCLIHandler(OnboardingBaseCLIHandler):
                 )
             elif resource_element.resource_element_type == "NF":
                 assert isinstance(resource_element.properties, NetworkFunctionPropertiesConfig)
-                # TODO: change artifact name and version to the nfd name and version or justify why it was this
-                #       in the first place
-                # AC4 note: I couldn't find a reference in the old code, but this
-                # does ring a bell. Was it so the artifact manifest didn't get broken with changes to NF versions?
-                # I.e., you could make an NF version change in CGV, and the artifact manifest, which is immutable,
-                # would still be valid?
-                # I am concerned that if we have multiple NFs we will have clashing artifact names.
-                # I'm not changing the behaviour right now as it's too high risk, but we should look again here.
                 nfdv_object = self._get_nfdv(resource_element.properties)
 
                 # Add nfvi_type to list for creating nfvisFromSite later
@@ -131,11 +122,8 @@ class OnboardingNSDCLIHandler(OnboardingBaseCLIHandler):
                 self.nfvi_types.append(nfdv_object.properties.network_function_template.nfvi_type)
 
                 nfd_input = NFDInput(
-                    # This would be the alternative if we swap from nsd name/version to nfd.
-                    # artifact_name=resource_element.properties.name,
-                    # artifact_version=resource_element.properties.version,
-                    artifact_name=self.config.nsd_name,
-                    artifact_version=self.config.nsd_version,
+                    artifact_name=resource_element.properties.name,
+                    artifact_version=resource_element.properties.version,
                     default_config={"location": self.config.location},
                     network_function_definition=nfdv_object,
                     arm_template_output_path=Path(
@@ -145,7 +133,7 @@ class OnboardingNSDCLIHandler(OnboardingBaseCLIHandler):
                     ),
                 )
                 nfd_processor = NFDProcessor(
-                    name=self.config.nsd_name, input_artifact=nfd_input
+                    name=resource_element.properties.name, input_artifact=nfd_input
                 )
                 processor_list.append(nfd_processor)
             else:


### PR DESCRIPTION
---
Problem:
When multiple nf RETs were defined in nsd-input.jsonc, there would be 2 RETs in the NSDV but they would be identical, there would also only be one mapping file. This was due to the previous design decision to call the RETs the NSD name and version, instead of the NF name.

Fix:
- Changed processor and artifacts to use nf name instead of nsd name

Testing:
- Testing single nf still behaves as expected with cnf to sns - ongoing
- Test NSDV republish with same values
- Test NSDV republish with different values
- Test multi nf to sns with 2 CNFS:
![image](https://github.com/jddarby/azure-cli-extensions/assets/72226943/76b9c976-77f4-4e33-9f87-05c40b24f4f5)

- 
This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
