### PR TITLE
Remove azure-storage-blob from dependencies.

### DIFF
--- a/src/aosm/setup.py
+++ b/src/aosm/setup.py
@@ -35,7 +35,6 @@ CLASSIFIERS = [
 
 DEPENDENCIES = [
     "oras~=0.1.19",
-    "azure-storage-blob>=12.15.0",
     "jinja2>=3.1.4",
     "genson>=1.2.2",
     "ruamel.yaml>=0.17.4",


### PR DESCRIPTION
The `azure-storage-blob` dependency was deleted and the library moved to `vendored_sdks` for the last release at the request of the central Azure CLI team (the namespacing of Azure SDKs causes problems on Macs).

It crept back in at some point. This PR removes it again.