### PR TITLE
Pk5/fix integration tests for release

### DIFF
--- a/src/aosm/azext_aosm/tests/latest/integration_tests/integration_test_mocks/mock_input_templates/cnf_input_template.jsonc
+++ b/src/aosm/azext_aosm/tests/latest/integration_tests/integration_test_mocks/mock_input_templates/cnf_input_template.jsonc
@@ -3,7 +3,7 @@
   "location": "uksouth",
   // Name of the Publisher resource you want your definition published to.
   // Will be created if it does not exist.
-  "publisher_name": "automated-cli-tests-nginx-publisher",
+  "publisher_name": "automated-cli-test-nginx-publisher",
   // Optional. Resource group for the Publisher resource.
   // Will be created if it does not exist (with a default name if none is supplied).
   "publisher_resource_group_name": "{{publisher_resource_group_name}}",

--- a/src/aosm/azext_aosm/tests/latest/integration_tests/integration_test_mocks/mock_input_templates/cnf_nsd_input_template.jsonc
+++ b/src/aosm/azext_aosm/tests/latest/integration_tests/integration_test_mocks/mock_input_templates/cnf_nsd_input_template.jsonc
@@ -1,11 +1,11 @@
 {
-  "publisher_name": "automated-cli-tests-nginx-publisher",
+  "publisher_name": "automated-cli-test-nginx-publisher",
   "publisher_resource_group_name": "{{publisher_resource_group_name}}",
   "acr_artifact_store_name": "nginx-nsd-acr",
   "location": "uksouth",
   "network_functions": [
     {
-      "publisher": "automated-cli-tests-nginx-publisher",
+      "publisher": "automated-cli-test-nginx-publisher",
       "publisher_resource_group": "{{publisher_resource_group_name}}",
       "name": "nginx-nfdg",
       "version": "1.0.0",

--- a/src/aosm/azext_aosm/tests/latest/integration_tests/integration_test_mocks/mock_input_templates/input_multi_nf_nsd.jsonc
+++ b/src/aosm/azext_aosm/tests/latest/integration_tests/integration_test_mocks/mock_input_templates/input_multi_nf_nsd.jsonc
@@ -1,6 +1,6 @@
 {
   "location": "uksouth",
-  "publisher_name": "automated-cli-tests-ubuntu-publisher",
+  "publisher_name": "automated-cli-test-ubuntu-publisher",
   "publisher_resource_group_name": "cli_test_nsd",
   "acr_artifact_store_name": "ubuntu-acr",
   "resource_element_templates": [
@@ -8,7 +8,7 @@
       "resource_element_type": "NF",
       "properties": {
         // The name of the existing publisher for the NSD.
-        "publisher": "automated-cli-tests-ubuntu-publisher",
+        "publisher": "automated-cli-test-ubuntu-publisher",
         // The resource group that the publisher is hosted in.
         "publisher_resource_group": "cli_test_nsd",
         // The name of the existing Network Function Definition Group to deploy using this NSD.
@@ -26,7 +26,7 @@
       "resource_element_type": "NF",
       "properties": {
         // The name of the existing publisher for the NSD.
-        "publisher": "automated-cli-tests-ubuntu-publisher",
+        "publisher": "automated-cli-test-ubuntu-publisher",
         // The resource group that the publisher is hosted in.
         "publisher_resource_group": "cli_test_nsd",
         // The name of the existing Network Function Definition Group to deploy using this NSD.

--- a/src/aosm/azext_aosm/tests/latest/integration_tests/integration_test_mocks/mock_input_templates/input_multiple_instances.jsonc
+++ b/src/aosm/azext_aosm/tests/latest/integration_tests/integration_test_mocks/mock_input_templates/input_multiple_instances.jsonc
@@ -1,6 +1,6 @@
 {
   "location": "uksouth",
-  "publisher_name": "automated-cli-tests-ubuntu-publisher",
+  "publisher_name": "automated-cli-test-ubuntu-publisher",
   "publisher_resource_group_name": "cli_test_nsd",
   "acr_artifact_store_name": "ubuntu-acr",
   "resource_element_templates": [
@@ -8,7 +8,7 @@
       "resource_element_type": "NF",
       "properties": {
         // The name of the existing publisher for the NSD.
-        "publisher": "automated-cli-tests-ubuntu-publisher",
+        "publisher": "automated-cli-test-ubuntu-publisher",
         // The resource group that the publisher is hosted in.
         "publisher_resource_group": "cli_test_nsd",
         // The name of the existing Network Function Definition Group to deploy using this NSD.

--- a/src/aosm/azext_aosm/tests/latest/integration_tests/integration_test_mocks/mock_input_templates/nsd_core_input.jsonc
+++ b/src/aosm/azext_aosm/tests/latest/integration_tests/integration_test_mocks/mock_input_templates/nsd_core_input.jsonc
@@ -1,6 +1,6 @@
 {
   "location": "uksouth",
-  "publisher_name": "automated-cli-tests-ubuntu-publisher",
+  "publisher_name": "automated-cli-test-ubuntu-publisher",
   "publisher_resource_group_name": "test_publisher_name",
   "acr_artifact_store_name": "ubuntu-acr",
   "resource_element_templates": [
@@ -8,7 +8,7 @@
       "resource_element_type": "NF",
       "properties": {
         // The name of the existing publisher for the NSD.
-        "publisher": "automated-cli-tests-ubuntu-publisher",
+        "publisher": "automated-cli-test-ubuntu-publisher",
         // The resource group that the publisher is hosted in.
         "publisher_resource_group": "test_publisher_name",
         // The name of the existing Network Function Definition Group to deploy using this NSD.

--- a/src/aosm/azext_aosm/tests/latest/integration_tests/integration_test_mocks/mock_input_templates/vnf_input_template.jsonc
+++ b/src/aosm/azext_aosm/tests/latest/integration_tests/integration_test_mocks/mock_input_templates/vnf_input_template.jsonc
@@ -3,7 +3,7 @@
   "location": "uksouth",
   // Name of the Publisher resource you want your definition published to.
   // Will be created if it does not exist.
-  "publisher_name": "automated-cli-tests-ubuntu-publisher",
+  "publisher_name": "automated-cli-test-ubuntu-publisher",
   // Optional. Resource group for the Publisher resource.
   // Will be created if it does not exist (with a default name if none is supplied).
   "publisher_resource_group_name": "{{publisher_resource_group_name}}",

--- a/src/aosm/azext_aosm/tests/latest/integration_tests/integration_test_mocks/mock_input_templates/vnf_input_with_sas_token_template.jsonc
+++ b/src/aosm/azext_aosm/tests/latest/integration_tests/integration_test_mocks/mock_input_templates/vnf_input_with_sas_token_template.jsonc
@@ -3,7 +3,7 @@
   "location": "uksouth",
   // Name of the Publisher resource you want your definition published to.
   // Will be created if it does not exist.
-  "publisher_name": "automated-cli-tests-ubuntu-publisher",
+  "publisher_name": "automated-cli-test-ubuntu-publisher",
   // Optional. Resource group for the Publisher resource.
   // Will be created if it does not exist (with a default name if none is supplied).
   "publisher_resource_group_name": "{{publisher_resource_group_name}}",

--- a/src/aosm/azext_aosm/tests/latest/integration_tests/integration_test_mocks/mock_input_templates/vnf_nsd_input_template.jsonc
+++ b/src/aosm/azext_aosm/tests/latest/integration_tests/integration_test_mocks/mock_input_templates/vnf_nsd_input_template.jsonc
@@ -1,6 +1,6 @@
 {
   "location": "uksouth",
-  "publisher_name": "automated-cli-tests-ubuntu-publisher",
+  "publisher_name": "automated-cli-test-ubuntu-publisher",
   "publisher_resource_group_name": "{{publisher_resource_group_name}}",
   "acr_artifact_store_name": "ubuntu-acr",
   "resource_element_templates": [
@@ -8,7 +8,7 @@
       "resource_element_type": "NF",
       "properties": {
         // The name of the existing publisher for the NSD.
-        "publisher": "automated-cli-tests-ubuntu-publisher",
+        "publisher": "automated-cli-test-ubuntu-publisher",
         // The resource group that the publisher is hosted in.
         "publisher_resource_group": "{{publisher_resource_group_name}}",
         // The name of the existing Network Function Definition Group to deploy using this NSD.

--- a/src/aosm/azext_aosm/tests/latest/integration_tests/nsd_output/test_build/all_deploy.parameters.json
+++ b/src/aosm/azext_aosm/tests/latest/integration_tests/nsd_output/test_build/all_deploy.parameters.json
@@ -1,6 +1,6 @@
 {
     "location": "uksouth",
-    "publisherName": "automated-cli-tests-ubuntu-publisher",
+    "publisherName": "automated-cli-test-ubuntu-publisher",
     "publisherResourceGroupName": "test_publisher_name",
     "acrArtifactStoreName": "ubuntu-acr",
     "acrManifestName": "ubuntu-nsd-manifest-1-0-0",

--- a/src/aosm/azext_aosm/tests/latest/integration_tests/nsd_output/test_build_multiple_instances/all_deploy.parameters.json
+++ b/src/aosm/azext_aosm/tests/latest/integration_tests/nsd_output/test_build_multiple_instances/all_deploy.parameters.json
@@ -1,6 +1,6 @@
 {
     "location": "uksouth",
-    "publisherName": "automated-cli-tests-ubuntu-publisher",
+    "publisherName": "automated-cli-test-ubuntu-publisher",
     "publisherResourceGroupName": "cli_test_nsd",
     "acrArtifactStoreName": "ubuntu-acr",
     "acrManifestName": "ubuntu-nsd-manifest-1-0-0",

--- a/src/aosm/azext_aosm/tests/latest/integration_tests/scenario_tests/recordings/test_cnf_nfd_build_and_publish.yaml
+++ b/src/aosm/azext_aosm/tests/latest/integration_tests/scenario_tests/recordings/test_cnf_nfd_build_and_publish.yaml
@@ -13,8 +13,7 @@ interactions:
       ParameterSetName:
       - -b --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: HEAD
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001?api-version=2022-09-01
   response:
@@ -26,22 +25,26 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 16 Apr 2024 13:00:40 GMT
+      - Wed, 15 May 2024 15:45:27 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: C24736659FD5488D8582658A4872D54A Ref B: AMS231020512033 Ref C: 2024-05-15T15:45:27Z'
     status:
       code: 204
       message: No Content
 - request:
     body: '{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
       "contentVersion": "1.0.0.0", "metadata": {"_generator": {"name": "bicep", "version":
-      "0.26.54.24096", "templateHash": "15628236071821911085"}}, "parameters": {"location":
+      "0.8.9.13224", "templateHash": "16280524387813352742"}}, "parameters": {"location":
       {"type": "string"}, "publisherName": {"type": "string", "metadata": {"description":
       "Name of a publisher, expected to be in the resource group where you deploy
       the template"}}, "acrArtifactStoreName": {"type": "string", "metadata": {"description":
@@ -53,12 +56,12 @@ interactions:
       "apiVersion": "2023-09-01", "name": "[format(''{0}/{1}'', parameters(''publisherName''),
       parameters(''acrArtifactStoreName''))]", "location": "[parameters(''location'')]",
       "properties": {"storeType": "AzureContainerRegistry"}, "dependsOn": ["[resourceId(''Microsoft.HybridNetwork/publishers'',
-      parameters(''publisherName''))]"]}, {"type": "Microsoft.HybridNetwork/publishers/networkFunctionDefinitionGroups",
+      parameters(''publisherName''))]"]}, {"type": "Microsoft.Hybridnetwork/publishers/networkfunctiondefinitiongroups",
       "apiVersion": "2023-09-01", "name": "[format(''{0}/{1}'', parameters(''publisherName''),
       parameters(''nfDefinitionGroup''))]", "location": "[parameters(''location'')]",
       "dependsOn": ["[resourceId(''Microsoft.HybridNetwork/publishers'', parameters(''publisherName''))]"]}]},
       "parameters": {"location": {"value": "uksouth"}, "publisherName": {"value":
-      "automated-cli-tests-nginx-publisher"}, "acrArtifactStoreName": {"value": "nginx-acr"},
+      "automated-cli-test-nginx-publisher"}, "acrArtifactStoreName": {"value": "nginx-acr"},
       "nfDefinitionGroup": {"value": "nginx"}}, "mode": "Incremental"}}'
     headers:
       Accept:
@@ -70,67 +73,70 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1890'
+      - '1887'
       Content-Type:
       - application/json
       ParameterSetName:
       - -b --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment/validate?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1713272445",
-        "name": "AOSM_CLI_deployment_1713272445", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "15628236071821911085", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1715787933",
+        "name": "AOSM_CLI_deployment_1715787933", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "16280524387813352742", "parameters": {"location":
         {"type": "String", "value": "uksouth"}, "publisherName": {"type": "String",
-        "value": "automated-cli-tests-nginx-publisher"}, "acrArtifactStoreName": {"type":
+        "value": "automated-cli-test-nginx-publisher"}, "acrArtifactStoreName": {"type":
         "String", "value": "nginx-acr"}, "nfDefinitionGroup": {"type": "String", "value":
         "nginx"}}, "mode": "Incremental", "provisioningState": "Succeeded", "timestamp":
-        "0001-01-01T00:00:00Z", "duration": "PT0S", "correlationId": "494dfe8c-15d2-4a98-a99a-137a523a1c25",
+        "0001-01-01T00:00:00Z", "duration": "PT0S", "correlationId": "717adb6d-3ec1-4f3d-90e6-ec8b47939dca",
         "providers": [{"namespace": "Microsoft.HybridNetwork", "resourceTypes": [{"resourceType":
         "publishers", "locations": ["uksouth"]}, {"resourceType": "publishers/artifactStores",
-        "locations": ["uksouth"]}, {"resourceType": "publishers/networkFunctionDefinitionGroups",
-        "locations": ["uksouth"]}]}], "dependencies": [{"dependsOn": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-nginx-publisher",
-        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-tests-nginx-publisher"}],
-        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-nginx-publisher/artifactStores/nginx-acr",
+        "locations": ["uksouth"]}, {"resourceType": "publishers/networkfunctiondefinitiongroups",
+        "locations": ["uksouth"]}]}], "dependencies": [{"dependsOn": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-nginx-publisher",
+        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-test-nginx-publisher"}],
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-nginx-publisher/artifactStores/nginx-acr",
         "resourceType": "Microsoft.HybridNetwork/publishers/artifactStores", "resourceName":
-        "automated-cli-tests-nginx-publisher/nginx-acr"}, {"dependsOn": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-nginx-publisher",
-        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-tests-nginx-publisher"}],
-        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-nginx-publisher/networkFunctionDefinitionGroups/nginx",
-        "resourceType": "Microsoft.HybridNetwork/publishers/networkFunctionDefinitionGroups",
-        "resourceName": "automated-cli-tests-nginx-publisher/nginx"}], "validatedResources":
-        [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-nginx-publisher"},
-        {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-nginx-publisher/artifactStores/nginx-acr"},
-        {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-nginx-publisher/networkFunctionDefinitionGroups/nginx"}]}}'
+        "automated-cli-test-nginx-publisher/nginx-acr"}, {"dependsOn": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-nginx-publisher",
+        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-test-nginx-publisher"}],
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.Hybridnetwork/publishers/automated-cli-test-nginx-publisher/networkfunctiondefinitiongroups/nginx",
+        "resourceType": "Microsoft.Hybridnetwork/publishers/networkfunctiondefinitiongroups",
+        "resourceName": "automated-cli-test-nginx-publisher/nginx"}], "validatedResources":
+        [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-nginx-publisher"},
+        {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-nginx-publisher/artifactStores/nginx-acr"},
+        {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.Hybridnetwork/publishers/automated-cli-test-nginx-publisher/networkfunctiondefinitiongroups/nginx"}]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3038'
+      - '3026'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:00:44 GMT
+      - Wed, 15 May 2024 15:45:34 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
+      x-msedge-ref:
+      - 'Ref A: C1D84EF9D32E4E8689289F75A0C61C4F Ref B: AMS231020512033 Ref C: 2024-05-15T15:45:34Z'
     status:
       code: 200
       message: OK
 - request:
     body: '{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
       "contentVersion": "1.0.0.0", "metadata": {"_generator": {"name": "bicep", "version":
-      "0.26.54.24096", "templateHash": "15628236071821911085"}}, "parameters": {"location":
+      "0.8.9.13224", "templateHash": "16280524387813352742"}}, "parameters": {"location":
       {"type": "string"}, "publisherName": {"type": "string", "metadata": {"description":
       "Name of a publisher, expected to be in the resource group where you deploy
       the template"}}, "acrArtifactStoreName": {"type": "string", "metadata": {"description":
@@ -142,12 +148,12 @@ interactions:
       "apiVersion": "2023-09-01", "name": "[format(''{0}/{1}'', parameters(''publisherName''),
       parameters(''acrArtifactStoreName''))]", "location": "[parameters(''location'')]",
       "properties": {"storeType": "AzureContainerRegistry"}, "dependsOn": ["[resourceId(''Microsoft.HybridNetwork/publishers'',
-      parameters(''publisherName''))]"]}, {"type": "Microsoft.HybridNetwork/publishers/networkFunctionDefinitionGroups",
+      parameters(''publisherName''))]"]}, {"type": "Microsoft.Hybridnetwork/publishers/networkfunctiondefinitiongroups",
       "apiVersion": "2023-09-01", "name": "[format(''{0}/{1}'', parameters(''publisherName''),
       parameters(''nfDefinitionGroup''))]", "location": "[parameters(''location'')]",
       "dependsOn": ["[resourceId(''Microsoft.HybridNetwork/publishers'', parameters(''publisherName''))]"]}]},
       "parameters": {"location": {"value": "uksouth"}, "publisherName": {"value":
-      "automated-cli-tests-nginx-publisher"}, "acrArtifactStoreName": {"value": "nginx-acr"},
+      "automated-cli-test-nginx-publisher"}, "acrArtifactStoreName": {"value": "nginx-acr"},
       "nfDefinitionGroup": {"value": "nginx"}}, "mode": "Incremental"}}'
     headers:
       Accept:
@@ -159,60 +165,63 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1890'
+      - '1887'
       Content-Type:
       - application/json
       ParameterSetName:
       - -b --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1713272445",
-        "name": "AOSM_CLI_deployment_1713272445", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "15628236071821911085", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1715787933",
+        "name": "AOSM_CLI_deployment_1715787933", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "16280524387813352742", "parameters": {"location":
         {"type": "String", "value": "uksouth"}, "publisherName": {"type": "String",
-        "value": "automated-cli-tests-nginx-publisher"}, "acrArtifactStoreName": {"type":
+        "value": "automated-cli-test-nginx-publisher"}, "acrArtifactStoreName": {"type":
         "String", "value": "nginx-acr"}, "nfDefinitionGroup": {"type": "String", "value":
         "nginx"}}, "mode": "Incremental", "provisioningState": "Accepted", "timestamp":
-        "2024-04-16T13:00:45.5609042Z", "duration": "PT0.0008285S", "correlationId":
-        "982295a5-7b5c-463b-8d28-52f53624ef6c", "providers": [{"namespace": "Microsoft.HybridNetwork",
+        "2024-05-15T15:45:35.354406Z", "duration": "PT0.0005935S", "correlationId":
+        "f0403d49-cca1-4802-b52a-f238847e2ffb", "providers": [{"namespace": "Microsoft.HybridNetwork",
         "resourceTypes": [{"resourceType": "publishers", "locations": ["uksouth"]},
         {"resourceType": "publishers/artifactStores", "locations": ["uksouth"]}, {"resourceType":
-        "publishers/networkFunctionDefinitionGroups", "locations": ["uksouth"]}]}],
-        "dependencies": [{"dependsOn": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-nginx-publisher",
-        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-tests-nginx-publisher"}],
-        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-nginx-publisher/artifactStores/nginx-acr",
+        "publishers/networkfunctiondefinitiongroups", "locations": ["uksouth"]}]}],
+        "dependencies": [{"dependsOn": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-nginx-publisher",
+        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-test-nginx-publisher"}],
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-nginx-publisher/artifactStores/nginx-acr",
         "resourceType": "Microsoft.HybridNetwork/publishers/artifactStores", "resourceName":
-        "automated-cli-tests-nginx-publisher/nginx-acr"}, {"dependsOn": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-nginx-publisher",
-        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-tests-nginx-publisher"}],
-        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-nginx-publisher/networkFunctionDefinitionGroups/nginx",
-        "resourceType": "Microsoft.HybridNetwork/publishers/networkFunctionDefinitionGroups",
-        "resourceName": "automated-cli-tests-nginx-publisher/nginx"}]}}'
+        "automated-cli-test-nginx-publisher/nginx-acr"}, {"dependsOn": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-nginx-publisher",
+        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-test-nginx-publisher"}],
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.Hybridnetwork/publishers/automated-cli-test-nginx-publisher/networkfunctiondefinitiongroups/nginx",
+        "resourceType": "Microsoft.Hybridnetwork/publishers/networkfunctiondefinitiongroups",
+        "resourceName": "automated-cli-test-nginx-publisher/nginx"}]}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1713272445/operationStatuses/08584883344401524198?api-version=2022-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1715787933/operationStatuses/08584858189504049589?api-version=2022-09-01
       cache-control:
       - no-cache
       content-length:
-      - '2417'
+      - '2407'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:00:44 GMT
+      - Wed, 15 May 2024 15:45:34 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
+      x-msedge-ref:
+      - 'Ref A: 09CCBA4CDFD645DD9AC43C66793D5B5F Ref B: AMS231020512033 Ref C: 2024-05-15T15:45:34Z'
     status:
       code: 201
       message: Created
@@ -230,10 +239,9 @@ interactions:
       ParameterSetName:
       - -b --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883344401524198?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858189504049589?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Accepted"}'
@@ -245,15 +253,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:00:44 GMT
+      - Wed, 15 May 2024 15:45:34 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: E364349D5422433EA2FE41289FF6C17C Ref B: AMS231020512033 Ref C: 2024-05-15T15:45:35Z'
     status:
       code: 200
       message: OK
@@ -271,10 +283,9 @@ interactions:
       ParameterSetName:
       - -b --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883344401524198?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858189504049589?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Running"}'
@@ -286,15 +297,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:01:15 GMT
+      - Wed, 15 May 2024 15:46:04 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: C4C93C07060C4E62BF7A35EB8543E504 Ref B: AMS231020512033 Ref C: 2024-05-15T15:46:05Z'
     status:
       code: 200
       message: OK
@@ -312,10 +327,9 @@ interactions:
       ParameterSetName:
       - -b --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883344401524198?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858189504049589?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Running"}'
@@ -327,15 +341,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:01:45 GMT
+      - Wed, 15 May 2024 15:46:34 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: F84BFB8127014A68B44079D21C15161E Ref B: AMS231020512033 Ref C: 2024-05-15T15:46:35Z'
     status:
       code: 200
       message: OK
@@ -353,10 +371,9 @@ interactions:
       ParameterSetName:
       - -b --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883344401524198?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858189504049589?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Running"}'
@@ -368,15 +385,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:02:15 GMT
+      - Wed, 15 May 2024 15:47:04 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: 2DFA308573F54A9AB3A5E1A2A03DB452 Ref B: AMS231020512033 Ref C: 2024-05-15T15:47:05Z'
     status:
       code: 200
       message: OK
@@ -394,10 +415,9 @@ interactions:
       ParameterSetName:
       - -b --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883344401524198?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858189504049589?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Running"}'
@@ -409,15 +429,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:02:44 GMT
+      - Wed, 15 May 2024 15:47:35 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: 7997DC90B599460FB234A944D6263A6B Ref B: AMS231020512033 Ref C: 2024-05-15T15:47:35Z'
     status:
       code: 200
       message: OK
@@ -435,10 +459,9 @@ interactions:
       ParameterSetName:
       - -b --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883344401524198?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858189504049589?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Running"}'
@@ -450,15 +473,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:03:12 GMT
+      - Wed, 15 May 2024 15:48:06 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: 54ED4E0B40D74B388BBFC6D46088E239 Ref B: AMS231020512033 Ref C: 2024-05-15T15:48:07Z'
     status:
       code: 200
       message: OK
@@ -476,10 +503,9 @@ interactions:
       ParameterSetName:
       - -b --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883344401524198?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858189504049589?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Running"}'
@@ -491,15 +517,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:03:42 GMT
+      - Wed, 15 May 2024 15:48:36 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: 074683E34C6849BBBB75505779220D34 Ref B: AMS231020512033 Ref C: 2024-05-15T15:48:37Z'
     status:
       code: 200
       message: OK
@@ -517,10 +547,9 @@ interactions:
       ParameterSetName:
       - -b --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883344401524198?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858189504049589?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Running"}'
@@ -532,15 +561,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:04:13 GMT
+      - Wed, 15 May 2024 15:49:06 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: 27076DE1E7CE4E96A96FAF19526AC4CA Ref B: AMS231020512033 Ref C: 2024-05-15T15:49:07Z'
     status:
       code: 200
       message: OK
@@ -558,10 +591,53 @@ interactions:
       ParameterSetName:
       - -b --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883344401524198?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858189504049589?api-version=2022-09-01
+  response:
+    body:
+      string: '{"status": "Running"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 15 May 2024 15:49:36 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
+      x-content-type-options:
+      - nosniff
+      x-msedge-ref:
+      - 'Ref A: 16CC1F39AE6047E1B6904BAB85C4EB8F Ref B: AMS231020512033 Ref C: 2024-05-15T15:49:37Z'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - aosm nfd publish
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -b --definition-type
+      User-Agent:
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858189504049589?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Succeeded"}'
@@ -573,15 +649,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:04:43 GMT
+      - Wed, 15 May 2024 15:50:06 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: 28A577FA6F494890ACE304DBB549F9E5 Ref B: AMS231020512033 Ref C: 2024-05-15T15:50:07Z'
     status:
       code: 200
       message: OK
@@ -599,53 +679,56 @@ interactions:
       ParameterSetName:
       - -b --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1713272445",
-        "name": "AOSM_CLI_deployment_1713272445", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "15628236071821911085", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1715787933",
+        "name": "AOSM_CLI_deployment_1715787933", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "16280524387813352742", "parameters": {"location":
         {"type": "String", "value": "uksouth"}, "publisherName": {"type": "String",
-        "value": "automated-cli-tests-nginx-publisher"}, "acrArtifactStoreName": {"type":
+        "value": "automated-cli-test-nginx-publisher"}, "acrArtifactStoreName": {"type":
         "String", "value": "nginx-acr"}, "nfDefinitionGroup": {"type": "String", "value":
         "nginx"}}, "mode": "Incremental", "provisioningState": "Succeeded", "timestamp":
-        "2024-04-16T13:04:32.594907Z", "duration": "PT3M47.0348313S", "correlationId":
-        "982295a5-7b5c-463b-8d28-52f53624ef6c", "providers": [{"namespace": "Microsoft.HybridNetwork",
+        "2024-05-15T15:49:40.0429444Z", "duration": "PT4M4.6891319S", "correlationId":
+        "f0403d49-cca1-4802-b52a-f238847e2ffb", "providers": [{"namespace": "Microsoft.HybridNetwork",
         "resourceTypes": [{"resourceType": "publishers", "locations": ["uksouth"]},
         {"resourceType": "publishers/artifactStores", "locations": ["uksouth"]}, {"resourceType":
-        "publishers/networkFunctionDefinitionGroups", "locations": ["uksouth"]}]}],
-        "dependencies": [{"dependsOn": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-nginx-publisher",
-        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-tests-nginx-publisher"}],
-        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-nginx-publisher/artifactStores/nginx-acr",
+        "publishers/networkfunctiondefinitiongroups", "locations": ["uksouth"]}]}],
+        "dependencies": [{"dependsOn": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-nginx-publisher",
+        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-test-nginx-publisher"}],
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-nginx-publisher/artifactStores/nginx-acr",
         "resourceType": "Microsoft.HybridNetwork/publishers/artifactStores", "resourceName":
-        "automated-cli-tests-nginx-publisher/nginx-acr"}, {"dependsOn": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-nginx-publisher",
-        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-tests-nginx-publisher"}],
-        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-nginx-publisher/networkFunctionDefinitionGroups/nginx",
-        "resourceType": "Microsoft.HybridNetwork/publishers/networkFunctionDefinitionGroups",
-        "resourceName": "automated-cli-tests-nginx-publisher/nginx"}], "outputResources":
-        [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-nginx-publisher"},
-        {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-nginx-publisher/artifactStores/nginx-acr"},
-        {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-nginx-publisher/networkFunctionDefinitionGroups/nginx"}]}}'
+        "automated-cli-test-nginx-publisher/nginx-acr"}, {"dependsOn": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-nginx-publisher",
+        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-test-nginx-publisher"}],
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.Hybridnetwork/publishers/automated-cli-test-nginx-publisher/networkfunctiondefinitiongroups/nginx",
+        "resourceType": "Microsoft.Hybridnetwork/publishers/networkfunctiondefinitiongroups",
+        "resourceName": "automated-cli-test-nginx-publisher/nginx"}], "outputResources":
+        [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-nginx-publisher"},
+        {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-nginx-publisher/artifactStores/nginx-acr"},
+        {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.Hybridnetwork/publishers/automated-cli-test-nginx-publisher/networkfunctiondefinitiongroups/nginx"}]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3053'
+      - '3041'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:04:43 GMT
+      - Wed, 15 May 2024 15:50:06 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: 8AD05E5274FF40C08AAB8316AF00A8E7 Ref B: AMS231020512033 Ref C: 2024-05-15T15:50:07Z'
     status:
       code: 200
       message: OK
@@ -663,54 +746,57 @@ interactions:
       ParameterSetName:
       - -b --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-hybridnetwork/unknown Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-nginx-publisher/artifactStores/nginx-acr/artifactManifests/nginx-acr-manifest-1-0-0?api-version=2023-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-nginx-publisher/artifactStores/nginx-acr/artifactManifests/nginx-acr-manifest-1-0-0?api-version=2023-09-01
   response:
     body:
-      string: '{"error": {"code": "ResourceNotFound", "message": "The Resource ''Microsoft.HybridNetwork/publishers/automated-cli-tests-nginx-publisher/artifactStores/nginx-acr/artifactManifests/nginx-acr-manifest-1-0-0''
+      string: '{"error": {"code": "ResourceNotFound", "message": "The Resource ''Microsoft.HybridNetwork/publishers/automated-cli-test-nginx-publisher/artifactStores/nginx-acr/artifactManifests/nginx-acr-manifest-1-0-0''
         under resource group ''cli_test_cnf_nfd_000001'' was not found. For more details
         please go to https://aka.ms/ARMResourceNotFoundFix"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '337'
+      - '336'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:04:43 GMT
+      - Wed, 15 May 2024 15:50:07 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
       x-ms-failure-cause:
       - gateway
+      x-msedge-ref:
+      - 'Ref A: 047DD02C6AA44EBA98A783E68A1BB1D5 Ref B: AMS231022012027 Ref C: 2024-05-15T15:50:07Z'
     status:
       code: 404
       message: Not Found
 - request:
     body: '{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
       "contentVersion": "1.0.0.0", "metadata": {"_generator": {"name": "bicep", "version":
-      "0.26.54.24096", "templateHash": "14797403328055843136"}}, "parameters": {"location":
+      "0.8.9.13224", "templateHash": "8068031912378000682"}}, "parameters": {"location":
       {"type": "string"}, "publisherName": {"type": "string", "metadata": {"description":
       "Name of an existing publisher, expected to be in the resource group where you
       deploy the template"}}, "acrArtifactStoreName": {"type": "string", "metadata":
       {"description": "Name of an existing ACR-backed Artifact Store, deployed under
       the publisher."}}, "acrManifestName": {"type": "string", "metadata": {"description":
       "Name of the manifest to deploy for the ACR-backed Artifact Store"}}}, "resources":
-      [{"type": "Microsoft.HybridNetwork/publishers/artifactStores/artifactManifests",
+      [{"type": "Microsoft.Hybridnetwork/publishers/artifactStores/artifactManifests",
       "apiVersion": "2023-09-01", "name": "[format(''{0}/{1}/{2}'', parameters(''publisherName''),
       parameters(''acrArtifactStoreName''), parameters(''acrManifestName''))]", "location":
       "[parameters(''location'')]", "properties": {"artifacts": [{"artifactName":
       "nginxdemo", "artifactType": "OCIArtifact", "artifactVersion": "0.1.0"}, {"artifactName":
       "nginx", "artifactType": "OCIArtifact", "artifactVersion": "stable"}]}}]}, "parameters":
-      {"location": {"value": "uksouth"}, "publisherName": {"value": "automated-cli-tests-nginx-publisher"},
+      {"location": {"value": "uksouth"}, "publisherName": {"value": "automated-cli-test-nginx-publisher"},
       "acrArtifactStoreName": {"value": "nginx-acr"}, "acrManifestName": {"value":
       "nginx-acr-manifest-1-0-0"}}, "mode": "Incremental"}}'
     headers:
@@ -723,69 +809,72 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1521'
+      - '1517'
       Content-Type:
       - application/json
       ParameterSetName:
       - -b --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment/validate?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1713272688",
-        "name": "AOSM_CLI_deployment_1713272688", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "14797403328055843136", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1715788212",
+        "name": "AOSM_CLI_deployment_1715788212", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "8068031912378000682", "parameters": {"location":
         {"type": "String", "value": "uksouth"}, "publisherName": {"type": "String",
-        "value": "automated-cli-tests-nginx-publisher"}, "acrArtifactStoreName": {"type":
+        "value": "automated-cli-test-nginx-publisher"}, "acrArtifactStoreName": {"type":
         "String", "value": "nginx-acr"}, "acrManifestName": {"type": "String", "value":
         "nginx-acr-manifest-1-0-0"}}, "mode": "Incremental", "provisioningState":
         "Succeeded", "timestamp": "0001-01-01T00:00:00Z", "duration": "PT0S", "correlationId":
-        "41bfd32f-0640-436c-aa3c-2f164faadd1c", "providers": [{"namespace": "Microsoft.HybridNetwork",
+        "0d4e3b2e-2dfb-498e-9356-42bf3bcee085", "providers": [{"namespace": "Microsoft.Hybridnetwork",
         "resourceTypes": [{"resourceType": "publishers/artifactStores/artifactManifests",
         "locations": ["uksouth"]}]}], "dependencies": [], "validatedResources": [{"id":
-        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-nginx-publisher/artifactStores/nginx-acr/artifactManifests/nginx-acr-manifest-1-0-0"}]}}'
+        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.Hybridnetwork/publishers/automated-cli-test-nginx-publisher/artifactStores/nginx-acr/artifactManifests/nginx-acr-manifest-1-0-0"}]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1242'
+      - '1239'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:04:48 GMT
+      - Wed, 15 May 2024 15:50:12 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
+      x-msedge-ref:
+      - 'Ref A: 364B03708AE64FE0B3B168D60DF0AC79 Ref B: AMS231020512033 Ref C: 2024-05-15T15:50:12Z'
     status:
       code: 200
       message: OK
 - request:
     body: '{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
       "contentVersion": "1.0.0.0", "metadata": {"_generator": {"name": "bicep", "version":
-      "0.26.54.24096", "templateHash": "14797403328055843136"}}, "parameters": {"location":
+      "0.8.9.13224", "templateHash": "8068031912378000682"}}, "parameters": {"location":
       {"type": "string"}, "publisherName": {"type": "string", "metadata": {"description":
       "Name of an existing publisher, expected to be in the resource group where you
       deploy the template"}}, "acrArtifactStoreName": {"type": "string", "metadata":
       {"description": "Name of an existing ACR-backed Artifact Store, deployed under
       the publisher."}}, "acrManifestName": {"type": "string", "metadata": {"description":
       "Name of the manifest to deploy for the ACR-backed Artifact Store"}}}, "resources":
-      [{"type": "Microsoft.HybridNetwork/publishers/artifactStores/artifactManifests",
+      [{"type": "Microsoft.Hybridnetwork/publishers/artifactStores/artifactManifests",
       "apiVersion": "2023-09-01", "name": "[format(''{0}/{1}/{2}'', parameters(''publisherName''),
       parameters(''acrArtifactStoreName''), parameters(''acrManifestName''))]", "location":
       "[parameters(''location'')]", "properties": {"artifacts": [{"artifactName":
       "nginxdemo", "artifactType": "OCIArtifact", "artifactVersion": "0.1.0"}, {"artifactName":
       "nginx", "artifactType": "OCIArtifact", "artifactVersion": "stable"}]}}]}, "parameters":
-      {"location": {"value": "uksouth"}, "publisherName": {"value": "automated-cli-tests-nginx-publisher"},
+      {"location": {"value": "uksouth"}, "publisherName": {"value": "automated-cli-test-nginx-publisher"},
       "acrArtifactStoreName": {"value": "nginx-acr"}, "acrManifestName": {"value":
       "nginx-acr-manifest-1-0-0"}}, "mode": "Incremental"}}'
     headers:
@@ -798,50 +887,53 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1521'
+      - '1517'
       Content-Type:
       - application/json
       ParameterSetName:
       - -b --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1713272688",
-        "name": "AOSM_CLI_deployment_1713272688", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "14797403328055843136", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1715788212",
+        "name": "AOSM_CLI_deployment_1715788212", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "8068031912378000682", "parameters": {"location":
         {"type": "String", "value": "uksouth"}, "publisherName": {"type": "String",
-        "value": "automated-cli-tests-nginx-publisher"}, "acrArtifactStoreName": {"type":
+        "value": "automated-cli-test-nginx-publisher"}, "acrArtifactStoreName": {"type":
         "String", "value": "nginx-acr"}, "acrManifestName": {"type": "String", "value":
         "nginx-acr-manifest-1-0-0"}}, "mode": "Incremental", "provisioningState":
-        "Accepted", "timestamp": "2024-04-16T13:04:49.5854159Z", "duration": "PT0.0008638S",
-        "correlationId": "b9f98d1b-8ccb-41a6-9fb2-e0969f882f6a", "providers": [{"namespace":
-        "Microsoft.HybridNetwork", "resourceTypes": [{"resourceType": "publishers/artifactStores/artifactManifests",
+        "Accepted", "timestamp": "2024-05-15T15:50:13.8230612Z", "duration": "PT0.0005394S",
+        "correlationId": "51454ea2-5690-41a5-80fd-270f98207b1f", "providers": [{"namespace":
+        "Microsoft.Hybridnetwork", "resourceTypes": [{"resourceType": "publishers/artifactStores/artifactManifests",
         "locations": ["uksouth"]}]}], "dependencies": []}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1713272688/operationStatuses/08584883341960697191?api-version=2022-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1715788212/operationStatuses/08584858186719967850?api-version=2022-09-01
       cache-control:
       - no-cache
       content-length:
-      - '982'
+      - '980'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:04:48 GMT
+      - Wed, 15 May 2024 15:50:13 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
+      x-msedge-ref:
+      - 'Ref A: A30C475B698A43A0AAC5A3C8379CE2B1 Ref B: AMS231020512033 Ref C: 2024-05-15T15:50:13Z'
     status:
       code: 201
       message: Created
@@ -859,10 +951,9 @@ interactions:
       ParameterSetName:
       - -b --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883341960697191?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858186719967850?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Accepted"}'
@@ -874,15 +965,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:04:48 GMT
+      - Wed, 15 May 2024 15:50:13 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: 22C508C2781249708F15B34C998DED89 Ref B: AMS231020512033 Ref C: 2024-05-15T15:50:13Z'
     status:
       code: 200
       message: OK
@@ -900,10 +995,9 @@ interactions:
       ParameterSetName:
       - -b --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883341960697191?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858186719967850?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Running"}'
@@ -915,15 +1009,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:05:17 GMT
+      - Wed, 15 May 2024 15:50:43 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: 043B0B8A67E842CC96CC6B8726276AC0 Ref B: AMS231020512033 Ref C: 2024-05-15T15:50:43Z'
     status:
       code: 200
       message: OK
@@ -941,10 +1039,9 @@ interactions:
       ParameterSetName:
       - -b --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883341960697191?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858186719967850?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Running"}'
@@ -956,15 +1053,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:05:47 GMT
+      - Wed, 15 May 2024 15:51:13 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: B3D3F99E90644C16A94D2AE58B801455 Ref B: AMS231020512033 Ref C: 2024-05-15T15:51:14Z'
     status:
       code: 200
       message: OK
@@ -982,10 +1083,9 @@ interactions:
       ParameterSetName:
       - -b --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883341960697191?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858186719967850?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Succeeded"}'
@@ -997,15 +1097,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:06:17 GMT
+      - Wed, 15 May 2024 15:51:44 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: 43891796A2A444E48413A82CD170D705 Ref B: AMS231020512033 Ref C: 2024-05-15T15:51:45Z'
     status:
       code: 200
       message: OK
@@ -1023,41 +1127,44 @@ interactions:
       ParameterSetName:
       - -b --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1713272688",
-        "name": "AOSM_CLI_deployment_1713272688", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "14797403328055843136", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1715788212",
+        "name": "AOSM_CLI_deployment_1715788212", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "8068031912378000682", "parameters": {"location":
         {"type": "String", "value": "uksouth"}, "publisherName": {"type": "String",
-        "value": "automated-cli-tests-nginx-publisher"}, "acrArtifactStoreName": {"type":
+        "value": "automated-cli-test-nginx-publisher"}, "acrArtifactStoreName": {"type":
         "String", "value": "nginx-acr"}, "acrManifestName": {"type": "String", "value":
         "nginx-acr-manifest-1-0-0"}}, "mode": "Incremental", "provisioningState":
-        "Succeeded", "timestamp": "2024-04-16T13:06:10.9595899Z", "duration": "PT1M21.3750378S",
-        "correlationId": "b9f98d1b-8ccb-41a6-9fb2-e0969f882f6a", "providers": [{"namespace":
-        "Microsoft.HybridNetwork", "resourceTypes": [{"resourceType": "publishers/artifactStores/artifactManifests",
+        "Succeeded", "timestamp": "2024-05-15T15:51:39.5757505Z", "duration": "PT1M25.7532287S",
+        "correlationId": "51454ea2-5690-41a5-80fd-270f98207b1f", "providers": [{"namespace":
+        "Microsoft.Hybridnetwork", "resourceTypes": [{"resourceType": "publishers/artifactStores/artifactManifests",
         "locations": ["uksouth"]}]}], "dependencies": [], "outputResources": [{"id":
-        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-nginx-publisher/artifactStores/nginx-acr/artifactManifests/nginx-acr-manifest-1-0-0"}]}}'
+        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.Hybridnetwork/publishers/automated-cli-test-nginx-publisher/artifactStores/nginx-acr/artifactManifests/nginx-acr-manifest-1-0-0"}]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1258'
+      - '1255'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:06:17 GMT
+      - Wed, 15 May 2024 15:51:44 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: 243BCB2313064E078ED1F884EC550A43 Ref B: AMS231020512033 Ref C: 2024-05-15T15:51:45Z'
     status:
       code: 200
       message: OK
@@ -1077,46 +1184,49 @@ interactions:
       ParameterSetName:
       - -b --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-hybridnetwork/unknown Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-nginx-publisher/artifactStores/nginx-acr/artifactManifests/nginx-acr-manifest-1-0-0/listCredential?api-version=2023-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-nginx-publisher/artifactStores/nginx-acr/artifactManifests/nginx-acr-manifest-1-0-0/listCredential?api-version=2023-09-01
   response:
     body:
       string: '{"username": "nginx-acr-manifest-1-0-0", "acrToken": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-        "acrServerUrl": "https://automatedclitestsnginxpublishernginxacr72dc38a622.azurecr.io",
-        "repositories": ["nginxdemo", "nginx"], "expiry": "2024-04-17T13:06:20.2909529+00:00",
+        "acrServerUrl": "https://automatedclitestnginxpublishernginxacr02f144b6e2.azurecr.io",
+        "repositories": ["nginxdemo", "nginx"], "expiry": "2024-05-16T15:51:49.7749+00:00",
         "credentialType": "AzureContainerRegistryScopedToken"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '338'
+      - '334'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:06:19 GMT
+      - Wed, 15 May 2024 15:51:49 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
       x-ms-build-version:
-      - 1.0.02651.2759
+      - 1.0.02682.2890
       x-ms-providerhub-traffic:
       - 'True'
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
+      x-msedge-ref:
+      - 'Ref A: EFBDFA66560545FEA6BCAE9E787EB932 Ref B: AMS231022012011 Ref C: 2024-05-15T15:51:45Z'
     status:
       code: 200
       message: OK
 - request:
     body: '{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
       "contentVersion": "1.0.0.0", "metadata": {"_generator": {"name": "bicep", "version":
-      "0.26.54.24096", "templateHash": "13894353345379066482"}}, "parameters": {"location":
+      "0.8.9.13224", "templateHash": "16747776660806024409"}}, "parameters": {"location":
       {"type": "string"}, "publisherName": {"type": "string", "metadata": {"description":
       "Name of an existing publisher, expected to be in the resource group where you
       deploy the template"}}, "acrArtifactStoreName": {"type": "string", "metadata":
@@ -1128,11 +1238,11 @@ interactions:
       "title": "DeployParametersSchema", "type": "object", "properties": {}}, "$fxv#1":
       {"replicaCount": 1, "image": {"repository": "overwriteme", "tag": "stable",
       "pullPolicy": "IfNotPresent"}, "imagePullSecrets": [], "nameOverride": "", "fullnameOverride":
-      "", "serviceAccount": {"create": false, "name": null}, "podSecurityContext":
+      "", "serviceAccount": {"create": false, "name": "[null()]"}, "podSecurityContext":
       {}, "securityContext": {}, "service": {"type": "ClusterIP", "port": 80}, "ingress":
       {"enabled": false, "annotations": {}, "hosts": [{"host": "chart-example.local",
       "paths": []}], "tls": []}, "resources": {}, "nodeSelector": {}, "tolerations":
-      [], "affinity": {}}}, "resources": [{"type": "Microsoft.HybridNetwork/publishers/networkFunctionDefinitionGroups/networkFunctionDefinitionVersions",
+      [], "affinity": {}}}, "resources": [{"type": "Microsoft.Hybridnetwork/publishers/networkfunctiondefinitiongroups/networkfunctiondefinitionversions",
       "apiVersion": "2023-09-01", "name": "[format(''{0}/{1}/{2}'', parameters(''publisherName''),
       parameters(''nfDefinitionGroup''), parameters(''nfDefinitionVersion''))]", "location":
       "[parameters(''location'')]", "properties": {"deployParameters": "[string(variables(''$fxv#0''))]",
@@ -1147,7 +1257,7 @@ interactions:
       "Enabled", "helmMappingRuleProfile": {"releaseNamespace": "nginxdemo", "releaseName":
       "nginxdemo", "helmPackageVersion": "0.1.0", "values": "[string(variables(''$fxv#1''))]"}}}]}}}]},
       "parameters": {"location": {"value": "uksouth"}, "publisherName": {"value":
-      "automated-cli-tests-nginx-publisher"}, "acrArtifactStoreName": {"value": "nginx-acr"},
+      "automated-cli-test-nginx-publisher"}, "acrArtifactStoreName": {"value": "nginx-acr"},
       "nfDefinitionGroup": {"value": "nginx"}, "nfDefinitionVersion": {"value": "1.0.0"}},
       "mode": "Incremental"}}'
     headers:
@@ -1160,57 +1270,60 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '3117'
+      - '3120'
       Content-Type:
       - application/json
       ParameterSetName:
       - -b --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment/validate?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1713272806",
-        "name": "AOSM_CLI_deployment_1713272806", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "13894353345379066482", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1715788332",
+        "name": "AOSM_CLI_deployment_1715788332", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "16747776660806024409", "parameters": {"location":
         {"type": "String", "value": "uksouth"}, "publisherName": {"type": "String",
-        "value": "automated-cli-tests-nginx-publisher"}, "acrArtifactStoreName": {"type":
+        "value": "automated-cli-test-nginx-publisher"}, "acrArtifactStoreName": {"type":
         "String", "value": "nginx-acr"}, "nfDefinitionGroup": {"type": "String", "value":
         "nginx"}, "nfDefinitionVersion": {"type": "String", "value": "1.0.0"}}, "mode":
         "Incremental", "provisioningState": "Succeeded", "timestamp": "0001-01-01T00:00:00Z",
-        "duration": "PT0S", "correlationId": "7c85e7d3-2f12-4532-8c6e-4a21869726f0",
-        "providers": [{"namespace": "Microsoft.HybridNetwork", "resourceTypes": [{"resourceType":
-        "publishers/networkFunctionDefinitionGroups/networkFunctionDefinitionVersions",
+        "duration": "PT0S", "correlationId": "ec9be03c-9634-44c6-9873-b81af4c77788",
+        "providers": [{"namespace": "Microsoft.Hybridnetwork", "resourceTypes": [{"resourceType":
+        "publishers/networkfunctiondefinitiongroups/networkfunctiondefinitionversions",
         "locations": ["uksouth"]}]}], "dependencies": [], "validatedResources": [{"id":
-        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-nginx-publisher/networkFunctionDefinitionGroups/nginx/networkFunctionDefinitionVersions/1.0.0"}]}}'
+        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.Hybridnetwork/publishers/automated-cli-test-nginx-publisher/networkfunctiondefinitiongroups/nginx/networkfunctiondefinitionversions/1.0.0"}]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1329'
+      - '1327'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:06:44 GMT
+      - Wed, 15 May 2024 15:52:13 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1199'
+      x-msedge-ref:
+      - 'Ref A: 3EC9B196BB5E4A6B905E556B6F65F26C Ref B: AMS231020512033 Ref C: 2024-05-15T15:52:13Z'
     status:
       code: 200
       message: OK
 - request:
     body: '{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
       "contentVersion": "1.0.0.0", "metadata": {"_generator": {"name": "bicep", "version":
-      "0.26.54.24096", "templateHash": "13894353345379066482"}}, "parameters": {"location":
+      "0.8.9.13224", "templateHash": "16747776660806024409"}}, "parameters": {"location":
       {"type": "string"}, "publisherName": {"type": "string", "metadata": {"description":
       "Name of an existing publisher, expected to be in the resource group where you
       deploy the template"}}, "acrArtifactStoreName": {"type": "string", "metadata":
@@ -1222,11 +1335,11 @@ interactions:
       "title": "DeployParametersSchema", "type": "object", "properties": {}}, "$fxv#1":
       {"replicaCount": 1, "image": {"repository": "overwriteme", "tag": "stable",
       "pullPolicy": "IfNotPresent"}, "imagePullSecrets": [], "nameOverride": "", "fullnameOverride":
-      "", "serviceAccount": {"create": false, "name": null}, "podSecurityContext":
+      "", "serviceAccount": {"create": false, "name": "[null()]"}, "podSecurityContext":
       {}, "securityContext": {}, "service": {"type": "ClusterIP", "port": 80}, "ingress":
       {"enabled": false, "annotations": {}, "hosts": [{"host": "chart-example.local",
       "paths": []}], "tls": []}, "resources": {}, "nodeSelector": {}, "tolerations":
-      [], "affinity": {}}}, "resources": [{"type": "Microsoft.HybridNetwork/publishers/networkFunctionDefinitionGroups/networkFunctionDefinitionVersions",
+      [], "affinity": {}}}, "resources": [{"type": "Microsoft.Hybridnetwork/publishers/networkfunctiondefinitiongroups/networkfunctiondefinitionversions",
       "apiVersion": "2023-09-01", "name": "[format(''{0}/{1}/{2}'', parameters(''publisherName''),
       parameters(''nfDefinitionGroup''), parameters(''nfDefinitionVersion''))]", "location":
       "[parameters(''location'')]", "properties": {"deployParameters": "[string(variables(''$fxv#0''))]",
@@ -1241,7 +1354,7 @@ interactions:
       "Enabled", "helmMappingRuleProfile": {"releaseNamespace": "nginxdemo", "releaseName":
       "nginxdemo", "helmPackageVersion": "0.1.0", "values": "[string(variables(''$fxv#1''))]"}}}]}}}]},
       "parameters": {"location": {"value": "uksouth"}, "publisherName": {"value":
-      "automated-cli-tests-nginx-publisher"}, "acrArtifactStoreName": {"value": "nginx-acr"},
+      "automated-cli-test-nginx-publisher"}, "acrArtifactStoreName": {"value": "nginx-acr"},
       "nfDefinitionGroup": {"value": "nginx"}, "nfDefinitionVersion": {"value": "1.0.0"}},
       "mode": "Incremental"}}'
     headers:
@@ -1254,51 +1367,54 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '3117'
+      - '3120'
       Content-Type:
       - application/json
       ParameterSetName:
       - -b --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1713272806",
-        "name": "AOSM_CLI_deployment_1713272806", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "13894353345379066482", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1715788332",
+        "name": "AOSM_CLI_deployment_1715788332", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "16747776660806024409", "parameters": {"location":
         {"type": "String", "value": "uksouth"}, "publisherName": {"type": "String",
-        "value": "automated-cli-tests-nginx-publisher"}, "acrArtifactStoreName": {"type":
+        "value": "automated-cli-test-nginx-publisher"}, "acrArtifactStoreName": {"type":
         "String", "value": "nginx-acr"}, "nfDefinitionGroup": {"type": "String", "value":
         "nginx"}, "nfDefinitionVersion": {"type": "String", "value": "1.0.0"}}, "mode":
-        "Incremental", "provisioningState": "Accepted", "timestamp": "2024-04-16T13:06:45.8173784Z",
-        "duration": "PT0.0008056S", "correlationId": "be87c359-0934-48ea-bc12-fa9aa4197fde",
-        "providers": [{"namespace": "Microsoft.HybridNetwork", "resourceTypes": [{"resourceType":
-        "publishers/networkFunctionDefinitionGroups/networkFunctionDefinitionVersions",
+        "Incremental", "provisioningState": "Accepted", "timestamp": "2024-05-15T15:52:14.874135Z",
+        "duration": "PT0.0007292S", "correlationId": "faaf77d1-078d-4a78-a313-47abd2f765f9",
+        "providers": [{"namespace": "Microsoft.Hybridnetwork", "resourceTypes": [{"resourceType":
+        "publishers/networkfunctiondefinitiongroups/networkfunctiondefinitionversions",
         "locations": ["uksouth"]}]}], "dependencies": []}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1713272806/operationStatuses/08584883340798271292?api-version=2022-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1715788332/operationStatuses/08584858185509487854?api-version=2022-09-01
       cache-control:
       - no-cache
       content-length:
-      - '1059'
+      - '1057'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:06:45 GMT
+      - Wed, 15 May 2024 15:52:14 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1199'
+      x-msedge-ref:
+      - 'Ref A: C2C23D8018664680B541F9612BDA90EE Ref B: AMS231020512033 Ref C: 2024-05-15T15:52:14Z'
     status:
       code: 201
       message: Created
@@ -1316,10 +1432,9 @@ interactions:
       ParameterSetName:
       - -b --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883340798271292?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858185509487854?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Accepted"}'
@@ -1331,15 +1446,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:06:45 GMT
+      - Wed, 15 May 2024 15:52:14 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: AA78064EBA6A4368AF9B289823E69032 Ref B: AMS231020512033 Ref C: 2024-05-15T15:52:14Z'
     status:
       code: 200
       message: OK
@@ -1357,10 +1476,9 @@ interactions:
       ParameterSetName:
       - -b --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883340798271292?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858185509487854?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Running"}'
@@ -1372,15 +1490,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:07:14 GMT
+      - Wed, 15 May 2024 15:52:44 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: 0810E1BE50884958AB08A818F570C24B Ref B: AMS231020512033 Ref C: 2024-05-15T15:52:44Z'
     status:
       code: 200
       message: OK
@@ -1398,10 +1520,9 @@ interactions:
       ParameterSetName:
       - -b --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883340798271292?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858185509487854?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Running"}'
@@ -1413,15 +1534,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:07:44 GMT
+      - Wed, 15 May 2024 15:53:14 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: 590839FE19744A32B8CE081632D322BE Ref B: AMS231020512033 Ref C: 2024-05-15T15:53:14Z'
     status:
       code: 200
       message: OK
@@ -1439,10 +1564,9 @@ interactions:
       ParameterSetName:
       - -b --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883340798271292?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858185509487854?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Succeeded"}'
@@ -1454,15 +1578,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:08:14 GMT
+      - Wed, 15 May 2024 15:53:44 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: A037827BBA3348D3B1F38CCEF4ADA38F Ref B: AMS231020512033 Ref C: 2024-05-15T15:53:45Z'
     status:
       code: 200
       message: OK
@@ -1480,42 +1608,45 @@ interactions:
       ParameterSetName:
       - -b --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1713272806",
-        "name": "AOSM_CLI_deployment_1713272806", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "13894353345379066482", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1715788332",
+        "name": "AOSM_CLI_deployment_1715788332", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "16747776660806024409", "parameters": {"location":
         {"type": "String", "value": "uksouth"}, "publisherName": {"type": "String",
-        "value": "automated-cli-tests-nginx-publisher"}, "acrArtifactStoreName": {"type":
+        "value": "automated-cli-test-nginx-publisher"}, "acrArtifactStoreName": {"type":
         "String", "value": "nginx-acr"}, "nfDefinitionGroup": {"type": "String", "value":
         "nginx"}, "nfDefinitionVersion": {"type": "String", "value": "1.0.0"}}, "mode":
-        "Incremental", "provisioningState": "Succeeded", "timestamp": "2024-04-16T13:08:06.9694954Z",
-        "duration": "PT1M21.1529226S", "correlationId": "be87c359-0934-48ea-bc12-fa9aa4197fde",
-        "providers": [{"namespace": "Microsoft.HybridNetwork", "resourceTypes": [{"resourceType":
-        "publishers/networkFunctionDefinitionGroups/networkFunctionDefinitionVersions",
+        "Incremental", "provisioningState": "Succeeded", "timestamp": "2024-05-15T15:53:37.7822316Z",
+        "duration": "PT1M22.9088258S", "correlationId": "faaf77d1-078d-4a78-a313-47abd2f765f9",
+        "providers": [{"namespace": "Microsoft.Hybridnetwork", "resourceTypes": [{"resourceType":
+        "publishers/networkfunctiondefinitiongroups/networkfunctiondefinitionversions",
         "locations": ["uksouth"]}]}], "dependencies": [], "outputResources": [{"id":
-        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-nginx-publisher/networkFunctionDefinitionGroups/nginx/networkFunctionDefinitionVersions/1.0.0"}]}}'
+        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cnf_nfd_000001/providers/Microsoft.Hybridnetwork/publishers/automated-cli-test-nginx-publisher/networkfunctiondefinitiongroups/nginx/networkfunctiondefinitionversions/1.0.0"}]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1345'
+      - '1343'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:08:14 GMT
+      - Wed, 15 May 2024 15:53:44 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: 42322D5D4C7F4B1283E1E433EFEB591D Ref B: AMS231020512033 Ref C: 2024-05-15T15:53:45Z'
     status:
       code: 200
       message: OK

--- a/src/aosm/azext_aosm/tests/latest/integration_tests/scenario_tests/recordings/test_vnf_nsd_build_and_publish.yaml
+++ b/src/aosm/azext_aosm/tests/latest/integration_tests/scenario_tests/recordings/test_vnf_nsd_build_and_publish.yaml
@@ -13,8 +13,7 @@ interactions:
       ParameterSetName:
       - --build-output-folder --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: HEAD
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001?api-version=2022-09-01
   response:
@@ -26,22 +25,26 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 16 Apr 2024 13:08:15 GMT
+      - Wed, 15 May 2024 16:02:13 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: E6360359AFD54F749402A1EBC8010913 Ref B: AMS231022012051 Ref C: 2024-05-15T16:02:13Z'
     status:
       code: 204
       message: No Content
 - request:
     body: '{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
       "contentVersion": "1.0.0.0", "metadata": {"_generator": {"name": "bicep", "version":
-      "0.26.54.24096", "templateHash": "4595863518953475042"}}, "parameters": {"location":
+      "0.8.9.13224", "templateHash": "9985939870973944498"}}, "parameters": {"location":
       {"type": "string"}, "publisherName": {"type": "string", "metadata": {"description":
       "Name of a publisher, expected to be in the resource group where you deploy
       the template"}}, "acrArtifactStoreName": {"type": "string", "metadata": {"description":
@@ -59,12 +62,12 @@ interactions:
       "apiVersion": "2023-09-01", "name": "[format(''{0}/{1}'', parameters(''publisherName''),
       parameters(''saArtifactStoreName''))]", "location": "[parameters(''location'')]",
       "properties": {"storeType": "AzureStorageAccount"}, "dependsOn": ["[resourceId(''Microsoft.HybridNetwork/publishers'',
-      parameters(''publisherName''))]"]}, {"type": "Microsoft.HybridNetwork/publishers/networkFunctionDefinitionGroups",
+      parameters(''publisherName''))]"]}, {"type": "Microsoft.Hybridnetwork/publishers/networkfunctiondefinitiongroups",
       "apiVersion": "2023-09-01", "name": "[format(''{0}/{1}'', parameters(''publisherName''),
       parameters(''nfDefinitionGroup''))]", "location": "[parameters(''location'')]",
       "dependsOn": ["[resourceId(''Microsoft.HybridNetwork/publishers'', parameters(''publisherName''))]"]}]},
       "parameters": {"location": {"value": "uksouth"}, "publisherName": {"value":
-      "automated-cli-tests-ubuntu-publisher"}, "acrArtifactStoreName": {"value": "ubuntu-acr"},
+      "automated-cli-test-ubuntu-publisher"}, "acrArtifactStoreName": {"value": "ubuntu-acr"},
       "nfDefinitionGroup": {"value": "ubuntu-vm"}, "saArtifactStoreName": {"value":
       "ubuntu-blob-store"}}, "mode": "Incremental"}}'
     headers:
@@ -77,76 +80,77 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '2480'
+      - '2477'
       Content-Type:
       - application/json
       ParameterSetName:
       - --build-output-folder --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/validate?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1713272902",
-        "name": "AOSM_CLI_deployment_1713272902", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "4595863518953475042", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1715788943",
+        "name": "AOSM_CLI_deployment_1715788943", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "9985939870973944498", "parameters": {"location":
         {"type": "String", "value": "uksouth"}, "publisherName": {"type": "String",
-        "value": "automated-cli-tests-ubuntu-publisher"}, "acrArtifactStoreName":
-        {"type": "String", "value": "ubuntu-acr"}, "saArtifactStoreName": {"type":
-        "String", "value": "ubuntu-blob-store"}, "nfDefinitionGroup": {"type": "String",
-        "value": "ubuntu-vm"}}, "mode": "Incremental", "provisioningState": "Succeeded",
-        "timestamp": "0001-01-01T00:00:00Z", "duration": "PT0S", "correlationId":
-        "e8de01a9-8158-4e6a-bc0e-4668ec1c7fda", "providers": [{"namespace": "Microsoft.HybridNetwork",
-        "resourceTypes": [{"resourceType": "publishers", "locations": ["uksouth"]},
-        {"resourceType": "publishers/artifactStores", "locations": ["uksouth"]}, {"resourceType":
-        "publishers/networkFunctionDefinitionGroups", "locations": ["uksouth"]}]}],
-        "dependencies": [{"dependsOn": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher",
-        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-tests-ubuntu-publisher"}],
-        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/artifactStores/ubuntu-acr",
+        "value": "automated-cli-test-ubuntu-publisher"}, "acrArtifactStoreName": {"type":
+        "String", "value": "ubuntu-acr"}, "saArtifactStoreName": {"type": "String",
+        "value": "ubuntu-blob-store"}, "nfDefinitionGroup": {"type": "String", "value":
+        "ubuntu-vm"}}, "mode": "Incremental", "provisioningState": "Succeeded", "timestamp":
+        "0001-01-01T00:00:00Z", "duration": "PT0S", "correlationId": "bdd33a2c-c84e-46b9-b3c2-555c878e5773",
+        "providers": [{"namespace": "Microsoft.HybridNetwork", "resourceTypes": [{"resourceType":
+        "publishers", "locations": ["uksouth"]}, {"resourceType": "publishers/artifactStores",
+        "locations": ["uksouth"]}, {"resourceType": "publishers/networkfunctiondefinitiongroups",
+        "locations": ["uksouth"]}]}], "dependencies": [{"dependsOn": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher",
+        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-test-ubuntu-publisher"}],
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher/artifactStores/ubuntu-acr",
         "resourceType": "Microsoft.HybridNetwork/publishers/artifactStores", "resourceName":
-        "automated-cli-tests-ubuntu-publisher/ubuntu-acr"}, {"dependsOn": [{"id":
-        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher",
-        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-tests-ubuntu-publisher"}],
-        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/artifactStores/ubuntu-blob-store",
+        "automated-cli-test-ubuntu-publisher/ubuntu-acr"}, {"dependsOn": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher",
+        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-test-ubuntu-publisher"}],
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher/artifactStores/ubuntu-blob-store",
         "resourceType": "Microsoft.HybridNetwork/publishers/artifactStores", "resourceName":
-        "automated-cli-tests-ubuntu-publisher/ubuntu-blob-store"}, {"dependsOn": [{"id":
-        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher",
-        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-tests-ubuntu-publisher"}],
-        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/networkFunctionDefinitionGroups/ubuntu-vm",
-        "resourceType": "Microsoft.HybridNetwork/publishers/networkFunctionDefinitionGroups",
-        "resourceName": "automated-cli-tests-ubuntu-publisher/ubuntu-vm"}], "validatedResources":
-        [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher"},
-        {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/artifactStores/ubuntu-acr"},
-        {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/artifactStores/ubuntu-blob-store"},
-        {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/networkFunctionDefinitionGroups/ubuntu-vm"}]}}'
+        "automated-cli-test-ubuntu-publisher/ubuntu-blob-store"}, {"dependsOn": [{"id":
+        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher",
+        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-test-ubuntu-publisher"}],
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/automated-cli-test-ubuntu-publisher/networkfunctiondefinitiongroups/ubuntu-vm",
+        "resourceType": "Microsoft.Hybridnetwork/publishers/networkfunctiondefinitiongroups",
+        "resourceName": "automated-cli-test-ubuntu-publisher/ubuntu-vm"}], "validatedResources":
+        [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher"},
+        {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher/artifactStores/ubuntu-acr"},
+        {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher/artifactStores/ubuntu-blob-store"},
+        {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/automated-cli-test-ubuntu-publisher/networkfunctiondefinitiongroups/ubuntu-vm"}]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '4028'
+      - '4011'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:08:21 GMT
+      - Wed, 15 May 2024 16:02:24 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
+      x-msedge-ref:
+      - 'Ref A: 77633448678C43C784A6D37C834A3AC7 Ref B: AMS231022012051 Ref C: 2024-05-15T16:02:24Z'
     status:
       code: 200
       message: OK
 - request:
     body: '{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
       "contentVersion": "1.0.0.0", "metadata": {"_generator": {"name": "bicep", "version":
-      "0.26.54.24096", "templateHash": "4595863518953475042"}}, "parameters": {"location":
+      "0.8.9.13224", "templateHash": "9985939870973944498"}}, "parameters": {"location":
       {"type": "string"}, "publisherName": {"type": "string", "metadata": {"description":
       "Name of a publisher, expected to be in the resource group where you deploy
       the template"}}, "acrArtifactStoreName": {"type": "string", "metadata": {"description":
@@ -164,12 +168,12 @@ interactions:
       "apiVersion": "2023-09-01", "name": "[format(''{0}/{1}'', parameters(''publisherName''),
       parameters(''saArtifactStoreName''))]", "location": "[parameters(''location'')]",
       "properties": {"storeType": "AzureStorageAccount"}, "dependsOn": ["[resourceId(''Microsoft.HybridNetwork/publishers'',
-      parameters(''publisherName''))]"]}, {"type": "Microsoft.HybridNetwork/publishers/networkFunctionDefinitionGroups",
+      parameters(''publisherName''))]"]}, {"type": "Microsoft.Hybridnetwork/publishers/networkfunctiondefinitiongroups",
       "apiVersion": "2023-09-01", "name": "[format(''{0}/{1}'', parameters(''publisherName''),
       parameters(''nfDefinitionGroup''))]", "location": "[parameters(''location'')]",
       "dependsOn": ["[resourceId(''Microsoft.HybridNetwork/publishers'', parameters(''publisherName''))]"]}]},
       "parameters": {"location": {"value": "uksouth"}, "publisherName": {"value":
-      "automated-cli-tests-ubuntu-publisher"}, "acrArtifactStoreName": {"value": "ubuntu-acr"},
+      "automated-cli-test-ubuntu-publisher"}, "acrArtifactStoreName": {"value": "ubuntu-acr"},
       "nfDefinitionGroup": {"value": "ubuntu-vm"}, "saArtifactStoreName": {"value":
       "ubuntu-blob-store"}}, "mode": "Incremental"}}'
     headers:
@@ -182,67 +186,69 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '2480'
+      - '2477'
       Content-Type:
       - application/json
       ParameterSetName:
       - --build-output-folder --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1713272902",
-        "name": "AOSM_CLI_deployment_1713272902", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "4595863518953475042", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1715788943",
+        "name": "AOSM_CLI_deployment_1715788943", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "9985939870973944498", "parameters": {"location":
         {"type": "String", "value": "uksouth"}, "publisherName": {"type": "String",
-        "value": "automated-cli-tests-ubuntu-publisher"}, "acrArtifactStoreName":
-        {"type": "String", "value": "ubuntu-acr"}, "saArtifactStoreName": {"type":
-        "String", "value": "ubuntu-blob-store"}, "nfDefinitionGroup": {"type": "String",
-        "value": "ubuntu-vm"}}, "mode": "Incremental", "provisioningState": "Accepted",
-        "timestamp": "2024-04-16T13:08:22.2836921Z", "duration": "PT0.0007337S", "correlationId":
-        "35e60e41-0ac9-49a7-97a1-b6a7962f68e8", "providers": [{"namespace": "Microsoft.HybridNetwork",
+        "value": "automated-cli-test-ubuntu-publisher"}, "acrArtifactStoreName": {"type":
+        "String", "value": "ubuntu-acr"}, "saArtifactStoreName": {"type": "String",
+        "value": "ubuntu-blob-store"}, "nfDefinitionGroup": {"type": "String", "value":
+        "ubuntu-vm"}}, "mode": "Incremental", "provisioningState": "Accepted", "timestamp":
+        "2024-05-15T16:02:25.6776587Z", "duration": "PT0.0001591S", "correlationId":
+        "9f41afdb-ab22-489b-aedf-e07fd939d662", "providers": [{"namespace": "Microsoft.HybridNetwork",
         "resourceTypes": [{"resourceType": "publishers", "locations": ["uksouth"]},
         {"resourceType": "publishers/artifactStores", "locations": ["uksouth"]}, {"resourceType":
-        "publishers/networkFunctionDefinitionGroups", "locations": ["uksouth"]}]}],
-        "dependencies": [{"dependsOn": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher",
-        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-tests-ubuntu-publisher"}],
-        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/artifactStores/ubuntu-acr",
+        "publishers/networkfunctiondefinitiongroups", "locations": ["uksouth"]}]}],
+        "dependencies": [{"dependsOn": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher",
+        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-test-ubuntu-publisher"}],
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher/artifactStores/ubuntu-acr",
         "resourceType": "Microsoft.HybridNetwork/publishers/artifactStores", "resourceName":
-        "automated-cli-tests-ubuntu-publisher/ubuntu-acr"}, {"dependsOn": [{"id":
-        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher",
-        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-tests-ubuntu-publisher"}],
-        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/artifactStores/ubuntu-blob-store",
+        "automated-cli-test-ubuntu-publisher/ubuntu-acr"}, {"dependsOn": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher",
+        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-test-ubuntu-publisher"}],
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher/artifactStores/ubuntu-blob-store",
         "resourceType": "Microsoft.HybridNetwork/publishers/artifactStores", "resourceName":
-        "automated-cli-tests-ubuntu-publisher/ubuntu-blob-store"}, {"dependsOn": [{"id":
-        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher",
-        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-tests-ubuntu-publisher"}],
-        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/networkFunctionDefinitionGroups/ubuntu-vm",
-        "resourceType": "Microsoft.HybridNetwork/publishers/networkFunctionDefinitionGroups",
-        "resourceName": "automated-cli-tests-ubuntu-publisher/ubuntu-vm"}]}}'
+        "automated-cli-test-ubuntu-publisher/ubuntu-blob-store"}, {"dependsOn": [{"id":
+        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher",
+        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-test-ubuntu-publisher"}],
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/automated-cli-test-ubuntu-publisher/networkfunctiondefinitiongroups/ubuntu-vm",
+        "resourceType": "Microsoft.Hybridnetwork/publishers/networkfunctiondefinitiongroups",
+        "resourceName": "automated-cli-test-ubuntu-publisher/ubuntu-vm"}]}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1713272902/operationStatuses/08584883339833700466?api-version=2022-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1715788943/operationStatuses/08584858179402236992?api-version=2022-09-01
       cache-control:
       - no-cache
       content-length:
-      - '3182'
+      - '3169'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:08:22 GMT
+      - Wed, 15 May 2024 16:02:25 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
+      x-msedge-ref:
+      - 'Ref A: 4366AD116FA246EDA79215BD30DEF460 Ref B: AMS231022012051 Ref C: 2024-05-15T16:02:24Z'
     status:
       code: 201
       message: Created
@@ -260,10 +266,9 @@ interactions:
       ParameterSetName:
       - --build-output-folder --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883339833700466?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858179402236992?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Accepted"}'
@@ -275,15 +280,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:08:22 GMT
+      - Wed, 15 May 2024 16:02:25 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: 3AA6765F17E7466A8026D9FD1A68903C Ref B: AMS231022012051 Ref C: 2024-05-15T16:02:25Z'
     status:
       code: 200
       message: OK
@@ -301,10 +310,9 @@ interactions:
       ParameterSetName:
       - --build-output-folder --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883339833700466?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858179402236992?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Running"}'
@@ -316,15 +324,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:08:51 GMT
+      - Wed, 15 May 2024 16:02:55 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: B217039ECFDD4EEE99F8D74CC52B1C80 Ref B: AMS231022012051 Ref C: 2024-05-15T16:02:55Z'
     status:
       code: 200
       message: OK
@@ -342,10 +354,9 @@ interactions:
       ParameterSetName:
       - --build-output-folder --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883339833700466?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858179402236992?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Running"}'
@@ -357,15 +368,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:09:22 GMT
+      - Wed, 15 May 2024 16:03:25 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: 632C0E1E36FA40C4BF135B3CE5E0B3AC Ref B: AMS231022012051 Ref C: 2024-05-15T16:03:25Z'
     status:
       code: 200
       message: OK
@@ -383,10 +398,9 @@ interactions:
       ParameterSetName:
       - --build-output-folder --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883339833700466?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858179402236992?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Running"}'
@@ -398,15 +412,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:09:51 GMT
+      - Wed, 15 May 2024 16:03:55 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: 8A445C84D29D47E28D7BA54E1794350C Ref B: AMS231022012051 Ref C: 2024-05-15T16:03:55Z'
     status:
       code: 200
       message: OK
@@ -424,10 +442,9 @@ interactions:
       ParameterSetName:
       - --build-output-folder --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883339833700466?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858179402236992?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Running"}'
@@ -439,15 +456,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:10:20 GMT
+      - Wed, 15 May 2024 16:04:25 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: 2BAFC15DD3CA4EAF91561797E1EADB24 Ref B: AMS231022012051 Ref C: 2024-05-15T16:04:26Z'
     status:
       code: 200
       message: OK
@@ -465,10 +486,9 @@ interactions:
       ParameterSetName:
       - --build-output-folder --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883339833700466?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858179402236992?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Running"}'
@@ -480,15 +500,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:10:50 GMT
+      - Wed, 15 May 2024 16:04:56 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: 7110AFFBE8C7409B8A864639E40D5B07 Ref B: AMS231022012051 Ref C: 2024-05-15T16:04:56Z'
     status:
       code: 200
       message: OK
@@ -506,10 +530,9 @@ interactions:
       ParameterSetName:
       - --build-output-folder --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883339833700466?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858179402236992?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Running"}'
@@ -521,15 +544,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:11:21 GMT
+      - Wed, 15 May 2024 16:05:26 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: 2D4A133F5F1A4A278A6CB31CCDEFCA4A Ref B: AMS231022012051 Ref C: 2024-05-15T16:05:26Z'
     status:
       code: 200
       message: OK
@@ -547,10 +574,9 @@ interactions:
       ParameterSetName:
       - --build-output-folder --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883339833700466?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858179402236992?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Running"}'
@@ -562,15 +588,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:11:49 GMT
+      - Wed, 15 May 2024 16:05:57 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: E84B494A97CE468F8D74A492377FDE45 Ref B: AMS231022012051 Ref C: 2024-05-15T16:05:57Z'
     status:
       code: 200
       message: OK
@@ -588,10 +618,9 @@ interactions:
       ParameterSetName:
       - --build-output-folder --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883339833700466?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858179402236992?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Succeeded"}'
@@ -603,15 +632,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:12:19 GMT
+      - Wed, 15 May 2024 16:06:27 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: 399C5A698CAA4561B748A291B807DF25 Ref B: AMS231022012051 Ref C: 2024-05-15T16:06:27Z'
     status:
       code: 200
       message: OK
@@ -629,61 +662,63 @@ interactions:
       ParameterSetName:
       - --build-output-folder --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1713272902",
-        "name": "AOSM_CLI_deployment_1713272902", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "4595863518953475042", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1715788943",
+        "name": "AOSM_CLI_deployment_1715788943", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "9985939870973944498", "parameters": {"location":
         {"type": "String", "value": "uksouth"}, "publisherName": {"type": "String",
-        "value": "automated-cli-tests-ubuntu-publisher"}, "acrArtifactStoreName":
-        {"type": "String", "value": "ubuntu-acr"}, "saArtifactStoreName": {"type":
-        "String", "value": "ubuntu-blob-store"}, "nfDefinitionGroup": {"type": "String",
-        "value": "ubuntu-vm"}}, "mode": "Incremental", "provisioningState": "Succeeded",
-        "timestamp": "2024-04-16T13:12:07.5717024Z", "duration": "PT3M45.288744S",
-        "correlationId": "35e60e41-0ac9-49a7-97a1-b6a7962f68e8", "providers": [{"namespace":
-        "Microsoft.HybridNetwork", "resourceTypes": [{"resourceType": "publishers",
-        "locations": ["uksouth"]}, {"resourceType": "publishers/artifactStores", "locations":
-        ["uksouth"]}, {"resourceType": "publishers/networkFunctionDefinitionGroups",
-        "locations": ["uksouth"]}]}], "dependencies": [{"dependsOn": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher",
-        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-tests-ubuntu-publisher"}],
-        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/artifactStores/ubuntu-acr",
+        "value": "automated-cli-test-ubuntu-publisher"}, "acrArtifactStoreName": {"type":
+        "String", "value": "ubuntu-acr"}, "saArtifactStoreName": {"type": "String",
+        "value": "ubuntu-blob-store"}, "nfDefinitionGroup": {"type": "String", "value":
+        "ubuntu-vm"}}, "mode": "Incremental", "provisioningState": "Succeeded", "timestamp":
+        "2024-05-15T16:06:16.5290346Z", "duration": "PT3M50.851535S", "correlationId":
+        "9f41afdb-ab22-489b-aedf-e07fd939d662", "providers": [{"namespace": "Microsoft.HybridNetwork",
+        "resourceTypes": [{"resourceType": "publishers", "locations": ["uksouth"]},
+        {"resourceType": "publishers/artifactStores", "locations": ["uksouth"]}, {"resourceType":
+        "publishers/networkfunctiondefinitiongroups", "locations": ["uksouth"]}]}],
+        "dependencies": [{"dependsOn": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher",
+        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-test-ubuntu-publisher"}],
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher/artifactStores/ubuntu-acr",
         "resourceType": "Microsoft.HybridNetwork/publishers/artifactStores", "resourceName":
-        "automated-cli-tests-ubuntu-publisher/ubuntu-acr"}, {"dependsOn": [{"id":
-        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher",
-        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-tests-ubuntu-publisher"}],
-        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/artifactStores/ubuntu-blob-store",
+        "automated-cli-test-ubuntu-publisher/ubuntu-acr"}, {"dependsOn": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher",
+        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-test-ubuntu-publisher"}],
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher/artifactStores/ubuntu-blob-store",
         "resourceType": "Microsoft.HybridNetwork/publishers/artifactStores", "resourceName":
-        "automated-cli-tests-ubuntu-publisher/ubuntu-blob-store"}, {"dependsOn": [{"id":
-        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher",
-        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-tests-ubuntu-publisher"}],
-        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/networkFunctionDefinitionGroups/ubuntu-vm",
-        "resourceType": "Microsoft.HybridNetwork/publishers/networkFunctionDefinitionGroups",
-        "resourceName": "automated-cli-tests-ubuntu-publisher/ubuntu-vm"}], "outputResources":
-        [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher"},
-        {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/artifactStores/ubuntu-acr"},
-        {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/artifactStores/ubuntu-blob-store"},
-        {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/networkFunctionDefinitionGroups/ubuntu-vm"}]}}'
+        "automated-cli-test-ubuntu-publisher/ubuntu-blob-store"}, {"dependsOn": [{"id":
+        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher",
+        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-test-ubuntu-publisher"}],
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/automated-cli-test-ubuntu-publisher/networkfunctiondefinitiongroups/ubuntu-vm",
+        "resourceType": "Microsoft.Hybridnetwork/publishers/networkfunctiondefinitiongroups",
+        "resourceName": "automated-cli-test-ubuntu-publisher/ubuntu-vm"}], "outputResources":
+        [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher"},
+        {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher/artifactStores/ubuntu-acr"},
+        {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher/artifactStores/ubuntu-blob-store"},
+        {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/automated-cli-test-ubuntu-publisher/networkfunctiondefinitiongroups/ubuntu-vm"}]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '4043'
+      - '4026'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:12:19 GMT
+      - Wed, 15 May 2024 16:06:27 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: D5B5E22F9E694D1EBC4245B5FCE01FF4 Ref B: AMS231022012051 Ref C: 2024-05-15T16:06:27Z'
     status:
       code: 200
       message: OK
@@ -701,34 +736,37 @@ interactions:
       ParameterSetName:
       - --build-output-folder --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-hybridnetwork/unknown Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-acr-manifest-1-0-0?api-version=2023-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-acr-manifest-1-0-0?api-version=2023-09-01
   response:
     body:
-      string: '{"error": {"code": "ResourceNotFound", "message": "The Resource ''Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-acr-manifest-1-0-0''
+      string: '{"error": {"code": "ResourceNotFound", "message": "The Resource ''Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-acr-manifest-1-0-0''
         under resource group ''cli_test_vnf_nsd_000001'' was not found. For more details
         please go to https://aka.ms/ARMResourceNotFoundFix"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '343'
+      - '342'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:12:19 GMT
+      - Wed, 15 May 2024 16:06:27 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
       x-ms-failure-cause:
       - gateway
+      x-msedge-ref:
+      - 'Ref A: DDC42D5D1D3347839D049F32C21A83FD Ref B: AMS231020512029 Ref C: 2024-05-15T16:06:28Z'
     status:
       code: 404
       message: Not Found
@@ -746,41 +784,44 @@ interactions:
       ParameterSetName:
       - --build-output-folder --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-hybridnetwork/unknown Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/artifactStores/ubuntu-blob-store/artifactManifests/ubuntu-vm-sa-manifest-1-0-0?api-version=2023-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher/artifactStores/ubuntu-blob-store/artifactManifests/ubuntu-vm-sa-manifest-1-0-0?api-version=2023-09-01
   response:
     body:
-      string: '{"error": {"code": "ResourceNotFound", "message": "The Resource ''Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/artifactStores/ubuntu-blob-store/artifactManifests/ubuntu-vm-sa-manifest-1-0-0''
+      string: '{"error": {"code": "ResourceNotFound", "message": "The Resource ''Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher/artifactStores/ubuntu-blob-store/artifactManifests/ubuntu-vm-sa-manifest-1-0-0''
         under resource group ''cli_test_vnf_nsd_000001'' was not found. For more details
         please go to https://aka.ms/ARMResourceNotFoundFix"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '349'
+      - '348'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:12:19 GMT
+      - Wed, 15 May 2024 16:06:28 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
       x-ms-failure-cause:
       - gateway
+      x-msedge-ref:
+      - 'Ref A: BD98E32446CB44A0A47FD8CB9B655DC2 Ref B: AMS231020512029 Ref C: 2024-05-15T16:06:28Z'
     status:
       code: 404
       message: Not Found
 - request:
     body: '{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
       "contentVersion": "1.0.0.0", "metadata": {"_generator": {"name": "bicep", "version":
-      "0.26.54.24096", "templateHash": "14347213902282880649"}}, "parameters": {"location":
+      "0.8.9.13224", "templateHash": "2261224723127030745"}}, "parameters": {"location":
       {"type": "string"}, "publisherName": {"type": "string", "metadata": {"description":
       "Name of an existing publisher, expected to be in the resource group where you
       deploy the template"}}, "acrArtifactStoreName": {"type": "string", "metadata":
@@ -790,18 +831,18 @@ interactions:
       publisher."}}, "acrManifestName": {"type": "string", "metadata": {"description":
       "Name of the manifest to deploy for the ACR-backed Artifact Store"}}, "saManifestName":
       {"type": "string", "metadata": {"description": "Name of the manifest to deploy
-      for the Storage Account-backed Artifact Store"}}}, "resources": [{"type": "Microsoft.HybridNetwork/publishers/artifactStores/artifactManifests",
+      for the Storage Account-backed Artifact Store"}}}, "resources": [{"type": "Microsoft.Hybridnetwork/publishers/artifactStores/artifactManifests",
       "apiVersion": "2023-09-01", "name": "[format(''{0}/{1}/{2}'', parameters(''publisherName''),
       parameters(''acrArtifactStoreName''), parameters(''acrManifestName''))]", "location":
       "[parameters(''location'')]", "properties": {"artifacts": [{"artifactName":
       "automated-cli-tests-artifact", "artifactType": "ArmTemplate", "artifactVersion":
-      "1.0.0"}]}}, {"type": "Microsoft.HybridNetwork/publishers/artifactStores/artifactManifests",
+      "1.0.0"}]}}, {"type": "Microsoft.Hybridnetwork/publishers/artifactStores/artifactManifests",
       "apiVersion": "2023-09-01", "name": "[format(''{0}/{1}/{2}'', parameters(''publisherName''),
       parameters(''saArtifactStoreName''), parameters(''saManifestName''))]", "location":
       "[parameters(''location'')]", "properties": {"artifacts": [{"artifactName":
       "automated-cli-tests-vhd", "artifactType": "VhdImageFile", "artifactVersion":
       "1-0-0"}]}}]}, "parameters": {"location": {"value": "uksouth"}, "publisherName":
-      {"value": "automated-cli-tests-ubuntu-publisher"}, "acrArtifactStoreName": {"value":
+      {"value": "automated-cli-test-ubuntu-publisher"}, "acrArtifactStoreName": {"value":
       "ubuntu-acr"}, "acrManifestName": {"value": "ubuntu-vm-acr-manifest-1-0-0"},
       "saArtifactStoreName": {"value": "ubuntu-blob-store"}, "saManifestName": {"value":
       "ubuntu-vm-sa-manifest-1-0-0"}}, "mode": "Incremental"}}'
@@ -815,59 +856,62 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '2299'
+      - '2295'
       Content-Type:
       - application/json
       ParameterSetName:
       - --build-output-folder --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/validate?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1713273146",
-        "name": "AOSM_CLI_deployment_1713273146", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "14347213902282880649", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1715789191",
+        "name": "AOSM_CLI_deployment_1715789191", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "2261224723127030745", "parameters": {"location":
         {"type": "String", "value": "uksouth"}, "publisherName": {"type": "String",
-        "value": "automated-cli-tests-ubuntu-publisher"}, "acrArtifactStoreName":
-        {"type": "String", "value": "ubuntu-acr"}, "saArtifactStoreName": {"type":
-        "String", "value": "ubuntu-blob-store"}, "acrManifestName": {"type": "String",
-        "value": "ubuntu-vm-acr-manifest-1-0-0"}, "saManifestName": {"type": "String",
-        "value": "ubuntu-vm-sa-manifest-1-0-0"}}, "mode": "Incremental", "provisioningState":
+        "value": "automated-cli-test-ubuntu-publisher"}, "acrArtifactStoreName": {"type":
+        "String", "value": "ubuntu-acr"}, "saArtifactStoreName": {"type": "String",
+        "value": "ubuntu-blob-store"}, "acrManifestName": {"type": "String", "value":
+        "ubuntu-vm-acr-manifest-1-0-0"}, "saManifestName": {"type": "String", "value":
+        "ubuntu-vm-sa-manifest-1-0-0"}}, "mode": "Incremental", "provisioningState":
         "Succeeded", "timestamp": "0001-01-01T00:00:00Z", "duration": "PT0S", "correlationId":
-        "4b5d463f-3938-4a10-9a5d-056483a45be3", "providers": [{"namespace": "Microsoft.HybridNetwork",
+        "dd2c3921-dc57-407a-9300-e5eec0846a07", "providers": [{"namespace": "Microsoft.Hybridnetwork",
         "resourceTypes": [{"resourceType": "publishers/artifactStores/artifactManifests",
         "locations": ["uksouth"]}]}], "dependencies": [], "validatedResources": [{"id":
-        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-acr-manifest-1-0-0"},
-        {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/artifactStores/ubuntu-blob-store/artifactManifests/ubuntu-vm-sa-manifest-1-0-0"}]}}'
+        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/automated-cli-test-ubuntu-publisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-acr-manifest-1-0-0"},
+        {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/automated-cli-test-ubuntu-publisher/artifactStores/ubuntu-blob-store/artifactManifests/ubuntu-vm-sa-manifest-1-0-0"}]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1668'
+      - '1664'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:12:24 GMT
+      - Wed, 15 May 2024 16:06:32 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
       - '1198'
+      x-msedge-ref:
+      - 'Ref A: 4E01128AD6764E7FB40D06B623A5E95B Ref B: AMS231022012051 Ref C: 2024-05-15T16:06:32Z'
     status:
       code: 200
       message: OK
 - request:
     body: '{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
       "contentVersion": "1.0.0.0", "metadata": {"_generator": {"name": "bicep", "version":
-      "0.26.54.24096", "templateHash": "14347213902282880649"}}, "parameters": {"location":
+      "0.8.9.13224", "templateHash": "2261224723127030745"}}, "parameters": {"location":
       {"type": "string"}, "publisherName": {"type": "string", "metadata": {"description":
       "Name of an existing publisher, expected to be in the resource group where you
       deploy the template"}}, "acrArtifactStoreName": {"type": "string", "metadata":
@@ -877,18 +921,18 @@ interactions:
       publisher."}}, "acrManifestName": {"type": "string", "metadata": {"description":
       "Name of the manifest to deploy for the ACR-backed Artifact Store"}}, "saManifestName":
       {"type": "string", "metadata": {"description": "Name of the manifest to deploy
-      for the Storage Account-backed Artifact Store"}}}, "resources": [{"type": "Microsoft.HybridNetwork/publishers/artifactStores/artifactManifests",
+      for the Storage Account-backed Artifact Store"}}}, "resources": [{"type": "Microsoft.Hybridnetwork/publishers/artifactStores/artifactManifests",
       "apiVersion": "2023-09-01", "name": "[format(''{0}/{1}/{2}'', parameters(''publisherName''),
       parameters(''acrArtifactStoreName''), parameters(''acrManifestName''))]", "location":
       "[parameters(''location'')]", "properties": {"artifacts": [{"artifactName":
       "automated-cli-tests-artifact", "artifactType": "ArmTemplate", "artifactVersion":
-      "1.0.0"}]}}, {"type": "Microsoft.HybridNetwork/publishers/artifactStores/artifactManifests",
+      "1.0.0"}]}}, {"type": "Microsoft.Hybridnetwork/publishers/artifactStores/artifactManifests",
       "apiVersion": "2023-09-01", "name": "[format(''{0}/{1}/{2}'', parameters(''publisherName''),
       parameters(''saArtifactStoreName''), parameters(''saManifestName''))]", "location":
       "[parameters(''location'')]", "properties": {"artifacts": [{"artifactName":
       "automated-cli-tests-vhd", "artifactType": "VhdImageFile", "artifactVersion":
       "1-0-0"}]}}]}, "parameters": {"location": {"value": "uksouth"}, "publisherName":
-      {"value": "automated-cli-tests-ubuntu-publisher"}, "acrArtifactStoreName": {"value":
+      {"value": "automated-cli-test-ubuntu-publisher"}, "acrArtifactStoreName": {"value":
       "ubuntu-acr"}, "acrManifestName": {"value": "ubuntu-vm-acr-manifest-1-0-0"},
       "saArtifactStoreName": {"value": "ubuntu-blob-store"}, "saManifestName": {"value":
       "ubuntu-vm-sa-manifest-1-0-0"}}, "mode": "Incremental"}}'
@@ -902,52 +946,55 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '2299'
+      - '2295'
       Content-Type:
       - application/json
       ParameterSetName:
       - --build-output-folder --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1713273146",
-        "name": "AOSM_CLI_deployment_1713273146", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "14347213902282880649", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1715789191",
+        "name": "AOSM_CLI_deployment_1715789191", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "2261224723127030745", "parameters": {"location":
         {"type": "String", "value": "uksouth"}, "publisherName": {"type": "String",
-        "value": "automated-cli-tests-ubuntu-publisher"}, "acrArtifactStoreName":
-        {"type": "String", "value": "ubuntu-acr"}, "saArtifactStoreName": {"type":
-        "String", "value": "ubuntu-blob-store"}, "acrManifestName": {"type": "String",
-        "value": "ubuntu-vm-acr-manifest-1-0-0"}, "saManifestName": {"type": "String",
-        "value": "ubuntu-vm-sa-manifest-1-0-0"}}, "mode": "Incremental", "provisioningState":
-        "Accepted", "timestamp": "2024-04-16T13:12:25.5594541Z", "duration": "PT0.0006074S",
-        "correlationId": "f9c7ecbe-d587-4f86-ba84-49d9780f4ecf", "providers": [{"namespace":
-        "Microsoft.HybridNetwork", "resourceTypes": [{"resourceType": "publishers/artifactStores/artifactManifests",
+        "value": "automated-cli-test-ubuntu-publisher"}, "acrArtifactStoreName": {"type":
+        "String", "value": "ubuntu-acr"}, "saArtifactStoreName": {"type": "String",
+        "value": "ubuntu-blob-store"}, "acrManifestName": {"type": "String", "value":
+        "ubuntu-vm-acr-manifest-1-0-0"}, "saManifestName": {"type": "String", "value":
+        "ubuntu-vm-sa-manifest-1-0-0"}}, "mode": "Incremental", "provisioningState":
+        "Accepted", "timestamp": "2024-05-15T16:06:33.8969395Z", "duration": "PT0.0001543S",
+        "correlationId": "dc308ca5-47d1-4718-b0e7-47cb729f2e92", "providers": [{"namespace":
+        "Microsoft.Hybridnetwork", "resourceTypes": [{"resourceType": "publishers/artifactStores/artifactManifests",
         "locations": ["uksouth"]}]}], "dependencies": []}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1713273146/operationStatuses/08584883337401066204?api-version=2022-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1715789191/operationStatuses/08584858176919688298?api-version=2022-09-01
       cache-control:
       - no-cache
       content-length:
-      - '1139'
+      - '1137'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:12:25 GMT
+      - Wed, 15 May 2024 16:06:33 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
+      x-msedge-ref:
+      - 'Ref A: EF1679A13E7F4E56BDF8E80287EC7DCB Ref B: AMS231022012051 Ref C: 2024-05-15T16:06:32Z'
     status:
       code: 201
       message: Created
@@ -965,10 +1012,9 @@ interactions:
       ParameterSetName:
       - --build-output-folder --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883337401066204?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858176919688298?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Accepted"}'
@@ -980,15 +1026,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:12:25 GMT
+      - Wed, 15 May 2024 16:06:33 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: A8B75181D62B4F85AD6CBD23EF46E31A Ref B: AMS231022012051 Ref C: 2024-05-15T16:06:34Z'
     status:
       code: 200
       message: OK
@@ -1006,10 +1056,9 @@ interactions:
       ParameterSetName:
       - --build-output-folder --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883337401066204?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858176919688298?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Running"}'
@@ -1021,15 +1070,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:12:55 GMT
+      - Wed, 15 May 2024 16:07:04 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: 504429F8B3FD472D87805692AFF21B9A Ref B: AMS231022012051 Ref C: 2024-05-15T16:07:04Z'
     status:
       code: 200
       message: OK
@@ -1047,10 +1100,9 @@ interactions:
       ParameterSetName:
       - --build-output-folder --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883337401066204?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858176919688298?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Running"}'
@@ -1062,15 +1114,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:13:24 GMT
+      - Wed, 15 May 2024 16:07:35 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: 14BEA329E2374AE7BF1FA3838F730A70 Ref B: AMS231022012051 Ref C: 2024-05-15T16:07:35Z'
     status:
       code: 200
       message: OK
@@ -1088,10 +1144,9 @@ interactions:
       ParameterSetName:
       - --build-output-folder --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883337401066204?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858176919688298?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Succeeded"}'
@@ -1103,15 +1158,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:13:54 GMT
+      - Wed, 15 May 2024 16:08:05 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: A567666607DF414EAD46485954D24896 Ref B: AMS231022012051 Ref C: 2024-05-15T16:08:05Z'
     status:
       code: 200
       message: OK
@@ -1129,44 +1188,47 @@ interactions:
       ParameterSetName:
       - --build-output-folder --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1713273146",
-        "name": "AOSM_CLI_deployment_1713273146", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "14347213902282880649", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1715789191",
+        "name": "AOSM_CLI_deployment_1715789191", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "2261224723127030745", "parameters": {"location":
         {"type": "String", "value": "uksouth"}, "publisherName": {"type": "String",
-        "value": "automated-cli-tests-ubuntu-publisher"}, "acrArtifactStoreName":
-        {"type": "String", "value": "ubuntu-acr"}, "saArtifactStoreName": {"type":
-        "String", "value": "ubuntu-blob-store"}, "acrManifestName": {"type": "String",
-        "value": "ubuntu-vm-acr-manifest-1-0-0"}, "saManifestName": {"type": "String",
-        "value": "ubuntu-vm-sa-manifest-1-0-0"}}, "mode": "Incremental", "provisioningState":
-        "Succeeded", "timestamp": "2024-04-16T13:13:47.3083141Z", "duration": "PT1M21.7494674S",
-        "correlationId": "f9c7ecbe-d587-4f86-ba84-49d9780f4ecf", "providers": [{"namespace":
-        "Microsoft.HybridNetwork", "resourceTypes": [{"resourceType": "publishers/artifactStores/artifactManifests",
+        "value": "automated-cli-test-ubuntu-publisher"}, "acrArtifactStoreName": {"type":
+        "String", "value": "ubuntu-acr"}, "saArtifactStoreName": {"type": "String",
+        "value": "ubuntu-blob-store"}, "acrManifestName": {"type": "String", "value":
+        "ubuntu-vm-acr-manifest-1-0-0"}, "saManifestName": {"type": "String", "value":
+        "ubuntu-vm-sa-manifest-1-0-0"}}, "mode": "Incremental", "provisioningState":
+        "Succeeded", "timestamp": "2024-05-15T16:08:00.2578628Z", "duration": "PT1M26.3610776S",
+        "correlationId": "dc308ca5-47d1-4718-b0e7-47cb729f2e92", "providers": [{"namespace":
+        "Microsoft.Hybridnetwork", "resourceTypes": [{"resourceType": "publishers/artifactStores/artifactManifests",
         "locations": ["uksouth"]}]}], "dependencies": [], "outputResources": [{"id":
-        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-acr-manifest-1-0-0"},
-        {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/artifactStores/ubuntu-blob-store/artifactManifests/ubuntu-vm-sa-manifest-1-0-0"}]}}'
+        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/automated-cli-test-ubuntu-publisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-acr-manifest-1-0-0"},
+        {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/automated-cli-test-ubuntu-publisher/artifactStores/ubuntu-blob-store/artifactManifests/ubuntu-vm-sa-manifest-1-0-0"}]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1684'
+      - '1680'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:13:54 GMT
+      - Wed, 15 May 2024 16:08:05 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: A0AE45D10F6043F0AD14A9A6511A96A6 Ref B: AMS231022012051 Ref C: 2024-05-15T16:08:05Z'
     status:
       code: 200
       message: OK
@@ -1186,15 +1248,14 @@ interactions:
       ParameterSetName:
       - --build-output-folder --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-hybridnetwork/unknown Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-acr-manifest-1-0-0/listCredential?api-version=2023-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-vm-acr-manifest-1-0-0/listCredential?api-version=2023-09-01
   response:
     body:
       string: '{"username": "ubuntu-vm-acr-manifest-1-0-0", "acrToken": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-        "acrServerUrl": "https://automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io",
-        "repositories": ["automated-cli-tests-artifact"], "expiry": "2024-04-17T13:13:56.8427489+00:00",
+        "acrServerUrl": "https://automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io",
+        "repositories": ["automated-cli-tests-artifact"], "expiry": "2024-05-16T16:08:10.0859796+00:00",
         "credentialType": "AzureContainerRegistryScopedToken"}'
     headers:
       cache-control:
@@ -1204,21 +1265,25 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:13:56 GMT
+      - Wed, 15 May 2024 16:08:09 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
       x-ms-build-version:
-      - 1.0.02651.2759
+      - 1.0.02682.2890
       x-ms-providerhub-traffic:
       - 'True'
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
+      x-msedge-ref:
+      - 'Ref A: 715046D33CA444D497D5CB90D60731FC Ref B: AMS231022012049 Ref C: 2024-05-15T16:08:05Z'
     status:
       code: 200
       message: OK
@@ -1236,9 +1301,9 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - python-requests/2.31.0
+      - python-requests/2.26.0
     method: POST
-    uri: https://automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io/v2/automated-cli-tests-artifact/blobs/uploads/
+    uri: https://automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io/v2/automated-cli-tests-artifact/blobs/uploads/
   response:
     body:
       string: '{"errors": [{"code": "UNAUTHORIZED", "message": "authentication required,
@@ -1258,7 +1323,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:13:57 GMT
+      - Wed, 15 May 2024 16:08:10 GMT
       docker-distribution-api-version:
       - registry/2.0
       server:
@@ -1267,7 +1332,7 @@ interactions:
       - max-age=31536000; includeSubDomains
       - max-age=31536000; includeSubDomains
       www-authenticate:
-      - Bearer realm="https://automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io/oauth2/token",service="automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io",scope="repository:automated-cli-tests-artifact:push,pull"
+      - Bearer realm="https://automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io/oauth2/token",service="automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io",scope="repository:automated-cli-tests-artifact:pull,push"
       x-content-type-options:
       - nosniff
     status:
@@ -1283,11 +1348,11 @@ interactions:
       Connection:
       - keep-alive
       Service:
-      - automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io
+      - automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io
       User-Agent:
       - oras-py
     method: GET
-    uri: https://automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io/oauth2/token?service=automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io&scope=repository%3Aautomated-cli-tests-artifact%3Apush%2Cpull
+    uri: https://automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io/oauth2/token?service=automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io&scope=repository%3Aautomated-cli-tests-artifact%3Apull%2Cpush
   response:
     body:
       string: '{"access_token": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}'
@@ -1297,7 +1362,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:13:57 GMT
+      - Wed, 15 May 2024 16:08:10 GMT
       server:
       - AzureContainerRegistry
       strict-transport-security:
@@ -1323,9 +1388,9 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - python-requests/2.31.0
+      - python-requests/2.26.0
     method: POST
-    uri: https://automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io/v2/automated-cli-tests-artifact/blobs/uploads/
+    uri: https://automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io/v2/automated-cli-tests-artifact/blobs/uploads/
   response:
     body:
       string: ''
@@ -1340,13 +1405,13 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 16 Apr 2024 13:13:57 GMT
+      - Wed, 15 May 2024 16:08:10 GMT
       docker-distribution-api-version:
       - registry/2.0
       docker-upload-uuid:
-      - 3810ed7f-fa42-420b-80b1-475159062fc5
+      - 51889e54-1858-492f-b518-a6da2a7fdc21
       location:
-      - /v2/automated-cli-tests-artifact/blobs/uploads/3810ed7f-fa42-420b-80b1-475159062fc5?_nouploadcache=false&_state=N2nJsSCDg27SKRxPBSeZnhKeXGSrLvZ8fue2DZmlVoF7Ik5hbWUiOiJhdXRvbWF0ZWQtY2xpLXRlc3RzLWFydGlmYWN0IiwiVVVJRCI6IjM4MTBlZDdmLWZhNDItNDIwYi04MGIxLTQ3NTE1OTA2MmZjNSIsIk9mZnNldCI6MCwiU3RhcnRlZEF0IjoiMjAyNC0wNC0xNlQxMzoxMzo1Ny40OTE4MTg2MTFaIn0%3D
+      - /v2/automated-cli-tests-artifact/blobs/uploads/51889e54-1858-492f-b518-a6da2a7fdc21?_nouploadcache=false&_state=r9me_bG-tX5vhDppbTk2M9p3GUhyPmes5SBElXVZp-d7Ik5hbWUiOiJhdXRvbWF0ZWQtY2xpLXRlc3RzLWFydGlmYWN0IiwiVVVJRCI6IjUxODg5ZTU0LTE4NTgtNDkyZi1iNTE4LWE2ZGEyYTdmZGMyMSIsIk9mZnNldCI6MCwiU3RhcnRlZEF0IjoiMjAyNC0wNS0xNVQxNjowODoxMC44MTMwODAxMDZaIn0%3D
       range:
       - 0-0
       server:
@@ -1417,9 +1482,9 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - python-requests/2.31.0
+      - python-requests/2.26.0
     method: PUT
-    uri: https://automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io/v2/automated-cli-tests-artifact/blobs/uploads/3810ed7f-fa42-420b-80b1-475159062fc5?_nouploadcache=false&_state=N2nJsSCDg27SKRxPBSeZnhKeXGSrLvZ8fue2DZmlVoF7Ik5hbWUiOiJhdXRvbWF0ZWQtY2xpLXRlc3RzLWFydGlmYWN0IiwiVVVJRCI6IjM4MTBlZDdmLWZhNDItNDIwYi04MGIxLTQ3NTE1OTA2MmZjNSIsIk9mZnNldCI6MCwiU3RhcnRlZEF0IjoiMjAyNC0wNC0xNlQxMzoxMzo1Ny40OTE4MTg2MTFaIn0%3D&digest=sha256%3Ae71bf56543dc33dc8e550a0c574efe9a4875754a4ddf74347e448dec2462798b
+    uri: https://automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io/v2/automated-cli-tests-artifact/blobs/uploads/51889e54-1858-492f-b518-a6da2a7fdc21?_nouploadcache=false&_state=r9me_bG-tX5vhDppbTk2M9p3GUhyPmes5SBElXVZp-d7Ik5hbWUiOiJhdXRvbWF0ZWQtY2xpLXRlc3RzLWFydGlmYWN0IiwiVVVJRCI6IjUxODg5ZTU0LTE4NTgtNDkyZi1iNTE4LWE2ZGEyYTdmZGMyMSIsIk9mZnNldCI6MCwiU3RhcnRlZEF0IjoiMjAyNC0wNS0xNVQxNjowODoxMC44MTMwODAxMDZaIn0%3D&digest=sha256%3Ae71bf56543dc33dc8e550a0c574efe9a4875754a4ddf74347e448dec2462798b
   response:
     body:
       string: ''
@@ -1434,7 +1499,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 16 Apr 2024 13:13:57 GMT
+      - Wed, 15 May 2024 16:08:10 GMT
       docker-content-digest:
       - sha256:e71bf56543dc33dc8e550a0c574efe9a4875754a4ddf74347e448dec2462798b
       docker-distribution-api-version:
@@ -1465,9 +1530,9 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - python-requests/2.31.0
+      - python-requests/2.26.0
     method: POST
-    uri: https://automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io/v2/automated-cli-tests-artifact/blobs/uploads/
+    uri: https://automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io/v2/automated-cli-tests-artifact/blobs/uploads/
   response:
     body:
       string: '{"errors": [{"code": "UNAUTHORIZED", "message": "authentication required,
@@ -1487,7 +1552,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:13:57 GMT
+      - Wed, 15 May 2024 16:08:11 GMT
       docker-distribution-api-version:
       - registry/2.0
       server:
@@ -1496,7 +1561,7 @@ interactions:
       - max-age=31536000; includeSubDomains
       - max-age=31536000; includeSubDomains
       www-authenticate:
-      - Bearer realm="https://automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io/oauth2/token",service="automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io",scope="repository:automated-cli-tests-artifact:pull,push"
+      - Bearer realm="https://automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io/oauth2/token",service="automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io",scope="repository:automated-cli-tests-artifact:pull,push"
       x-content-type-options:
       - nosniff
     status:
@@ -1512,11 +1577,11 @@ interactions:
       Connection:
       - keep-alive
       Service:
-      - automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io
+      - automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io
       User-Agent:
       - oras-py
     method: GET
-    uri: https://automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io/oauth2/token?service=automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io&scope=repository%3Aautomated-cli-tests-artifact%3Apull%2Cpush
+    uri: https://automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io/oauth2/token?service=automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io&scope=repository%3Aautomated-cli-tests-artifact%3Apull%2Cpush
   response:
     body:
       string: '{"access_token": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}'
@@ -1526,7 +1591,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:13:57 GMT
+      - Wed, 15 May 2024 16:08:11 GMT
       server:
       - AzureContainerRegistry
       strict-transport-security:
@@ -1552,9 +1617,9 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - python-requests/2.31.0
+      - python-requests/2.26.0
     method: POST
-    uri: https://automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io/v2/automated-cli-tests-artifact/blobs/uploads/
+    uri: https://automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io/v2/automated-cli-tests-artifact/blobs/uploads/
   response:
     body:
       string: ''
@@ -1569,13 +1634,13 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 16 Apr 2024 13:13:57 GMT
+      - Wed, 15 May 2024 16:08:11 GMT
       docker-distribution-api-version:
       - registry/2.0
       docker-upload-uuid:
-      - ec08a746-9100-4f0a-ab71-cf252af14449
+      - d5f51eee-9058-42b1-beb7-a6e0da4e8dea
       location:
-      - /v2/automated-cli-tests-artifact/blobs/uploads/ec08a746-9100-4f0a-ab71-cf252af14449?_nouploadcache=false&_state=U4PxEc7ZPjmDH5Lum_jeOTz2aZvBYD-p67_QIYJkLiF7Ik5hbWUiOiJhdXRvbWF0ZWQtY2xpLXRlc3RzLWFydGlmYWN0IiwiVVVJRCI6ImVjMDhhNzQ2LTkxMDAtNGYwYS1hYjcxLWNmMjUyYWYxNDQ0OSIsIk9mZnNldCI6MCwiU3RhcnRlZEF0IjoiMjAyNC0wNC0xNlQxMzoxMzo1Ny44MjAzOTI5ODFaIn0%3D
+      - /v2/automated-cli-tests-artifact/blobs/uploads/d5f51eee-9058-42b1-beb7-a6e0da4e8dea?_nouploadcache=false&_state=DxIhePmvKmkUSDcKXpb_t1u9k5JKfzWJXY2ADBXBzc97Ik5hbWUiOiJhdXRvbWF0ZWQtY2xpLXRlc3RzLWFydGlmYWN0IiwiVVVJRCI6ImQ1ZjUxZWVlLTkwNTgtNDJiMS1iZWI3LWE2ZTBkYTRlOGRlYSIsIk9mZnNldCI6MCwiU3RhcnRlZEF0IjoiMjAyNC0wNS0xNVQxNjowODoxMS4wNzQ2NTE2NjdaIn0%3D
       range:
       - 0-0
       server:
@@ -1589,7 +1654,7 @@ interactions:
       code: 202
       message: Accepted
 - request:
-    body: '{}'
+    body: null
     headers:
       Accept:
       - '*/*'
@@ -1598,13 +1663,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '2'
+      - '0'
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - python-requests/2.31.0
+      - python-requests/2.26.0
     method: PUT
-    uri: https://automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io/v2/automated-cli-tests-artifact/blobs/uploads/ec08a746-9100-4f0a-ab71-cf252af14449?_nouploadcache=false&_state=U4PxEc7ZPjmDH5Lum_jeOTz2aZvBYD-p67_QIYJkLiF7Ik5hbWUiOiJhdXRvbWF0ZWQtY2xpLXRlc3RzLWFydGlmYWN0IiwiVVVJRCI6ImVjMDhhNzQ2LTkxMDAtNGYwYS1hYjcxLWNmMjUyYWYxNDQ0OSIsIk9mZnNldCI6MCwiU3RhcnRlZEF0IjoiMjAyNC0wNC0xNlQxMzoxMzo1Ny44MjAzOTI5ODFaIn0%3D&digest=sha256%3A44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+    uri: https://automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io/v2/automated-cli-tests-artifact/blobs/uploads/d5f51eee-9058-42b1-beb7-a6e0da4e8dea?_nouploadcache=false&_state=DxIhePmvKmkUSDcKXpb_t1u9k5JKfzWJXY2ADBXBzc97Ik5hbWUiOiJhdXRvbWF0ZWQtY2xpLXRlc3RzLWFydGlmYWN0IiwiVVVJRCI6ImQ1ZjUxZWVlLTkwNTgtNDJiMS1iZWI3LWE2ZTBkYTRlOGRlYSIsIk9mZnNldCI6MCwiU3RhcnRlZEF0IjoiMjAyNC0wNS0xNVQxNjowODoxMS4wNzQ2NTE2NjdaIn0%3D&digest=sha256%3Ae3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   response:
     body:
       string: ''
@@ -1619,13 +1684,13 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 16 Apr 2024 13:13:57 GMT
+      - Wed, 15 May 2024 16:08:11 GMT
       docker-content-digest:
-      - sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+      - sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       docker-distribution-api-version:
       - registry/2.0
       location:
-      - /v2/automated-cli-tests-artifact/blobs/sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+      - /v2/automated-cli-tests-artifact/blobs/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       server:
       - AzureContainerRegistry
       strict-transport-security:
@@ -1638,8 +1703,8 @@ interactions:
       message: Created
 - request:
     body: '{"schemaVersion": 2, "mediaType": "application/vnd.oci.image.manifest.v1+json",
-      "config": {"mediaType": "application/vnd.unknown.config.v1+json", "size": 2,
-      "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"},
+      "config": {"mediaType": "application/vnd.unknown.config.v1+json", "size": 0,
+      "digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
       "layers": [{"mediaType": "application/vnd.oci.image.layer.v1.tar", "size": 3591,
       "digest": "sha256:e71bf56543dc33dc8e550a0c574efe9a4875754a4ddf74347e448dec2462798b",
       "annotations": {"org.opencontainers.image.title": "ubuntu_template.json"}}],
@@ -1656,9 +1721,9 @@ interactions:
       Content-Type:
       - application/vnd.oci.image.manifest.v1+json
       User-Agent:
-      - python-requests/2.31.0
+      - python-requests/2.26.0
     method: PUT
-    uri: https://automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io/v2/automated-cli-tests-artifact/manifests/1.0.0
+    uri: https://automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io/v2/automated-cli-tests-artifact/manifests/1.0.0
   response:
     body:
       string: '{"errors": [{"code": "UNAUTHORIZED", "message": "authentication required,
@@ -1678,7 +1743,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:13:58 GMT
+      - Wed, 15 May 2024 16:08:11 GMT
       docker-distribution-api-version:
       - registry/2.0
       server:
@@ -1687,7 +1752,7 @@ interactions:
       - max-age=31536000; includeSubDomains
       - max-age=31536000; includeSubDomains
       www-authenticate:
-      - Bearer realm="https://automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io/oauth2/token",service="automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io",scope="repository:automated-cli-tests-artifact:pull,push"
+      - Bearer realm="https://automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io/oauth2/token",service="automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io",scope="repository:automated-cli-tests-artifact:pull,push"
       x-content-type-options:
       - nosniff
     status:
@@ -1703,11 +1768,11 @@ interactions:
       Connection:
       - keep-alive
       Service:
-      - automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io
+      - automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io
       User-Agent:
       - oras-py
     method: GET
-    uri: https://automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io/oauth2/token?service=automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io&scope=repository%3Aautomated-cli-tests-artifact%3Apull%2Cpush
+    uri: https://automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io/oauth2/token?service=automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io&scope=repository%3Aautomated-cli-tests-artifact%3Apull%2Cpush
   response:
     body:
       string: '{"access_token": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}'
@@ -1717,7 +1782,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:13:58 GMT
+      - Wed, 15 May 2024 16:08:11 GMT
       server:
       - AzureContainerRegistry
       strict-transport-security:
@@ -1731,8 +1796,8 @@ interactions:
       message: OK
 - request:
     body: '{"schemaVersion": 2, "mediaType": "application/vnd.oci.image.manifest.v1+json",
-      "config": {"mediaType": "application/vnd.unknown.config.v1+json", "size": 2,
-      "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"},
+      "config": {"mediaType": "application/vnd.unknown.config.v1+json", "size": 0,
+      "digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
       "layers": [{"mediaType": "application/vnd.oci.image.layer.v1.tar", "size": 3591,
       "digest": "sha256:e71bf56543dc33dc8e550a0c574efe9a4875754a4ddf74347e448dec2462798b",
       "annotations": {"org.opencontainers.image.title": "ubuntu_template.json"}}],
@@ -1749,9 +1814,9 @@ interactions:
       Content-Type:
       - application/vnd.oci.image.manifest.v1+json
       User-Agent:
-      - python-requests/2.31.0
+      - python-requests/2.26.0
     method: PUT
-    uri: https://automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io/v2/automated-cli-tests-artifact/manifests/1.0.0
+    uri: https://automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io/v2/automated-cli-tests-artifact/manifests/1.0.0
   response:
     body:
       string: ''
@@ -1766,13 +1831,13 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 16 Apr 2024 13:13:58 GMT
+      - Wed, 15 May 2024 16:08:11 GMT
       docker-content-digest:
-      - sha256:17d25d33c38f40fda4c9e45a0cec218b3f7f75e9c680ed8dd2a12ed0abdbc36b
+      - sha256:8923fa544da97914212bc9173ec512741d331940e4a2c7b6fbad979657a5c507
       docker-distribution-api-version:
       - registry/2.0
       location:
-      - /v2/automated-cli-tests-artifact/manifests/sha256:17d25d33c38f40fda4c9e45a0cec218b3f7f75e9c680ed8dd2a12ed0abdbc36b
+      - /v2/automated-cli-tests-artifact/manifests/sha256:8923fa544da97914212bc9173ec512741d331940e4a2c7b6fbad979657a5c507
       server:
       - AzureContainerRegistry
       strict-transport-security:
@@ -1799,16 +1864,15 @@ interactions:
       ParameterSetName:
       - --build-output-folder --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-hybridnetwork/unknown Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/artifactStores/ubuntu-blob-store/artifactManifests/ubuntu-vm-sa-manifest-1-0-0/listCredential?api-version=2023-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher/artifactStores/ubuntu-blob-store/artifactManifests/ubuntu-vm-sa-manifest-1-0-0/listCredential?api-version=2023-09-01
   response:
     body:
-      string: '{"storageAccountId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/ubuntu-blob-store-HostedResources-0441DCA7/providers/Microsoft.Storage/storageAccounts/0441dca7ubuntublobstore5",
+      string: '{"storageAccountId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/ubuntu-blob-store-HostedResources-5FDE8F99/providers/Microsoft.Storage/storageAccounts/5fde8f99ubuntublobstorea",
         "containerCredentials": [{"containerName": "automatedclitestsvhd-1-0-0", "containerSasUri":
         "https://xxxxxxxxxxxxxxx.blob.core.windows.net/automatedclitestsvhd-1-0-0?sv=2021-08-06&si=StorageAccountAccessPolicy&sr=xxxxxxxxxxxxxxxxxxxx"}],
-        "expiry": "2024-04-17T13:14:00.1536208+00:00", "credentialType": "AzureStorageAccountToken"}'
+        "expiry": "2024-05-16T16:08:17.0687433+00:00", "credentialType": "AzureStorageAccountToken"}'
     headers:
       cache-control:
       - no-cache
@@ -1817,21 +1881,25 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:14:00 GMT
+      - Wed, 15 May 2024 16:08:16 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
       x-ms-build-version:
-      - 1.0.02651.2759
+      - 1.0.02682.2890
       x-ms-providerhub-traffic:
       - 'True'
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
+      x-msedge-ref:
+      - 'Ref A: E277FFDF65CD406EBC678A1D949691FE Ref B: AMS231022012049 Ref C: 2024-05-15T16:08:11Z'
     status:
       code: 200
       message: OK
@@ -1853,7 +1921,7 @@ interactions:
       x-ms-blob-type:
       - PageBlob
       x-ms-date:
-      - Tue, 16 Apr 2024 13:14:02 GMT
+      - Wed, 15 May 2024 16:08:16 GMT
       x-ms-version:
       - '2022-11-02'
     method: PUT
@@ -1865,11 +1933,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 16 Apr 2024 13:14:00 GMT
+      - Wed, 15 May 2024 16:08:16 GMT
       etag:
-      - '"0x8DC5E1714AAF5C2"'
+      - '"0x8DC74F93B69D766"'
       last-modified:
-      - Tue, 16 Apr 2024 13:14:00 GMT
+      - Wed, 15 May 2024 16:08:17 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
@@ -1899,11 +1967,11 @@ interactions:
       Content-Type:
       - application/octet-stream
       If-Match:
-      - '"0x8DC5E1714AAF5C2"'
+      - '"0x8DC74F93B69D766"'
       User-Agent:
       - azsdk-python-storage-blob/12.16.0 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
       x-ms-date:
-      - Tue, 16 Apr 2024 13:14:02 GMT
+      - Wed, 15 May 2024 16:08:16 GMT
       x-ms-page-write:
       - update
       x-ms-range:
@@ -1919,11 +1987,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 16 Apr 2024 13:14:00 GMT
+      - Wed, 15 May 2024 16:08:16 GMT
       etag:
-      - '"0x8DC5E1714EEB767"'
+      - '"0x8DC74F93B76259C"'
       last-modified:
-      - Tue, 16 Apr 2024 13:14:00 GMT
+      - Wed, 15 May 2024 16:08:17 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-sequence-number:
@@ -1940,7 +2008,7 @@ interactions:
 - request:
     body: '{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
       "contentVersion": "1.0.0.0", "metadata": {"_generator": {"name": "bicep", "version":
-      "0.26.54.24096", "templateHash": "12072405825285278441"}}, "parameters": {"location":
+      "0.8.9.13224", "templateHash": "7199002541811128072"}}, "parameters": {"location":
       {"type": "string"}, "publisherName": {"type": "string", "metadata": {"description":
       "Name of an existing publisher, expected to be in the resource group where you
       deploy the template"}}, "acrArtifactStoreName": {"type": "string", "metadata":
@@ -1959,7 +2027,7 @@ interactions:
       "subnetName": "{deployParameters.automated-cli-tests-artifact.subnetName}",
       "virtualNetworkId": "{deployParameters.automated-cli-tests-artifact.virtualNetworkId}",
       "sshPublicKeyAdmin": "{deployParameters.automated-cli-tests-artifact.sshPublicKeyAdmin}"}},
-      "resources": [{"type": "Microsoft.HybridNetwork/publishers/networkFunctionDefinitionGroups/networkFunctionDefinitionVersions",
+      "resources": [{"type": "Microsoft.Hybridnetwork/publishers/networkfunctiondefinitiongroups/networkfunctiondefinitionversions",
       "apiVersion": "2023-09-01", "name": "[format(''{0}/{1}/{2}'', parameters(''publisherName''),
       parameters(''nfDefinitionGroup''), parameters(''nfDefinitionVersion''))]", "location":
       "[parameters(''location'')]", "properties": {"deployParameters": "[string(variables(''$fxv#0''))]",
@@ -1977,7 +2045,7 @@ interactions:
       parameters(''publisherName''), parameters(''acrArtifactStoreName''))]"}}, "deployParametersMappingRuleProfile":
       {"templateMappingRuleProfile": {"templateParameters": "[string(variables(''$fxv#2''))]"},
       "applicationEnablement": "Enabled"}}]}}}]}, "parameters": {"location": {"value":
-      "uksouth"}, "publisherName": {"value": "automated-cli-tests-ubuntu-publisher"},
+      "uksouth"}, "publisherName": {"value": "automated-cli-test-ubuntu-publisher"},
       "acrArtifactStoreName": {"value": "ubuntu-acr"}, "nfDefinitionGroup": {"value":
       "ubuntu-vm"}, "nfDefinitionVersion": {"value": "1.0.0"}, "saArtifactStoreName":
       {"value": "ubuntu-blob-store"}}, "mode": "Incremental"}}'
@@ -1991,58 +2059,61 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '3771'
+      - '3767'
       Content-Type:
       - application/json
       ParameterSetName:
       - --build-output-folder --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/validate?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1713273247",
-        "name": "AOSM_CLI_deployment_1713273247", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "12072405825285278441", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1715789300",
+        "name": "AOSM_CLI_deployment_1715789300", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "7199002541811128072", "parameters": {"location":
         {"type": "String", "value": "uksouth"}, "publisherName": {"type": "String",
-        "value": "automated-cli-tests-ubuntu-publisher"}, "acrArtifactStoreName":
-        {"type": "String", "value": "ubuntu-acr"}, "saArtifactStoreName": {"type":
-        "String", "value": "ubuntu-blob-store"}, "nfDefinitionGroup": {"type": "String",
-        "value": "ubuntu-vm"}, "nfDefinitionVersion": {"type": "String", "value":
-        "1.0.0"}}, "mode": "Incremental", "provisioningState": "Succeeded", "timestamp":
-        "0001-01-01T00:00:00Z", "duration": "PT0S", "correlationId": "dd629976-3e9a-495b-86da-73a6b63e9baa",
-        "providers": [{"namespace": "Microsoft.HybridNetwork", "resourceTypes": [{"resourceType":
-        "publishers/networkFunctionDefinitionGroups/networkFunctionDefinitionVersions",
+        "value": "automated-cli-test-ubuntu-publisher"}, "acrArtifactStoreName": {"type":
+        "String", "value": "ubuntu-acr"}, "saArtifactStoreName": {"type": "String",
+        "value": "ubuntu-blob-store"}, "nfDefinitionGroup": {"type": "String", "value":
+        "ubuntu-vm"}, "nfDefinitionVersion": {"type": "String", "value": "1.0.0"}},
+        "mode": "Incremental", "provisioningState": "Succeeded", "timestamp": "0001-01-01T00:00:00Z",
+        "duration": "PT0S", "correlationId": "e9d2b09f-f275-4a96-8a34-f05c7cf8fba4",
+        "providers": [{"namespace": "Microsoft.Hybridnetwork", "resourceTypes": [{"resourceType":
+        "publishers/networkfunctiondefinitiongroups/networkfunctiondefinitionversions",
         "locations": ["uksouth"]}]}], "dependencies": [], "validatedResources": [{"id":
-        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/networkFunctionDefinitionGroups/ubuntu-vm/networkFunctionDefinitionVersions/1.0.0"}]}}'
+        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/automated-cli-test-ubuntu-publisher/networkfunctiondefinitiongroups/ubuntu-vm/networkfunctiondefinitionversions/1.0.0"}]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1413'
+      - '1410'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:14:05 GMT
+      - Wed, 15 May 2024 16:08:21 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1199'
+      x-msedge-ref:
+      - 'Ref A: AC20EBB42CB04A72BD2E5A66D59ABE7D Ref B: AMS231022012051 Ref C: 2024-05-15T16:08:20Z'
     status:
       code: 200
       message: OK
 - request:
     body: '{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
       "contentVersion": "1.0.0.0", "metadata": {"_generator": {"name": "bicep", "version":
-      "0.26.54.24096", "templateHash": "12072405825285278441"}}, "parameters": {"location":
+      "0.8.9.13224", "templateHash": "7199002541811128072"}}, "parameters": {"location":
       {"type": "string"}, "publisherName": {"type": "string", "metadata": {"description":
       "Name of an existing publisher, expected to be in the resource group where you
       deploy the template"}}, "acrArtifactStoreName": {"type": "string", "metadata":
@@ -2061,7 +2132,7 @@ interactions:
       "subnetName": "{deployParameters.automated-cli-tests-artifact.subnetName}",
       "virtualNetworkId": "{deployParameters.automated-cli-tests-artifact.virtualNetworkId}",
       "sshPublicKeyAdmin": "{deployParameters.automated-cli-tests-artifact.sshPublicKeyAdmin}"}},
-      "resources": [{"type": "Microsoft.HybridNetwork/publishers/networkFunctionDefinitionGroups/networkFunctionDefinitionVersions",
+      "resources": [{"type": "Microsoft.Hybridnetwork/publishers/networkfunctiondefinitiongroups/networkfunctiondefinitionversions",
       "apiVersion": "2023-09-01", "name": "[format(''{0}/{1}/{2}'', parameters(''publisherName''),
       parameters(''nfDefinitionGroup''), parameters(''nfDefinitionVersion''))]", "location":
       "[parameters(''location'')]", "properties": {"deployParameters": "[string(variables(''$fxv#0''))]",
@@ -2079,7 +2150,7 @@ interactions:
       parameters(''publisherName''), parameters(''acrArtifactStoreName''))]"}}, "deployParametersMappingRuleProfile":
       {"templateMappingRuleProfile": {"templateParameters": "[string(variables(''$fxv#2''))]"},
       "applicationEnablement": "Enabled"}}]}}}]}, "parameters": {"location": {"value":
-      "uksouth"}, "publisherName": {"value": "automated-cli-tests-ubuntu-publisher"},
+      "uksouth"}, "publisherName": {"value": "automated-cli-test-ubuntu-publisher"},
       "acrArtifactStoreName": {"value": "ubuntu-acr"}, "nfDefinitionGroup": {"value":
       "ubuntu-vm"}, "nfDefinitionVersion": {"value": "1.0.0"}, "saArtifactStoreName":
       {"value": "ubuntu-blob-store"}}, "mode": "Incremental"}}'
@@ -2093,52 +2164,55 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '3771'
+      - '3767'
       Content-Type:
       - application/json
       ParameterSetName:
       - --build-output-folder --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1713273247",
-        "name": "AOSM_CLI_deployment_1713273247", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "12072405825285278441", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1715789300",
+        "name": "AOSM_CLI_deployment_1715789300", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "7199002541811128072", "parameters": {"location":
         {"type": "String", "value": "uksouth"}, "publisherName": {"type": "String",
-        "value": "automated-cli-tests-ubuntu-publisher"}, "acrArtifactStoreName":
-        {"type": "String", "value": "ubuntu-acr"}, "saArtifactStoreName": {"type":
-        "String", "value": "ubuntu-blob-store"}, "nfDefinitionGroup": {"type": "String",
-        "value": "ubuntu-vm"}, "nfDefinitionVersion": {"type": "String", "value":
-        "1.0.0"}}, "mode": "Incremental", "provisioningState": "Accepted", "timestamp":
-        "2024-04-16T13:14:06.5182362Z", "duration": "PT0.0000744S", "correlationId":
-        "aa229535-f8a6-40e5-b706-c5d368c0cb27", "providers": [{"namespace": "Microsoft.HybridNetwork",
-        "resourceTypes": [{"resourceType": "publishers/networkFunctionDefinitionGroups/networkFunctionDefinitionVersions",
+        "value": "automated-cli-test-ubuntu-publisher"}, "acrArtifactStoreName": {"type":
+        "String", "value": "ubuntu-acr"}, "saArtifactStoreName": {"type": "String",
+        "value": "ubuntu-blob-store"}, "nfDefinitionGroup": {"type": "String", "value":
+        "ubuntu-vm"}, "nfDefinitionVersion": {"type": "String", "value": "1.0.0"}},
+        "mode": "Incremental", "provisioningState": "Accepted", "timestamp": "2024-05-15T16:08:22.2741828Z",
+        "duration": "PT0.0006601S", "correlationId": "ce4ef616-5273-41cc-a30b-8aed634094ac",
+        "providers": [{"namespace": "Microsoft.Hybridnetwork", "resourceTypes": [{"resourceType":
+        "publishers/networkfunctiondefinitiongroups/networkfunctiondefinitionversions",
         "locations": ["uksouth"]}]}], "dependencies": []}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1713273247/operationStatuses/08584883336391176441?api-version=2022-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1715789300/operationStatuses/08584858175836048079?api-version=2022-09-01
       cache-control:
       - no-cache
       content-length:
-      - '1138'
+      - '1136'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:14:06 GMT
+      - Wed, 15 May 2024 16:08:22 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1198'
+      x-msedge-ref:
+      - 'Ref A: 7E2170B98A7F402CAFA4568BC36C430E Ref B: AMS231022012051 Ref C: 2024-05-15T16:08:21Z'
     status:
       code: 201
       message: Created
@@ -2156,10 +2230,9 @@ interactions:
       ParameterSetName:
       - --build-output-folder --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883336391176441?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858175836048079?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Accepted"}'
@@ -2171,15 +2244,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:14:06 GMT
+      - Wed, 15 May 2024 16:08:22 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: D34F45CE8F594E9CB07780C9E429C2D9 Ref B: AMS231022012051 Ref C: 2024-05-15T16:08:22Z'
     status:
       code: 200
       message: OK
@@ -2197,10 +2274,9 @@ interactions:
       ParameterSetName:
       - --build-output-folder --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883336391176441?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858175836048079?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Running"}'
@@ -2212,15 +2288,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:14:36 GMT
+      - Wed, 15 May 2024 16:08:52 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: EC3C8438DD5242E0A7527E6B3E1BC0DA Ref B: AMS231022012051 Ref C: 2024-05-15T16:08:52Z'
     status:
       code: 200
       message: OK
@@ -2238,10 +2318,9 @@ interactions:
       ParameterSetName:
       - --build-output-folder --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883336391176441?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858175836048079?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Running"}'
@@ -2253,15 +2332,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:15:06 GMT
+      - Wed, 15 May 2024 16:09:22 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: 7B05F8D6FEFD44589020D91338DFCC28 Ref B: AMS231022012051 Ref C: 2024-05-15T16:09:22Z'
     status:
       code: 200
       message: OK
@@ -2279,10 +2362,9 @@ interactions:
       ParameterSetName:
       - --build-output-folder --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883336391176441?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858175836048079?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Succeeded"}'
@@ -2294,15 +2376,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:15:36 GMT
+      - Wed, 15 May 2024 16:09:53 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: AC78BDB5088E4F0CB4B99D1675D4A18D Ref B: AMS231022012051 Ref C: 2024-05-15T16:09:54Z'
     status:
       code: 200
       message: OK
@@ -2320,43 +2406,46 @@ interactions:
       ParameterSetName:
       - --build-output-folder --definition-type
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1713273247",
-        "name": "AOSM_CLI_deployment_1713273247", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "12072405825285278441", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1715789300",
+        "name": "AOSM_CLI_deployment_1715789300", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "7199002541811128072", "parameters": {"location":
         {"type": "String", "value": "uksouth"}, "publisherName": {"type": "String",
-        "value": "automated-cli-tests-ubuntu-publisher"}, "acrArtifactStoreName":
-        {"type": "String", "value": "ubuntu-acr"}, "saArtifactStoreName": {"type":
-        "String", "value": "ubuntu-blob-store"}, "nfDefinitionGroup": {"type": "String",
-        "value": "ubuntu-vm"}, "nfDefinitionVersion": {"type": "String", "value":
-        "1.0.0"}}, "mode": "Incremental", "provisioningState": "Succeeded", "timestamp":
-        "2024-04-16T13:15:26.4916326Z", "duration": "PT1M19.9734708S", "correlationId":
-        "aa229535-f8a6-40e5-b706-c5d368c0cb27", "providers": [{"namespace": "Microsoft.HybridNetwork",
-        "resourceTypes": [{"resourceType": "publishers/networkFunctionDefinitionGroups/networkFunctionDefinitionVersions",
+        "value": "automated-cli-test-ubuntu-publisher"}, "acrArtifactStoreName": {"type":
+        "String", "value": "ubuntu-acr"}, "saArtifactStoreName": {"type": "String",
+        "value": "ubuntu-blob-store"}, "nfDefinitionGroup": {"type": "String", "value":
+        "ubuntu-vm"}, "nfDefinitionVersion": {"type": "String", "value": "1.0.0"}},
+        "mode": "Incremental", "provisioningState": "Succeeded", "timestamp": "2024-05-15T16:09:45.7530552Z",
+        "duration": "PT1M23.4795325S", "correlationId": "ce4ef616-5273-41cc-a30b-8aed634094ac",
+        "providers": [{"namespace": "Microsoft.Hybridnetwork", "resourceTypes": [{"resourceType":
+        "publishers/networkfunctiondefinitiongroups/networkfunctiondefinitionversions",
         "locations": ["uksouth"]}]}], "dependencies": [], "outputResources": [{"id":
-        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/networkFunctionDefinitionGroups/ubuntu-vm/networkFunctionDefinitionVersions/1.0.0"}]}}'
+        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/automated-cli-test-ubuntu-publisher/networkfunctiondefinitiongroups/ubuntu-vm/networkfunctiondefinitionversions/1.0.0"}]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1429'
+      - '1426'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:15:36 GMT
+      - Wed, 15 May 2024 16:09:53 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: DCF4C1115F7D40ACBB0C25C011D7C44E Ref B: AMS231022012051 Ref C: 2024-05-15T16:09:54Z'
     status:
       code: 200
       message: OK
@@ -2374,27 +2463,25 @@ interactions:
       ParameterSetName:
       - -f
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-hybridnetwork/unknown Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/networkFunctionDefinitionGroups/ubuntu-vm/networkFunctionDefinitionVersions/1.0.0?api-version=2023-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher/networkFunctionDefinitionGroups/ubuntu-vm/networkFunctionDefinitionVersions/1.0.0?api-version=2023-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/networkFunctionDefinitionGroups/ubuntu-vm/networkFunctionDefinitionVersions/1.0.0",
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/automated-cli-test-ubuntu-publisher/networkfunctiondefinitiongroups/ubuntu-vm/networkfunctiondefinitionversions/1.0.0",
         "name": "1.0.0", "type": "microsoft.hybridnetwork/publishers/networkfunctiondefinitiongroups/networkfunctiondefinitionversions",
         "location": "uksouth", "systemData": {"createdBy": "xxxxxxxxxxx@microsoft.com",
-        "createdByType": "User", "createdAt": "2024-04-16T13:14:06.9513421Z", "lastModifiedBy":
+        "createdByType": "User", "createdAt": "2024-05-15T16:08:23.37636Z", "lastModifiedBy":
         "xxxxxxxxxxx@microsoft.com", "lastModifiedByType": "User", "lastModifiedAt":
-        "2024-04-16T13:14:06.9513421Z"}, "properties": {"networkFunctionTemplate":
-        {"networkFunctionApplications": [{"artifactProfile": {"vhdArtifactProfile":
-        {"vhdName": "automated-cli-tests-vhd", "vhdVersion": "1-0-0"}, "artifactStore":
-        {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/artifactStores/ubuntu-blob-store"}},
+        "2024-05-15T16:08:23.37636Z"}, "properties": {"networkFunctionTemplate": {"networkFunctionApplications":
+        [{"artifactProfile": {"vhdArtifactProfile": {"vhdName": "automated-cli-tests-vhd",
+        "vhdVersion": "1-0-0"}, "artifactStore": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher/artifactStores/ubuntu-blob-store"}},
         "deployParametersMappingRuleProfile": {"vhdImageMappingRuleProfile": {"userConfiguration":
         "{\"imageHyperVGeneration\":\"V1\",\"imageName\":\"ubuntu-vmImage\"}"}, "applicationEnablement":
         "Enabled"}, "artifactType": "VhdImageFile", "dependsOnProfile": null, "name":
         "automated-cli-tests-vhd"}, {"artifactProfile": {"templateArtifactProfile":
         {"templateName": "automated-cli-tests-artifact", "templateVersion": "1.0.0"},
-        "artifactStore": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/artifactStores/ubuntu-acr"}},
+        "artifactStore": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher/artifactStores/ubuntu-acr"}},
         "deployParametersMappingRuleProfile": {"templateMappingRuleProfile": {"templateParameters":
         "{\"imageName\":\"ubuntu-vmImage\",\"subnetName\":\"{deployParameters.automated-cli-tests-artifact.subnetName}\",\"virtualNetworkId\":\"{deployParameters.automated-cli-tests-artifact.virtualNetworkId}\",\"sshPublicKeyAdmin\":\"{deployParameters.automated-cli-tests-artifact.sshPublicKeyAdmin}\"}"},
         "applicationEnablement": "Enabled"}, "artifactType": "ArmTemplate", "dependsOnProfile":
@@ -2405,23 +2492,27 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '2893'
+      - '2886'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:15:37 GMT
+      - Wed, 15 May 2024 16:09:54 GMT
       etag:
-      - '"1f001e4f-0000-1100-0000-661e79b20000"'
+      - '"ff01f00c-0000-1100-0000-6644de0d0000"'
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
       x-ms-providerhub-traffic:
       - 'True'
+      x-msedge-ref:
+      - 'Ref A: AD3617036B8F4C9292523DF33AC2B2E2 Ref B: AMS231020615025 Ref C: 2024-05-15T16:09:54Z'
     status:
       code: 200
       message: OK
@@ -2439,8 +2530,7 @@ interactions:
       ParameterSetName:
       - --build-output-folder
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: HEAD
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001?api-version=2022-09-01
   response:
@@ -2452,22 +2542,26 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 16 Apr 2024 13:15:37 GMT
+      - Wed, 15 May 2024 16:12:06 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: DDF19D670093499E91DB10D9AF9B6045 Ref B: AMS231032609045 Ref C: 2024-05-15T16:12:06Z'
     status:
       code: 204
       message: No Content
 - request:
     body: '{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
       "contentVersion": "1.0.0.0", "metadata": {"_generator": {"name": "bicep", "version":
-      "0.26.54.24096", "templateHash": "14743947880900953734"}}, "parameters": {"location":
+      "0.8.9.13224", "templateHash": "1380436735645816911"}}, "parameters": {"location":
       {"type": "string"}, "publisherName": {"type": "string", "metadata": {"description":
       "Name of a publisher, expected to be in the resource group where you deploy
       the template"}}, "acrArtifactStoreName": {"type": "string", "metadata": {"description":
@@ -2479,12 +2573,12 @@ interactions:
       "apiVersion": "2023-09-01", "name": "[format(''{0}/{1}'', parameters(''publisherName''),
       parameters(''acrArtifactStoreName''))]", "location": "[parameters(''location'')]",
       "properties": {"storeType": "AzureContainerRegistry"}, "dependsOn": ["[resourceId(''Microsoft.HybridNetwork/publishers'',
-      parameters(''publisherName''))]"]}, {"type": "Microsoft.HybridNetwork/publishers/networkServiceDesignGroups",
+      parameters(''publisherName''))]"]}, {"type": "Microsoft.Hybridnetwork/publishers/networkservicedesigngroups",
       "apiVersion": "2023-09-01", "name": "[format(''{0}/{1}'', parameters(''publisherName''),
       parameters(''nsDesignGroup''))]", "location": "[parameters(''location'')]",
       "dependsOn": ["[resourceId(''Microsoft.HybridNetwork/publishers'', parameters(''publisherName''))]"]}]},
       "parameters": {"location": {"value": "uksouth"}, "publisherName": {"value":
-      "automated-cli-tests-ubuntu-publisher"}, "acrArtifactStoreName": {"value": "ubuntu-acr"},
+      "automated-cli-test-ubuntu-publisher"}, "acrArtifactStoreName": {"value": "ubuntu-acr"},
       "nsDesignGroup": {"value": "ubuntu"}}, "mode": "Incremental"}}'
     headers:
       Accept:
@@ -2496,69 +2590,70 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1872'
+      - '1868'
       Content-Type:
       - application/json
       ParameterSetName:
       - --build-output-folder
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/validate?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1713273343",
-        "name": "AOSM_CLI_deployment_1713273343", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "14743947880900953734", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1715789530",
+        "name": "AOSM_CLI_deployment_1715789530", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "1380436735645816911", "parameters": {"location":
         {"type": "String", "value": "uksouth"}, "publisherName": {"type": "String",
-        "value": "automated-cli-tests-ubuntu-publisher"}, "acrArtifactStoreName":
-        {"type": "String", "value": "ubuntu-acr"}, "nsDesignGroup": {"type": "String",
-        "value": "ubuntu"}}, "mode": "Incremental", "provisioningState": "Succeeded",
-        "timestamp": "0001-01-01T00:00:00Z", "duration": "PT0S", "correlationId":
-        "6cd4b820-c985-4d40-9084-b1b2539dd937", "providers": [{"namespace": "Microsoft.HybridNetwork",
-        "resourceTypes": [{"resourceType": "publishers", "locations": ["uksouth"]},
-        {"resourceType": "publishers/artifactStores", "locations": ["uksouth"]}, {"resourceType":
-        "publishers/networkServiceDesignGroups", "locations": ["uksouth"]}]}], "dependencies":
-        [{"dependsOn": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher",
-        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-tests-ubuntu-publisher"}],
-        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/artifactStores/ubuntu-acr",
+        "value": "automated-cli-test-ubuntu-publisher"}, "acrArtifactStoreName": {"type":
+        "String", "value": "ubuntu-acr"}, "nsDesignGroup": {"type": "String", "value":
+        "ubuntu"}}, "mode": "Incremental", "provisioningState": "Succeeded", "timestamp":
+        "0001-01-01T00:00:00Z", "duration": "PT0S", "correlationId": "d1a37ad7-1bbd-4daa-9318-f0efc8642b1e",
+        "providers": [{"namespace": "Microsoft.HybridNetwork", "resourceTypes": [{"resourceType":
+        "publishers", "locations": ["uksouth"]}, {"resourceType": "publishers/artifactStores",
+        "locations": ["uksouth"]}, {"resourceType": "publishers/networkservicedesigngroups",
+        "locations": ["uksouth"]}]}], "dependencies": [{"dependsOn": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher",
+        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-test-ubuntu-publisher"}],
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher/artifactStores/ubuntu-acr",
         "resourceType": "Microsoft.HybridNetwork/publishers/artifactStores", "resourceName":
-        "automated-cli-tests-ubuntu-publisher/ubuntu-acr"}, {"dependsOn": [{"id":
-        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher",
-        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-tests-ubuntu-publisher"}],
-        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/networkServiceDesignGroups/ubuntu",
-        "resourceType": "Microsoft.HybridNetwork/publishers/networkServiceDesignGroups",
-        "resourceName": "automated-cli-tests-ubuntu-publisher/ubuntu"}], "validatedResources":
-        [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher"},
-        {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/artifactStores/ubuntu-acr"},
-        {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/networkServiceDesignGroups/ubuntu"}]}}'
+        "automated-cli-test-ubuntu-publisher/ubuntu-acr"}, {"dependsOn": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher",
+        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-test-ubuntu-publisher"}],
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/automated-cli-test-ubuntu-publisher/networkservicedesigngroups/ubuntu",
+        "resourceType": "Microsoft.Hybridnetwork/publishers/networkservicedesigngroups",
+        "resourceName": "automated-cli-test-ubuntu-publisher/ubuntu"}], "validatedResources":
+        [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher"},
+        {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher/artifactStores/ubuntu-acr"},
+        {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/automated-cli-test-ubuntu-publisher/networkservicedesigngroups/ubuntu"}]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3034'
+      - '3021'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:15:41 GMT
+      - Wed, 15 May 2024 16:12:11 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
+      x-msedge-ref:
+      - 'Ref A: D89AF93E5A804F8494BF97D77C31F8C4 Ref B: AMS231032609045 Ref C: 2024-05-15T16:12:10Z'
     status:
       code: 200
       message: OK
 - request:
     body: '{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
       "contentVersion": "1.0.0.0", "metadata": {"_generator": {"name": "bicep", "version":
-      "0.26.54.24096", "templateHash": "14743947880900953734"}}, "parameters": {"location":
+      "0.8.9.13224", "templateHash": "1380436735645816911"}}, "parameters": {"location":
       {"type": "string"}, "publisherName": {"type": "string", "metadata": {"description":
       "Name of a publisher, expected to be in the resource group where you deploy
       the template"}}, "acrArtifactStoreName": {"type": "string", "metadata": {"description":
@@ -2570,12 +2665,12 @@ interactions:
       "apiVersion": "2023-09-01", "name": "[format(''{0}/{1}'', parameters(''publisherName''),
       parameters(''acrArtifactStoreName''))]", "location": "[parameters(''location'')]",
       "properties": {"storeType": "AzureContainerRegistry"}, "dependsOn": ["[resourceId(''Microsoft.HybridNetwork/publishers'',
-      parameters(''publisherName''))]"]}, {"type": "Microsoft.HybridNetwork/publishers/networkServiceDesignGroups",
+      parameters(''publisherName''))]"]}, {"type": "Microsoft.Hybridnetwork/publishers/networkservicedesigngroups",
       "apiVersion": "2023-09-01", "name": "[format(''{0}/{1}'', parameters(''publisherName''),
       parameters(''nsDesignGroup''))]", "location": "[parameters(''location'')]",
       "dependsOn": ["[resourceId(''Microsoft.HybridNetwork/publishers'', parameters(''publisherName''))]"]}]},
       "parameters": {"location": {"value": "uksouth"}, "publisherName": {"value":
-      "automated-cli-tests-ubuntu-publisher"}, "acrArtifactStoreName": {"value": "ubuntu-acr"},
+      "automated-cli-test-ubuntu-publisher"}, "acrArtifactStoreName": {"value": "ubuntu-acr"},
       "nsDesignGroup": {"value": "ubuntu"}}, "mode": "Incremental"}}'
     headers:
       Accept:
@@ -2587,61 +2682,63 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1872'
+      - '1868'
       Content-Type:
       - application/json
       ParameterSetName:
       - --build-output-folder
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1713273343",
-        "name": "AOSM_CLI_deployment_1713273343", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "14743947880900953734", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1715789530",
+        "name": "AOSM_CLI_deployment_1715789530", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "1380436735645816911", "parameters": {"location":
         {"type": "String", "value": "uksouth"}, "publisherName": {"type": "String",
-        "value": "automated-cli-tests-ubuntu-publisher"}, "acrArtifactStoreName":
-        {"type": "String", "value": "ubuntu-acr"}, "nsDesignGroup": {"type": "String",
-        "value": "ubuntu"}}, "mode": "Incremental", "provisioningState": "Accepted",
-        "timestamp": "2024-04-16T13:15:42.6486828Z", "duration": "PT0.0003317S", "correlationId":
-        "ff0f5875-e8c2-431a-a2ae-791397b949b5", "providers": [{"namespace": "Microsoft.HybridNetwork",
+        "value": "automated-cli-test-ubuntu-publisher"}, "acrArtifactStoreName": {"type":
+        "String", "value": "ubuntu-acr"}, "nsDesignGroup": {"type": "String", "value":
+        "ubuntu"}}, "mode": "Incremental", "provisioningState": "Accepted", "timestamp":
+        "2024-05-15T16:12:12.2099893Z", "duration": "PT0.0003056S", "correlationId":
+        "41cefaa9-6df9-4e82-8241-af93d7f9e7e5", "providers": [{"namespace": "Microsoft.HybridNetwork",
         "resourceTypes": [{"resourceType": "publishers", "locations": ["uksouth"]},
         {"resourceType": "publishers/artifactStores", "locations": ["uksouth"]}, {"resourceType":
-        "publishers/networkServiceDesignGroups", "locations": ["uksouth"]}]}], "dependencies":
-        [{"dependsOn": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher",
-        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-tests-ubuntu-publisher"}],
-        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/artifactStores/ubuntu-acr",
+        "publishers/networkservicedesigngroups", "locations": ["uksouth"]}]}], "dependencies":
+        [{"dependsOn": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher",
+        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-test-ubuntu-publisher"}],
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher/artifactStores/ubuntu-acr",
         "resourceType": "Microsoft.HybridNetwork/publishers/artifactStores", "resourceName":
-        "automated-cli-tests-ubuntu-publisher/ubuntu-acr"}, {"dependsOn": [{"id":
-        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher",
-        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-tests-ubuntu-publisher"}],
-        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/networkServiceDesignGroups/ubuntu",
-        "resourceType": "Microsoft.HybridNetwork/publishers/networkServiceDesignGroups",
-        "resourceName": "automated-cli-tests-ubuntu-publisher/ubuntu"}]}}'
+        "automated-cli-test-ubuntu-publisher/ubuntu-acr"}, {"dependsOn": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher",
+        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-test-ubuntu-publisher"}],
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/automated-cli-test-ubuntu-publisher/networkservicedesigngroups/ubuntu",
+        "resourceType": "Microsoft.Hybridnetwork/publishers/networkservicedesigngroups",
+        "resourceName": "automated-cli-test-ubuntu-publisher/ubuntu"}]}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1713273343/operationStatuses/08584883335430249127?api-version=2022-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1715789530/operationStatuses/08584858173536291857?api-version=2022-09-01
       cache-control:
       - no-cache
       content-length:
-      - '2413'
+      - '2403'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:15:42 GMT
+      - Wed, 15 May 2024 16:12:11 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
+      x-msedge-ref:
+      - 'Ref A: D8E7915439B34673810A6F9D192EDF4B Ref B: AMS231032609045 Ref C: 2024-05-15T16:12:11Z'
     status:
       code: 201
       message: Created
@@ -2659,10 +2756,9 @@ interactions:
       ParameterSetName:
       - --build-output-folder
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883335430249127?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858173536291857?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Accepted"}'
@@ -2674,15 +2770,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:15:42 GMT
+      - Wed, 15 May 2024 16:12:11 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: DC2E46750A374366A8ADB0A7A7061BB7 Ref B: AMS231032609045 Ref C: 2024-05-15T16:12:12Z'
     status:
       code: 200
       message: OK
@@ -2700,10 +2800,9 @@ interactions:
       ParameterSetName:
       - --build-output-folder
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883335430249127?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858173536291857?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Running"}'
@@ -2715,15 +2814,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:16:12 GMT
+      - Wed, 15 May 2024 16:12:41 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: 18667A9EACA449A3BE94A1875F0D815D Ref B: AMS231032609045 Ref C: 2024-05-15T16:12:42Z'
     status:
       code: 200
       message: OK
@@ -2741,10 +2844,9 @@ interactions:
       ParameterSetName:
       - --build-output-folder
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883335430249127?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858173536291857?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Running"}'
@@ -2756,15 +2858,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:16:42 GMT
+      - Wed, 15 May 2024 16:13:11 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: 68C167E96FD040DCA1B292CEA4400749 Ref B: AMS231032609045 Ref C: 2024-05-15T16:13:12Z'
     status:
       code: 200
       message: OK
@@ -2782,10 +2888,9 @@ interactions:
       ParameterSetName:
       - --build-output-folder
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883335430249127?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858173536291857?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Running"}'
@@ -2797,15 +2902,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:17:12 GMT
+      - Wed, 15 May 2024 16:13:42 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: 9331A1C1A78743298A7E13493F7CABFE Ref B: AMS231032609045 Ref C: 2024-05-15T16:13:42Z'
     status:
       code: 200
       message: OK
@@ -2823,10 +2932,9 @@ interactions:
       ParameterSetName:
       - --build-output-folder
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883335430249127?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858173536291857?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Running"}'
@@ -2838,15 +2946,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:17:40 GMT
+      - Wed, 15 May 2024 16:14:13 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: 057408F803B148C8AB4C5E5422FA4521 Ref B: AMS231032609045 Ref C: 2024-05-15T16:14:13Z'
     status:
       code: 200
       message: OK
@@ -2864,10 +2976,9 @@ interactions:
       ParameterSetName:
       - --build-output-folder
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883335430249127?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858173536291857?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Running"}'
@@ -2879,15 +2990,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:18:09 GMT
+      - Wed, 15 May 2024 16:14:43 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: DCF0E25BB6FC4ED5B6439BF739F1B16F Ref B: AMS231032609045 Ref C: 2024-05-15T16:14:43Z'
     status:
       code: 200
       message: OK
@@ -2905,10 +3020,9 @@ interactions:
       ParameterSetName:
       - --build-output-folder
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883335430249127?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858173536291857?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Running"}'
@@ -2920,15 +3034,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:18:39 GMT
+      - Wed, 15 May 2024 16:15:13 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: 0910937C221847B6B33978C3C8F63CEC Ref B: AMS231032609045 Ref C: 2024-05-15T16:15:13Z'
     status:
       code: 200
       message: OK
@@ -2946,10 +3064,9 @@ interactions:
       ParameterSetName:
       - --build-output-folder
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883335430249127?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858173536291857?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Running"}'
@@ -2961,15 +3078,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:19:10 GMT
+      - Wed, 15 May 2024 16:15:43 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: 29E11207DF57433CB3D3203F92215DA8 Ref B: AMS231032609045 Ref C: 2024-05-15T16:15:43Z'
     status:
       code: 200
       message: OK
@@ -2987,10 +3108,9 @@ interactions:
       ParameterSetName:
       - --build-output-folder
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883335430249127?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858173536291857?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Succeeded"}'
@@ -3002,15 +3122,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:19:38 GMT
+      - Wed, 15 May 2024 16:16:13 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: 2D92CFB9745B44B4A6A69CC5A1D5D0D8 Ref B: AMS231032609045 Ref C: 2024-05-15T16:16:14Z'
     status:
       code: 200
       message: OK
@@ -3028,56 +3152,56 @@ interactions:
       ParameterSetName:
       - --build-output-folder
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1713273343",
-        "name": "AOSM_CLI_deployment_1713273343", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "14743947880900953734", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1715789530",
+        "name": "AOSM_CLI_deployment_1715789530", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "1380436735645816911", "parameters": {"location":
         {"type": "String", "value": "uksouth"}, "publisherName": {"type": "String",
-        "value": "automated-cli-tests-ubuntu-publisher"}, "acrArtifactStoreName":
-        {"type": "String", "value": "ubuntu-acr"}, "nsDesignGroup": {"type": "String",
-        "value": "ubuntu"}}, "mode": "Incremental", "provisioningState": "Succeeded",
-        "timestamp": "2024-04-16T13:19:27.3124125Z", "duration": "PT3M44.6640614S",
-        "correlationId": "ff0f5875-e8c2-431a-a2ae-791397b949b5", "providers": [{"namespace":
-        "Microsoft.HybridNetwork", "resourceTypes": [{"resourceType": "publishers",
-        "locations": ["uksouth"]}, {"resourceType": "publishers/artifactStores", "locations":
-        ["uksouth"]}, {"resourceType": "publishers/networkServiceDesignGroups", "locations":
-        ["uksouth"]}]}], "dependencies": [{"dependsOn": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher",
-        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-tests-ubuntu-publisher"}],
-        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/artifactStores/ubuntu-acr",
+        "value": "automated-cli-test-ubuntu-publisher"}, "acrArtifactStoreName": {"type":
+        "String", "value": "ubuntu-acr"}, "nsDesignGroup": {"type": "String", "value":
+        "ubuntu"}}, "mode": "Incremental", "provisioningState": "Succeeded", "timestamp":
+        "2024-05-15T16:16:00.7528482Z", "duration": "PT3M48.5431645S", "correlationId":
+        "41cefaa9-6df9-4e82-8241-af93d7f9e7e5", "providers": [{"namespace": "Microsoft.HybridNetwork",
+        "resourceTypes": [{"resourceType": "publishers", "locations": ["uksouth"]},
+        {"resourceType": "publishers/artifactStores", "locations": ["uksouth"]}, {"resourceType":
+        "publishers/networkservicedesigngroups", "locations": ["uksouth"]}]}], "dependencies":
+        [{"dependsOn": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher",
+        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-test-ubuntu-publisher"}],
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher/artifactStores/ubuntu-acr",
         "resourceType": "Microsoft.HybridNetwork/publishers/artifactStores", "resourceName":
-        "automated-cli-tests-ubuntu-publisher/ubuntu-acr"}, {"dependsOn": [{"id":
-        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher",
-        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-tests-ubuntu-publisher"}],
-        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/networkServiceDesignGroups/ubuntu",
-        "resourceType": "Microsoft.HybridNetwork/publishers/networkServiceDesignGroups",
-        "resourceName": "automated-cli-tests-ubuntu-publisher/ubuntu"}], "outputResources":
-        [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher"},
-        {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/artifactStores/ubuntu-acr"},
-        {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/networkServiceDesignGroups/ubuntu"}]}}'
+        "automated-cli-test-ubuntu-publisher/ubuntu-acr"}, {"dependsOn": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher",
+        "resourceType": "Microsoft.HybridNetwork/publishers", "resourceName": "automated-cli-test-ubuntu-publisher"}],
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/automated-cli-test-ubuntu-publisher/networkservicedesigngroups/ubuntu",
+        "resourceType": "Microsoft.Hybridnetwork/publishers/networkservicedesigngroups",
+        "resourceName": "automated-cli-test-ubuntu-publisher/ubuntu"}], "outputResources":
+        [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher"},
+        {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher/artifactStores/ubuntu-acr"},
+        {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/automated-cli-test-ubuntu-publisher/networkservicedesigngroups/ubuntu"}]}}'
     headers:
       cache-control:
       - no-cache
-      connection:
-      - close
       content-length:
-      - '3050'
+      - '3037'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:19:38 GMT
+      - Wed, 15 May 2024 16:16:13 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: D7BACAD1456D4E99A642AE16718061C2 Ref B: AMS231032609045 Ref C: 2024-05-15T16:16:14Z'
     status:
       code: 200
       message: OK
@@ -3095,52 +3219,55 @@ interactions:
       ParameterSetName:
       - --build-output-folder
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-hybridnetwork/unknown Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-nsd-manifest-1-0-0?api-version=2023-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-nsd-manifest-1-0-0?api-version=2023-09-01
   response:
     body:
-      string: '{"error": {"code": "ResourceNotFound", "message": "The Resource ''Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-nsd-manifest-1-0-0''
+      string: '{"error": {"code": "ResourceNotFound", "message": "The Resource ''Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-nsd-manifest-1-0-0''
         under resource group ''cli_test_vnf_nsd_000001'' was not found. For more details
         please go to https://aka.ms/ARMResourceNotFoundFix"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '340'
+      - '339'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:19:39 GMT
+      - Wed, 15 May 2024 16:16:14 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
       x-ms-failure-cause:
       - gateway
+      x-msedge-ref:
+      - 'Ref A: B3C9DC0ECB334CAB826B8974A6524646 Ref B: AMS231032609047 Ref C: 2024-05-15T16:16:14Z'
     status:
       code: 404
       message: Not Found
 - request:
     body: '{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
       "contentVersion": "1.0.0.0", "metadata": {"_generator": {"name": "bicep", "version":
-      "0.26.54.24096", "templateHash": "4244437476724292391"}}, "parameters": {"location":
+      "0.8.9.13224", "templateHash": "1992933778514196637"}}, "parameters": {"location":
       {"type": "string"}, "publisherName": {"type": "string", "metadata": {"description":
       "Name of an existing publisher, expected to be in the resource group where you
       deploy the template"}}, "acrArtifactStoreName": {"type": "string", "metadata":
       {"description": "Name of an existing ACR-backed Artifact Store, deployed under
       the publisher."}}, "acrManifestName": {"type": "string", "metadata": {"description":
-      "Name of the Artifact Manifest to create"}}}, "resources": [{"type": "Microsoft.HybridNetwork/publishers/artifactStores/artifactManifests",
+      "Name of the Artifact Manifest to create"}}}, "resources": [{"type": "Microsoft.Hybridnetwork/publishers/artifactStores/artifactManifests",
       "apiVersion": "2023-09-01", "name": "[format(''{0}/{1}/{2}'', parameters(''publisherName''),
       parameters(''acrArtifactStoreName''), parameters(''acrManifestName''))]", "location":
       "[parameters(''location'')]", "properties": {"artifacts": [{"artifactName":
       "ubuntu", "artifactType": "OCIArtifact", "artifactVersion": "1.0.0"}]}}]}, "parameters":
-      {"location": {"value": "uksouth"}, "publisherName": {"value": "automated-cli-tests-ubuntu-publisher"},
+      {"location": {"value": "uksouth"}, "publisherName": {"value": "automated-cli-test-ubuntu-publisher"},
       "acrArtifactStoreName": {"value": "ubuntu-acr"}, "acrManifestName": {"value":
       "ubuntu-nsd-manifest-1-0-0"}}, "mode": "Incremental"}}'
     headers:
@@ -3153,67 +3280,70 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1408'
+      - '1405'
       Content-Type:
       - application/json
       ParameterSetName:
       - --build-output-folder
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/validate?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1713273583",
-        "name": "AOSM_CLI_deployment_1713273583", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "4244437476724292391", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1715789778",
+        "name": "AOSM_CLI_deployment_1715789778", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "1992933778514196637", "parameters": {"location":
         {"type": "String", "value": "uksouth"}, "publisherName": {"type": "String",
-        "value": "automated-cli-tests-ubuntu-publisher"}, "acrArtifactStoreName":
-        {"type": "String", "value": "ubuntu-acr"}, "acrManifestName": {"type": "String",
-        "value": "ubuntu-nsd-manifest-1-0-0"}}, "mode": "Incremental", "provisioningState":
+        "value": "automated-cli-test-ubuntu-publisher"}, "acrArtifactStoreName": {"type":
+        "String", "value": "ubuntu-acr"}, "acrManifestName": {"type": "String", "value":
+        "ubuntu-nsd-manifest-1-0-0"}}, "mode": "Incremental", "provisioningState":
         "Succeeded", "timestamp": "0001-01-01T00:00:00Z", "duration": "PT0S", "correlationId":
-        "95221558-4498-45e2-9c09-0583afa64b10", "providers": [{"namespace": "Microsoft.HybridNetwork",
+        "5387b5ea-d34a-45f7-b931-78aef6e34553", "providers": [{"namespace": "Microsoft.Hybridnetwork",
         "resourceTypes": [{"resourceType": "publishers/artifactStores/artifactManifests",
         "locations": ["uksouth"]}]}], "dependencies": [], "validatedResources": [{"id":
-        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-nsd-manifest-1-0-0"}]}}'
+        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/automated-cli-test-ubuntu-publisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-nsd-manifest-1-0-0"}]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1247'
+      - '1245'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:19:42 GMT
+      - Wed, 15 May 2024 16:16:18 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
+      x-msedge-ref:
+      - 'Ref A: 7FA8F57F08094471A4619EAF38D667A1 Ref B: AMS231032609045 Ref C: 2024-05-15T16:16:18Z'
     status:
       code: 200
       message: OK
 - request:
     body: '{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
       "contentVersion": "1.0.0.0", "metadata": {"_generator": {"name": "bicep", "version":
-      "0.26.54.24096", "templateHash": "4244437476724292391"}}, "parameters": {"location":
+      "0.8.9.13224", "templateHash": "1992933778514196637"}}, "parameters": {"location":
       {"type": "string"}, "publisherName": {"type": "string", "metadata": {"description":
       "Name of an existing publisher, expected to be in the resource group where you
       deploy the template"}}, "acrArtifactStoreName": {"type": "string", "metadata":
       {"description": "Name of an existing ACR-backed Artifact Store, deployed under
       the publisher."}}, "acrManifestName": {"type": "string", "metadata": {"description":
-      "Name of the Artifact Manifest to create"}}}, "resources": [{"type": "Microsoft.HybridNetwork/publishers/artifactStores/artifactManifests",
+      "Name of the Artifact Manifest to create"}}}, "resources": [{"type": "Microsoft.Hybridnetwork/publishers/artifactStores/artifactManifests",
       "apiVersion": "2023-09-01", "name": "[format(''{0}/{1}/{2}'', parameters(''publisherName''),
       parameters(''acrArtifactStoreName''), parameters(''acrManifestName''))]", "location":
       "[parameters(''location'')]", "properties": {"artifacts": [{"artifactName":
       "ubuntu", "artifactType": "OCIArtifact", "artifactVersion": "1.0.0"}]}}]}, "parameters":
-      {"location": {"value": "uksouth"}, "publisherName": {"value": "automated-cli-tests-ubuntu-publisher"},
+      {"location": {"value": "uksouth"}, "publisherName": {"value": "automated-cli-test-ubuntu-publisher"},
       "acrArtifactStoreName": {"value": "ubuntu-acr"}, "acrManifestName": {"value":
       "ubuntu-nsd-manifest-1-0-0"}}, "mode": "Incremental"}}'
     headers:
@@ -3226,50 +3356,53 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1408'
+      - '1405'
       Content-Type:
       - application/json
       ParameterSetName:
       - --build-output-folder
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1713273583",
-        "name": "AOSM_CLI_deployment_1713273583", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "4244437476724292391", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1715789778",
+        "name": "AOSM_CLI_deployment_1715789778", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "1992933778514196637", "parameters": {"location":
         {"type": "String", "value": "uksouth"}, "publisherName": {"type": "String",
-        "value": "automated-cli-tests-ubuntu-publisher"}, "acrArtifactStoreName":
-        {"type": "String", "value": "ubuntu-acr"}, "acrManifestName": {"type": "String",
-        "value": "ubuntu-nsd-manifest-1-0-0"}}, "mode": "Incremental", "provisioningState":
-        "Accepted", "timestamp": "2024-04-16T13:19:42.9828172Z", "duration": "PT0.0006542S",
-        "correlationId": "ee5db3bd-1723-4e48-a1e5-f1e139b9fc53", "providers": [{"namespace":
-        "Microsoft.HybridNetwork", "resourceTypes": [{"resourceType": "publishers/artifactStores/artifactManifests",
+        "value": "automated-cli-test-ubuntu-publisher"}, "acrArtifactStoreName": {"type":
+        "String", "value": "ubuntu-acr"}, "acrManifestName": {"type": "String", "value":
+        "ubuntu-nsd-manifest-1-0-0"}}, "mode": "Incremental", "provisioningState":
+        "Accepted", "timestamp": "2024-05-15T16:16:19.7318707Z", "duration": "PT0.0005784S",
+        "correlationId": "40ce4210-03f7-4e46-ada1-1e1e5752e8c7", "providers": [{"namespace":
+        "Microsoft.Hybridnetwork", "resourceTypes": [{"resourceType": "publishers/artifactStores/artifactManifests",
         "locations": ["uksouth"]}]}], "dependencies": []}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1713273583/operationStatuses/08584883333027222951?api-version=2022-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1715789778/operationStatuses/08584858171061299931?api-version=2022-09-01
       cache-control:
       - no-cache
       content-length:
-      - '984'
+      - '983'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:19:42 GMT
+      - Wed, 15 May 2024 16:16:19 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
+      x-msedge-ref:
+      - 'Ref A: 7FF1AFD25126429E825D595C577B285C Ref B: AMS231032609045 Ref C: 2024-05-15T16:16:19Z'
     status:
       code: 201
       message: Created
@@ -3287,10 +3420,9 @@ interactions:
       ParameterSetName:
       - --build-output-folder
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883333027222951?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858171061299931?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Accepted"}'
@@ -3302,15 +3434,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:19:42 GMT
+      - Wed, 15 May 2024 16:16:19 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: 7F5FAAE854884DA0AEF43078AA6B51EF Ref B: AMS231032609045 Ref C: 2024-05-15T16:16:19Z'
     status:
       code: 200
       message: OK
@@ -3328,10 +3464,9 @@ interactions:
       ParameterSetName:
       - --build-output-folder
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883333027222951?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858171061299931?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Running"}'
@@ -3343,15 +3478,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:20:12 GMT
+      - Wed, 15 May 2024 16:16:50 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: 479C2F9C32EA4CB09655183BEE667415 Ref B: AMS231032609045 Ref C: 2024-05-15T16:16:50Z'
     status:
       code: 200
       message: OK
@@ -3369,10 +3508,9 @@ interactions:
       ParameterSetName:
       - --build-output-folder
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883333027222951?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858171061299931?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Running"}'
@@ -3384,15 +3522,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:20:40 GMT
+      - Wed, 15 May 2024 16:17:20 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: 2C39ABAFAE0940D29CB462DB72969A27 Ref B: AMS231032609045 Ref C: 2024-05-15T16:17:21Z'
     status:
       code: 200
       message: OK
@@ -3410,10 +3552,9 @@ interactions:
       ParameterSetName:
       - --build-output-folder
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883333027222951?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858171061299931?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Succeeded"}'
@@ -3425,15 +3566,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:21:10 GMT
+      - Wed, 15 May 2024 16:17:50 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: 82F70067A773465EA686FF1C6BDC599E Ref B: AMS231032609045 Ref C: 2024-05-15T16:17:50Z'
     status:
       code: 200
       message: OK
@@ -3451,41 +3596,44 @@ interactions:
       ParameterSetName:
       - --build-output-folder
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1713273583",
-        "name": "AOSM_CLI_deployment_1713273583", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "4244437476724292391", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1715789778",
+        "name": "AOSM_CLI_deployment_1715789778", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "1992933778514196637", "parameters": {"location":
         {"type": "String", "value": "uksouth"}, "publisherName": {"type": "String",
-        "value": "automated-cli-tests-ubuntu-publisher"}, "acrArtifactStoreName":
-        {"type": "String", "value": "ubuntu-acr"}, "acrManifestName": {"type": "String",
-        "value": "ubuntu-nsd-manifest-1-0-0"}}, "mode": "Incremental", "provisioningState":
-        "Succeeded", "timestamp": "2024-04-16T13:21:09.8419899Z", "duration": "PT1M26.8598269S",
-        "correlationId": "ee5db3bd-1723-4e48-a1e5-f1e139b9fc53", "providers": [{"namespace":
-        "Microsoft.HybridNetwork", "resourceTypes": [{"resourceType": "publishers/artifactStores/artifactManifests",
+        "value": "automated-cli-test-ubuntu-publisher"}, "acrArtifactStoreName": {"type":
+        "String", "value": "ubuntu-acr"}, "acrManifestName": {"type": "String", "value":
+        "ubuntu-nsd-manifest-1-0-0"}}, "mode": "Incremental", "provisioningState":
+        "Succeeded", "timestamp": "2024-05-15T16:17:44.0430297Z", "duration": "PT1M24.3117374S",
+        "correlationId": "40ce4210-03f7-4e46-ada1-1e1e5752e8c7", "providers": [{"namespace":
+        "Microsoft.Hybridnetwork", "resourceTypes": [{"resourceType": "publishers/artifactStores/artifactManifests",
         "locations": ["uksouth"]}]}], "dependencies": [], "outputResources": [{"id":
-        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-nsd-manifest-1-0-0"}]}}'
+        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/automated-cli-test-ubuntu-publisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-nsd-manifest-1-0-0"}]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1263'
+      - '1261'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:21:10 GMT
+      - Wed, 15 May 2024 16:17:50 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: FE73D64D5AAC44FCA72262BA93C75FE9 Ref B: AMS231032609045 Ref C: 2024-05-15T16:17:50Z'
     status:
       code: 200
       message: OK
@@ -3505,15 +3653,14 @@ interactions:
       ParameterSetName:
       - --build-output-folder
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-hybridnetwork/unknown Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-nsd-manifest-1-0-0/listCredential?api-version=2023-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-test-ubuntu-publisher/artifactStores/ubuntu-acr/artifactManifests/ubuntu-nsd-manifest-1-0-0/listCredential?api-version=2023-09-01
   response:
     body:
       string: '{"username": "ubuntu-nsd-manifest-1-0-0", "acrToken": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-        "acrServerUrl": "https://automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io",
-        "repositories": ["ubuntu"], "expiry": "2024-04-17T13:21:16.8129886+00:00",
+        "acrServerUrl": "https://automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io",
+        "repositories": ["ubuntu"], "expiry": "2024-05-16T16:17:59.2073317+00:00",
         "credentialType": "AzureContainerRegistryScopedToken"}'
     headers:
       cache-control:
@@ -3523,21 +3670,25 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:21:16 GMT
+      - Wed, 15 May 2024 16:17:59 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
       x-ms-build-version:
-      - 1.0.02651.2759
+      - 1.0.02682.2890
       x-ms-providerhub-traffic:
       - 'True'
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
+      x-msedge-ref:
+      - 'Ref A: 1ECD5555BC8743EE94E709CB09B10EEA Ref B: AMS231020614045 Ref C: 2024-05-15T16:17:55Z'
     status:
       code: 200
       message: OK
@@ -3555,9 +3706,9 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - python-requests/2.31.0
+      - python-requests/2.26.0
     method: POST
-    uri: https://automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io/v2/ubuntu/blobs/uploads/
+    uri: https://automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io/v2/ubuntu/blobs/uploads/
   response:
     body:
       string: '{"errors": [{"code": "UNAUTHORIZED", "message": "authentication required,
@@ -3577,7 +3728,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:21:17 GMT
+      - Wed, 15 May 2024 16:17:59 GMT
       docker-distribution-api-version:
       - registry/2.0
       server:
@@ -3586,7 +3737,7 @@ interactions:
       - max-age=31536000; includeSubDomains
       - max-age=31536000; includeSubDomains
       www-authenticate:
-      - Bearer realm="https://automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io/oauth2/token",service="automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io",scope="repository:ubuntu:pull,push"
+      - Bearer realm="https://automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io/oauth2/token",service="automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io",scope="repository:ubuntu:pull,push"
       x-content-type-options:
       - nosniff
     status:
@@ -3602,11 +3753,11 @@ interactions:
       Connection:
       - keep-alive
       Service:
-      - automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io
+      - automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io
       User-Agent:
       - oras-py
     method: GET
-    uri: https://automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io/oauth2/token?service=automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io&scope=repository%3Aubuntu%3Apull%2Cpush
+    uri: https://automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io/oauth2/token?service=automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io&scope=repository%3Aubuntu%3Apull%2Cpush
   response:
     body:
       string: '{"access_token": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}'
@@ -3616,7 +3767,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:21:17 GMT
+      - Wed, 15 May 2024 16:17:59 GMT
       server:
       - AzureContainerRegistry
       strict-transport-security:
@@ -3642,9 +3793,9 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - python-requests/2.31.0
+      - python-requests/2.26.0
     method: POST
-    uri: https://automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io/v2/ubuntu/blobs/uploads/
+    uri: https://automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io/v2/ubuntu/blobs/uploads/
   response:
     body:
       string: ''
@@ -3659,13 +3810,13 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 16 Apr 2024 13:21:17 GMT
+      - Wed, 15 May 2024 16:18:00 GMT
       docker-distribution-api-version:
       - registry/2.0
       docker-upload-uuid:
-      - a4b7f09e-12a9-4751-ae3a-4d05c72c7fa2
+      - a669cfb3-97c1-411d-ad5d-bcb161f5f03c
       location:
-      - /v2/ubuntu/blobs/uploads/a4b7f09e-12a9-4751-ae3a-4d05c72c7fa2?_nouploadcache=false&_state=NdO6huBXH3TDSMe403U0pGZK0D4-7zs0vDHOXcecV0Z7Ik5hbWUiOiJ1YnVudHUiLCJVVUlEIjoiYTRiN2YwOWUtMTJhOS00NzUxLWFlM2EtNGQwNWM3MmM3ZmEyIiwiT2Zmc2V0IjowLCJTdGFydGVkQXQiOiIyMDI0LTA0LTE2VDEzOjIxOjE3LjMyMTQ0MDMzNFoifQ%3D%3D
+      - /v2/ubuntu/blobs/uploads/a669cfb3-97c1-411d-ad5d-bcb161f5f03c?_nouploadcache=false&_state=SZ4K6sXHIIIr4DuvEtcOPLfxkmqtdoFcaORgFSuMwQ17Ik5hbWUiOiJ1YnVudHUiLCJVVUlEIjoiYTY2OWNmYjMtOTdjMS00MTFkLWFkNWQtYmNiMTYxZjVmMDNjIiwiT2Zmc2V0IjowLCJTdGFydGVkQXQiOiIyMDI0LTA1LTE1VDE2OjE3OjU5Ljk2NDg5OTk4N1oifQ%3D%3D
       range:
       - 0-0
       server:
@@ -3681,7 +3832,7 @@ interactions:
 - request:
     body: '{"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
       "contentVersion": "1.0.0.0", "metadata": {"_generator": {"name": "bicep", "version":
-      "0.26.54.24096", "templateHash": "13997939921627854066"}}, "parameters": {"configObject":
+      "0.8.9.13224", "templateHash": "8518384207964034190"}}, "parameters": {"configObject":
       {"type": "secureObject"}}, "variables": {"resourceGroupId": "[resourceGroup().id]",
       "identityObject": "[if(equals(parameters(''configObject'').managedIdentityId,
       ''''), createObject(''type'', ''SystemAssigned''), createObject(''type'', ''UserAssigned'',
@@ -3694,7 +3845,7 @@ interactions:
       "location": "[parameters(''configObject'').location]", "identity": "[variables(''identityObject'')]",
       "properties": {"networkFunctionDefinitionVersionResourceReference": {"id": "[extensionResourceId(format(''/subscriptions/{0}/resourceGroups/{1}'',
       subscription().subscriptionId, parameters(''configObject'').publisherResourceGroup),
-      ''Microsoft.HybridNetwork/publishers/networkFunctionDefinitionGroups/networkFunctionDefinitionVersions'',
+      ''Microsoft.Hybridnetwork/publishers/networkfunctiondefinitiongroups/networkfunctiondefinitionversions'',
       split(variables(''nfdvSymbolicName''), ''/'')[0], split(variables(''nfdvSymbolicName''),
       ''/'')[1], split(variables(''nfdvSymbolicName''), ''/'')[2])]", "idType": "Open"},
       "nfviType": "AzureCore", "nfviId": "[if(equals(parameters(''configObject'').customLocationId,
@@ -3709,13 +3860,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1981'
+      - '1978'
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - python-requests/2.31.0
+      - python-requests/2.26.0
     method: PUT
-    uri: https://automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io/v2/ubuntu/blobs/uploads/a4b7f09e-12a9-4751-ae3a-4d05c72c7fa2?_nouploadcache=false&_state=NdO6huBXH3TDSMe403U0pGZK0D4-7zs0vDHOXcecV0Z7Ik5hbWUiOiJ1YnVudHUiLCJVVUlEIjoiYTRiN2YwOWUtMTJhOS00NzUxLWFlM2EtNGQwNWM3MmM3ZmEyIiwiT2Zmc2V0IjowLCJTdGFydGVkQXQiOiIyMDI0LTA0LTE2VDEzOjIxOjE3LjMyMTQ0MDMzNFoifQ%3D%3D&digest=sha256%3A3ccb87556f82c72b4c80c83273d1ac390d77d09ef3504cce53e2c7dd78338bfe
+    uri: https://automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io/v2/ubuntu/blobs/uploads/a669cfb3-97c1-411d-ad5d-bcb161f5f03c?_nouploadcache=false&_state=SZ4K6sXHIIIr4DuvEtcOPLfxkmqtdoFcaORgFSuMwQ17Ik5hbWUiOiJ1YnVudHUiLCJVVUlEIjoiYTY2OWNmYjMtOTdjMS00MTFkLWFkNWQtYmNiMTYxZjVmMDNjIiwiT2Zmc2V0IjowLCJTdGFydGVkQXQiOiIyMDI0LTA1LTE1VDE2OjE3OjU5Ljk2NDg5OTk4N1oifQ%3D%3D&digest=sha256%3A1de8a2eeb110ed93ac8d61feceadcce5c95cd2dea2adff9ae11166d87e254dfa
   response:
     body:
       string: ''
@@ -3730,13 +3881,13 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 16 Apr 2024 13:21:17 GMT
+      - Wed, 15 May 2024 16:18:00 GMT
       docker-content-digest:
-      - sha256:3ccb87556f82c72b4c80c83273d1ac390d77d09ef3504cce53e2c7dd78338bfe
+      - sha256:1de8a2eeb110ed93ac8d61feceadcce5c95cd2dea2adff9ae11166d87e254dfa
       docker-distribution-api-version:
       - registry/2.0
       location:
-      - /v2/ubuntu/blobs/sha256:3ccb87556f82c72b4c80c83273d1ac390d77d09ef3504cce53e2c7dd78338bfe
+      - /v2/ubuntu/blobs/sha256:1de8a2eeb110ed93ac8d61feceadcce5c95cd2dea2adff9ae11166d87e254dfa
       server:
       - AzureContainerRegistry
       strict-transport-security:
@@ -3761,9 +3912,9 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - python-requests/2.31.0
+      - python-requests/2.26.0
     method: POST
-    uri: https://automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io/v2/ubuntu/blobs/uploads/
+    uri: https://automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io/v2/ubuntu/blobs/uploads/
   response:
     body:
       string: '{"errors": [{"code": "UNAUTHORIZED", "message": "authentication required,
@@ -3783,7 +3934,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:21:17 GMT
+      - Wed, 15 May 2024 16:18:00 GMT
       docker-distribution-api-version:
       - registry/2.0
       server:
@@ -3792,7 +3943,7 @@ interactions:
       - max-age=31536000; includeSubDomains
       - max-age=31536000; includeSubDomains
       www-authenticate:
-      - Bearer realm="https://automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io/oauth2/token",service="automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io",scope="repository:ubuntu:pull,push"
+      - Bearer realm="https://automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io/oauth2/token",service="automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io",scope="repository:ubuntu:pull,push"
       x-content-type-options:
       - nosniff
     status:
@@ -3808,11 +3959,11 @@ interactions:
       Connection:
       - keep-alive
       Service:
-      - automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io
+      - automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io
       User-Agent:
       - oras-py
     method: GET
-    uri: https://automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io/oauth2/token?service=automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io&scope=repository%3Aubuntu%3Apull%2Cpush
+    uri: https://automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io/oauth2/token?service=automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io&scope=repository%3Aubuntu%3Apull%2Cpush
   response:
     body:
       string: '{"access_token": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}'
@@ -3822,7 +3973,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:21:17 GMT
+      - Wed, 15 May 2024 16:18:00 GMT
       server:
       - AzureContainerRegistry
       strict-transport-security:
@@ -3848,9 +3999,9 @@ interactions:
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - python-requests/2.31.0
+      - python-requests/2.26.0
     method: POST
-    uri: https://automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io/v2/ubuntu/blobs/uploads/
+    uri: https://automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io/v2/ubuntu/blobs/uploads/
   response:
     body:
       string: ''
@@ -3865,13 +4016,13 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 16 Apr 2024 13:21:17 GMT
+      - Wed, 15 May 2024 16:18:00 GMT
       docker-distribution-api-version:
       - registry/2.0
       docker-upload-uuid:
-      - 34c4c8b8-d90d-4b0d-841d-59e2277e23a4
+      - 7717c759-478f-4697-82b2-f525d2345068
       location:
-      - /v2/ubuntu/blobs/uploads/34c4c8b8-d90d-4b0d-841d-59e2277e23a4?_nouploadcache=false&_state=qwb7OExMjydwf5Tul-7GIBLyIGK9WLrukjrYhzIWXax7Ik5hbWUiOiJ1YnVudHUiLCJVVUlEIjoiMzRjNGM4YjgtZDkwZC00YjBkLTg0MWQtNTllMjI3N2UyM2E0IiwiT2Zmc2V0IjowLCJTdGFydGVkQXQiOiIyMDI0LTA0LTE2VDEzOjIxOjE3LjU4NjIzMzQzOVoifQ%3D%3D
+      - /v2/ubuntu/blobs/uploads/7717c759-478f-4697-82b2-f525d2345068?_nouploadcache=false&_state=dKhyLGWF8u0ZqLhV3U3nWLUIVWWUhgn3m44F4P0puQZ7Ik5hbWUiOiJ1YnVudHUiLCJVVUlEIjoiNzcxN2M3NTktNDc4Zi00Njk3LTgyYjItZjUyNWQyMzQ1MDY4IiwiT2Zmc2V0IjowLCJTdGFydGVkQXQiOiIyMDI0LTA1LTE1VDE2OjE4OjAwLjI2MTM5MDAyNloifQ%3D%3D
       range:
       - 0-0
       server:
@@ -3885,7 +4036,7 @@ interactions:
       code: 202
       message: Accepted
 - request:
-    body: '{}'
+    body: null
     headers:
       Accept:
       - '*/*'
@@ -3894,13 +4045,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '2'
+      - '0'
       Content-Type:
       - application/octet-stream
       User-Agent:
-      - python-requests/2.31.0
+      - python-requests/2.26.0
     method: PUT
-    uri: https://automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io/v2/ubuntu/blobs/uploads/34c4c8b8-d90d-4b0d-841d-59e2277e23a4?_nouploadcache=false&_state=qwb7OExMjydwf5Tul-7GIBLyIGK9WLrukjrYhzIWXax7Ik5hbWUiOiJ1YnVudHUiLCJVVUlEIjoiMzRjNGM4YjgtZDkwZC00YjBkLTg0MWQtNTllMjI3N2UyM2E0IiwiT2Zmc2V0IjowLCJTdGFydGVkQXQiOiIyMDI0LTA0LTE2VDEzOjIxOjE3LjU4NjIzMzQzOVoifQ%3D%3D&digest=sha256%3A44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+    uri: https://automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io/v2/ubuntu/blobs/uploads/7717c759-478f-4697-82b2-f525d2345068?_nouploadcache=false&_state=dKhyLGWF8u0ZqLhV3U3nWLUIVWWUhgn3m44F4P0puQZ7Ik5hbWUiOiJ1YnVudHUiLCJVVUlEIjoiNzcxN2M3NTktNDc4Zi00Njk3LTgyYjItZjUyNWQyMzQ1MDY4IiwiT2Zmc2V0IjowLCJTdGFydGVkQXQiOiIyMDI0LTA1LTE1VDE2OjE4OjAwLjI2MTM5MDAyNloifQ%3D%3D&digest=sha256%3Ae3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   response:
     body:
       string: ''
@@ -3915,13 +4066,13 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 16 Apr 2024 13:21:17 GMT
+      - Wed, 15 May 2024 16:18:00 GMT
       docker-content-digest:
-      - sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+      - sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       docker-distribution-api-version:
       - registry/2.0
       location:
-      - /v2/ubuntu/blobs/sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+      - /v2/ubuntu/blobs/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       server:
       - AzureContainerRegistry
       strict-transport-security:
@@ -3934,10 +4085,10 @@ interactions:
       message: Created
 - request:
     body: '{"schemaVersion": 2, "mediaType": "application/vnd.oci.image.manifest.v1+json",
-      "config": {"mediaType": "application/vnd.unknown.config.v1+json", "size": 2,
-      "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"},
-      "layers": [{"mediaType": "application/vnd.oci.image.layer.v1.tar", "size": 1981,
-      "digest": "sha256:3ccb87556f82c72b4c80c83273d1ac390d77d09ef3504cce53e2c7dd78338bfe",
+      "config": {"mediaType": "application/vnd.unknown.config.v1+json", "size": 0,
+      "digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+      "layers": [{"mediaType": "application/vnd.oci.image.layer.v1.tar", "size": 1978,
+      "digest": "sha256:1de8a2eeb110ed93ac8d61feceadcce5c95cd2dea2adff9ae11166d87e254dfa",
       "annotations": {"org.opencontainers.image.title": "ubuntu-vm.json"}}], "annotations":
       {}}'
     headers:
@@ -3952,9 +4103,9 @@ interactions:
       Content-Type:
       - application/vnd.oci.image.manifest.v1+json
       User-Agent:
-      - python-requests/2.31.0
+      - python-requests/2.26.0
     method: PUT
-    uri: https://automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io/v2/ubuntu/manifests/1.0.0
+    uri: https://automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io/v2/ubuntu/manifests/1.0.0
   response:
     body:
       string: '{"errors": [{"code": "UNAUTHORIZED", "message": "authentication required,
@@ -3974,7 +4125,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:21:17 GMT
+      - Wed, 15 May 2024 16:18:00 GMT
       docker-distribution-api-version:
       - registry/2.0
       server:
@@ -3983,7 +4134,7 @@ interactions:
       - max-age=31536000; includeSubDomains
       - max-age=31536000; includeSubDomains
       www-authenticate:
-      - Bearer realm="https://automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io/oauth2/token",service="automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io",scope="repository:ubuntu:pull,push"
+      - Bearer realm="https://automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io/oauth2/token",service="automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io",scope="repository:ubuntu:pull,push"
       x-content-type-options:
       - nosniff
     status:
@@ -3999,11 +4150,11 @@ interactions:
       Connection:
       - keep-alive
       Service:
-      - automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io
+      - automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io
       User-Agent:
       - oras-py
     method: GET
-    uri: https://automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io/oauth2/token?service=automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io&scope=repository%3Aubuntu%3Apull%2Cpush
+    uri: https://automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io/oauth2/token?service=automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io&scope=repository%3Aubuntu%3Apull%2Cpush
   response:
     body:
       string: '{"access_token": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}'
@@ -4013,7 +4164,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:21:17 GMT
+      - Wed, 15 May 2024 16:18:00 GMT
       server:
       - AzureContainerRegistry
       strict-transport-security:
@@ -4027,10 +4178,10 @@ interactions:
       message: OK
 - request:
     body: '{"schemaVersion": 2, "mediaType": "application/vnd.oci.image.manifest.v1+json",
-      "config": {"mediaType": "application/vnd.unknown.config.v1+json", "size": 2,
-      "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"},
-      "layers": [{"mediaType": "application/vnd.oci.image.layer.v1.tar", "size": 1981,
-      "digest": "sha256:3ccb87556f82c72b4c80c83273d1ac390d77d09ef3504cce53e2c7dd78338bfe",
+      "config": {"mediaType": "application/vnd.unknown.config.v1+json", "size": 0,
+      "digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+      "layers": [{"mediaType": "application/vnd.oci.image.layer.v1.tar", "size": 1978,
+      "digest": "sha256:1de8a2eeb110ed93ac8d61feceadcce5c95cd2dea2adff9ae11166d87e254dfa",
       "annotations": {"org.opencontainers.image.title": "ubuntu-vm.json"}}], "annotations":
       {}}'
     headers:
@@ -4045,9 +4196,9 @@ interactions:
       Content-Type:
       - application/vnd.oci.image.manifest.v1+json
       User-Agent:
-      - python-requests/2.31.0
+      - python-requests/2.26.0
     method: PUT
-    uri: https://automatedclitestsubuntupublisherubuntuaca3e684b70e.azurecr.io/v2/ubuntu/manifests/1.0.0
+    uri: https://automatedclitestubuntupublisherubuntuacr1f68c8ee37.azurecr.io/v2/ubuntu/manifests/1.0.0
   response:
     body:
       string: ''
@@ -4062,13 +4213,13 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 16 Apr 2024 13:21:18 GMT
+      - Wed, 15 May 2024 16:18:00 GMT
       docker-content-digest:
-      - sha256:7516e68c6e8b63fcbb428b1ac84e62da7af611846b0a395a546642d45bfe3141
+      - sha256:1d0f31e46a08c4480c4c9c0cb762af78641b8cdf0a8e8a34eb1acbd7ac8709e3
       docker-distribution-api-version:
       - registry/2.0
       location:
-      - /v2/ubuntu/manifests/sha256:7516e68c6e8b63fcbb428b1ac84e62da7af611846b0a395a546642d45bfe3141
+      - /v2/ubuntu/manifests/sha256:1d0f31e46a08c4480c4c9c0cb762af78641b8cdf0a8e8a34eb1acbd7ac8709e3
       server:
       - AzureContainerRegistry
       strict-transport-security:
@@ -4082,7 +4233,7 @@ interactions:
 - request:
     body: '{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
       "contentVersion": "1.0.0.0", "metadata": {"_generator": {"name": "bicep", "version":
-      "0.26.54.24096", "templateHash": "7665769847335104070"}}, "parameters": {"location":
+      "0.8.9.13224", "templateHash": "774629352801001138"}}, "parameters": {"location":
       {"type": "string"}, "publisherName": {"type": "string", "metadata": {"description":
       "Name of an existing publisher, expected to be in the resource group where you
       deploy the template"}}, "acrArtifactStoreName": {"type": "string", "metadata":
@@ -4101,19 +4252,19 @@ interactions:
       "virtualNetworkId", "sshPublicKeyAdmin"]}}, "required": ["automated-cli-tests-artifact"]}},
       "managedIdentityId": {"type": "string"}}, "required": ["nfdv", "deployParameters",
       "managedIdentityId"]}}, "required": ["ubuntu"]}, "$fxv#1": {"configObject":
-      {"location": "uksouth", "publisherName": "automated-cli-tests-ubuntu-publisher",
+      {"location": "uksouth", "publisherName": "automated-cli-test-ubuntu-publisher",
       "nfdgName": "ubuntu-vm", "publisherResourceGroup": "cli_test_vnf_nsd_000001",
       "customLocationId": "", "nfdv": "{configurationparameters(''ConfigGroupSchema'').ubuntu.nfdv}",
       "deployParameters": "{configurationparameters(''ConfigGroupSchema'').ubuntu.deployParameters}",
       "managedIdentityId": "{configurationparameters(''ConfigGroupSchema'').ubuntu.managedIdentityId}"}}},
-      "resources": [{"type": "Microsoft.HybridNetwork/publishers/configurationGroupSchemas",
+      "resources": [{"type": "Microsoft.Hybridnetwork/publishers/configurationGroupSchemas",
       "apiVersion": "2023-09-01", "name": "[format(''{0}/{1}'', parameters(''publisherName''),
       ''ConfigGroupSchema'')]", "location": "[parameters(''location'')]", "properties":
-      {"schemaDefinition": "[string(variables(''$fxv#0''))]"}}, {"type": "Microsoft.HybridNetwork/publishers/networkServiceDesignGroups/networkServiceDesignVersions",
+      {"schemaDefinition": "[string(variables(''$fxv#0''))]"}}, {"type": "Microsoft.Hybridnetwork/publishers/networkservicedesigngroups/networkservicedesignversions",
       "apiVersion": "2023-09-01", "name": "[format(''{0}/{1}/{2}'', parameters(''publisherName''),
       parameters(''nsDesignGroup''), parameters(''nsDesignVersion''))]", "location":
       "[parameters(''location'')]", "properties": {"description": "Plain ubuntu VM",
-      "configurationGroupSchemaReferences": {"ConfigGroupSchema": {"id": "[resourceId(''Microsoft.HybridNetwork/publishers/configurationGroupSchemas'',
+      "configurationGroupSchemaReferences": {"ConfigGroupSchema": {"id": "[resourceId(''Microsoft.Hybridnetwork/publishers/configurationGroupSchemas'',
       parameters(''publisherName''), ''ConfigGroupSchema'')]"}}, "nfvisFromSite":
       {"nfvi1": {"name": "[format(''{0}1'', parameters(''nfviSiteName''))]", "type":
       "AzureCore"}}, "resourceElementTemplates": [{"name": "ubuntu", "type": "NetworkFunctionDefinition",
@@ -4121,9 +4272,9 @@ interactions:
       parameters(''publisherName''), parameters(''acrArtifactStoreName''))]"}, "artifactName":
       "ubuntu", "artifactVersion": "1.0.0"}, "templateType": "ArmTemplate", "parameterValues":
       "[string(variables(''$fxv#1''))]"}, "dependsOnProfile": {"installDependsOn":
-      [], "uninstallDependsOn": [], "updateDependsOn": []}}]}, "dependsOn": ["[resourceId(''Microsoft.HybridNetwork/publishers/configurationGroupSchemas'',
+      [], "uninstallDependsOn": [], "updateDependsOn": []}}]}, "dependsOn": ["[resourceId(''Microsoft.Hybridnetwork/publishers/configurationGroupSchemas'',
       parameters(''publisherName''), ''ConfigGroupSchema'')]"]}]}, "parameters": {"location":
-      {"value": "uksouth"}, "publisherName": {"value": "automated-cli-tests-ubuntu-publisher"},
+      {"value": "uksouth"}, "publisherName": {"value": "automated-cli-test-ubuntu-publisher"},
       "acrArtifactStoreName": {"value": "ubuntu-acr"}, "nsDesignGroup": {"value":
       "ubuntu"}, "nsDesignVersion": {"value": "1.0.0"}, "nfviSiteName": {"value":
       "ubuntu_NFVI"}}, "mode": "Incremental"}}'
@@ -4137,65 +4288,67 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '4147'
+      - '4142'
       Content-Type:
       - application/json
       ParameterSetName:
       - --build-output-folder
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/validate?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1713273682",
-        "name": "AOSM_CLI_deployment_1713273682", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "7665769847335104070", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1715789884",
+        "name": "AOSM_CLI_deployment_1715789884", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "774629352801001138", "parameters": {"location":
         {"type": "String", "value": "uksouth"}, "publisherName": {"type": "String",
-        "value": "automated-cli-tests-ubuntu-publisher"}, "acrArtifactStoreName":
-        {"type": "String", "value": "ubuntu-acr"}, "nsDesignGroup": {"type": "String",
-        "value": "ubuntu"}, "nsDesignVersion": {"type": "String", "value": "1.0.0"},
-        "nfviSiteName": {"type": "String", "value": "ubuntu_NFVI"}}, "mode": "Incremental",
-        "provisioningState": "Succeeded", "timestamp": "0001-01-01T00:00:00Z", "duration":
-        "PT0S", "correlationId": "d1e292f0-5baa-4604-9806-521286a98be5", "providers":
-        [{"namespace": "Microsoft.HybridNetwork", "resourceTypes": [{"resourceType":
-        "publishers/configurationGroupSchemas", "locations": ["uksouth"]}, {"resourceType":
-        "publishers/networkServiceDesignGroups/networkServiceDesignVersions", "locations":
-        ["uksouth"]}]}], "dependencies": [{"dependsOn": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/configurationGroupSchemas/ConfigGroupSchema",
-        "resourceType": "Microsoft.HybridNetwork/publishers/configurationGroupSchemas",
-        "resourceName": "automated-cli-tests-ubuntu-publisher/ConfigGroupSchema"}],
-        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/networkServiceDesignGroups/ubuntu/networkServiceDesignVersions/1.0.0",
-        "resourceType": "Microsoft.HybridNetwork/publishers/networkServiceDesignGroups/networkServiceDesignVersions",
-        "resourceName": "automated-cli-tests-ubuntu-publisher/ubuntu/1.0.0"}], "validatedResources":
-        [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/configurationGroupSchemas/ConfigGroupSchema"},
-        {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/networkServiceDesignGroups/ubuntu/networkServiceDesignVersions/1.0.0"}]}}'
+        "value": "automated-cli-test-ubuntu-publisher"}, "acrArtifactStoreName": {"type":
+        "String", "value": "ubuntu-acr"}, "nsDesignGroup": {"type": "String", "value":
+        "ubuntu"}, "nsDesignVersion": {"type": "String", "value": "1.0.0"}, "nfviSiteName":
+        {"type": "String", "value": "ubuntu_NFVI"}}, "mode": "Incremental", "provisioningState":
+        "Succeeded", "timestamp": "0001-01-01T00:00:00Z", "duration": "PT0S", "correlationId":
+        "9f37a68d-d2a7-44b5-ad08-98ceb6146345", "providers": [{"namespace": "Microsoft.Hybridnetwork",
+        "resourceTypes": [{"resourceType": "publishers/configurationGroupSchemas",
+        "locations": ["uksouth"]}, {"resourceType": "publishers/networkservicedesigngroups/networkservicedesignversions",
+        "locations": ["uksouth"]}]}], "dependencies": [{"dependsOn": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/automated-cli-test-ubuntu-publisher/configurationGroupSchemas/ConfigGroupSchema",
+        "resourceType": "Microsoft.Hybridnetwork/publishers/configurationGroupSchemas",
+        "resourceName": "automated-cli-test-ubuntu-publisher/ConfigGroupSchema"}],
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/automated-cli-test-ubuntu-publisher/networkservicedesigngroups/ubuntu/networkservicedesignversions/1.0.0",
+        "resourceType": "Microsoft.Hybridnetwork/publishers/networkservicedesigngroups/networkservicedesignversions",
+        "resourceName": "automated-cli-test-ubuntu-publisher/ubuntu/1.0.0"}], "validatedResources":
+        [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/automated-cli-test-ubuntu-publisher/configurationGroupSchemas/ConfigGroupSchema"},
+        {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/automated-cli-test-ubuntu-publisher/networkservicedesigngroups/ubuntu/networkservicedesignversions/1.0.0"}]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '2504'
+      - '2496'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:21:20 GMT
+      - Wed, 15 May 2024 16:18:04 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
+      x-msedge-ref:
+      - 'Ref A: 63794877A754452D86E858F7F9342C9D Ref B: AMS231032609045 Ref C: 2024-05-15T16:18:04Z'
     status:
       code: 200
       message: OK
 - request:
     body: '{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
       "contentVersion": "1.0.0.0", "metadata": {"_generator": {"name": "bicep", "version":
-      "0.26.54.24096", "templateHash": "7665769847335104070"}}, "parameters": {"location":
+      "0.8.9.13224", "templateHash": "774629352801001138"}}, "parameters": {"location":
       {"type": "string"}, "publisherName": {"type": "string", "metadata": {"description":
       "Name of an existing publisher, expected to be in the resource group where you
       deploy the template"}}, "acrArtifactStoreName": {"type": "string", "metadata":
@@ -4214,19 +4367,19 @@ interactions:
       "virtualNetworkId", "sshPublicKeyAdmin"]}}, "required": ["automated-cli-tests-artifact"]}},
       "managedIdentityId": {"type": "string"}}, "required": ["nfdv", "deployParameters",
       "managedIdentityId"]}}, "required": ["ubuntu"]}, "$fxv#1": {"configObject":
-      {"location": "uksouth", "publisherName": "automated-cli-tests-ubuntu-publisher",
+      {"location": "uksouth", "publisherName": "automated-cli-test-ubuntu-publisher",
       "nfdgName": "ubuntu-vm", "publisherResourceGroup": "cli_test_vnf_nsd_000001",
       "customLocationId": "", "nfdv": "{configurationparameters(''ConfigGroupSchema'').ubuntu.nfdv}",
       "deployParameters": "{configurationparameters(''ConfigGroupSchema'').ubuntu.deployParameters}",
       "managedIdentityId": "{configurationparameters(''ConfigGroupSchema'').ubuntu.managedIdentityId}"}}},
-      "resources": [{"type": "Microsoft.HybridNetwork/publishers/configurationGroupSchemas",
+      "resources": [{"type": "Microsoft.Hybridnetwork/publishers/configurationGroupSchemas",
       "apiVersion": "2023-09-01", "name": "[format(''{0}/{1}'', parameters(''publisherName''),
       ''ConfigGroupSchema'')]", "location": "[parameters(''location'')]", "properties":
-      {"schemaDefinition": "[string(variables(''$fxv#0''))]"}}, {"type": "Microsoft.HybridNetwork/publishers/networkServiceDesignGroups/networkServiceDesignVersions",
+      {"schemaDefinition": "[string(variables(''$fxv#0''))]"}}, {"type": "Microsoft.Hybridnetwork/publishers/networkservicedesigngroups/networkservicedesignversions",
       "apiVersion": "2023-09-01", "name": "[format(''{0}/{1}/{2}'', parameters(''publisherName''),
       parameters(''nsDesignGroup''), parameters(''nsDesignVersion''))]", "location":
       "[parameters(''location'')]", "properties": {"description": "Plain ubuntu VM",
-      "configurationGroupSchemaReferences": {"ConfigGroupSchema": {"id": "[resourceId(''Microsoft.HybridNetwork/publishers/configurationGroupSchemas'',
+      "configurationGroupSchemaReferences": {"ConfigGroupSchema": {"id": "[resourceId(''Microsoft.Hybridnetwork/publishers/configurationGroupSchemas'',
       parameters(''publisherName''), ''ConfigGroupSchema'')]"}}, "nfvisFromSite":
       {"nfvi1": {"name": "[format(''{0}1'', parameters(''nfviSiteName''))]", "type":
       "AzureCore"}}, "resourceElementTemplates": [{"name": "ubuntu", "type": "NetworkFunctionDefinition",
@@ -4234,9 +4387,9 @@ interactions:
       parameters(''publisherName''), parameters(''acrArtifactStoreName''))]"}, "artifactName":
       "ubuntu", "artifactVersion": "1.0.0"}, "templateType": "ArmTemplate", "parameterValues":
       "[string(variables(''$fxv#1''))]"}, "dependsOnProfile": {"installDependsOn":
-      [], "uninstallDependsOn": [], "updateDependsOn": []}}]}, "dependsOn": ["[resourceId(''Microsoft.HybridNetwork/publishers/configurationGroupSchemas'',
+      [], "uninstallDependsOn": [], "updateDependsOn": []}}]}, "dependsOn": ["[resourceId(''Microsoft.Hybridnetwork/publishers/configurationGroupSchemas'',
       parameters(''publisherName''), ''ConfigGroupSchema'')]"]}]}, "parameters": {"location":
-      {"value": "uksouth"}, "publisherName": {"value": "automated-cli-tests-ubuntu-publisher"},
+      {"value": "uksouth"}, "publisherName": {"value": "automated-cli-test-ubuntu-publisher"},
       "acrArtifactStoreName": {"value": "ubuntu-acr"}, "nsDesignGroup": {"value":
       "ubuntu"}, "nsDesignVersion": {"value": "1.0.0"}, "nfviSiteName": {"value":
       "ubuntu_NFVI"}}, "mode": "Incremental"}}'
@@ -4250,58 +4403,60 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '4147'
+      - '4142'
       Content-Type:
       - application/json
       ParameterSetName:
       - --build-output-folder
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1713273682",
-        "name": "AOSM_CLI_deployment_1713273682", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "7665769847335104070", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1715789884",
+        "name": "AOSM_CLI_deployment_1715789884", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "774629352801001138", "parameters": {"location":
         {"type": "String", "value": "uksouth"}, "publisherName": {"type": "String",
-        "value": "automated-cli-tests-ubuntu-publisher"}, "acrArtifactStoreName":
-        {"type": "String", "value": "ubuntu-acr"}, "nsDesignGroup": {"type": "String",
-        "value": "ubuntu"}, "nsDesignVersion": {"type": "String", "value": "1.0.0"},
-        "nfviSiteName": {"type": "String", "value": "ubuntu_NFVI"}}, "mode": "Incremental",
-        "provisioningState": "Accepted", "timestamp": "2024-04-16T13:21:21.7260107Z",
-        "duration": "PT0.000726S", "correlationId": "a61f081e-5a1e-46cf-8601-243a87ddf2f7",
-        "providers": [{"namespace": "Microsoft.HybridNetwork", "resourceTypes": [{"resourceType":
-        "publishers/configurationGroupSchemas", "locations": ["uksouth"]}, {"resourceType":
-        "publishers/networkServiceDesignGroups/networkServiceDesignVersions", "locations":
-        ["uksouth"]}]}], "dependencies": [{"dependsOn": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/configurationGroupSchemas/ConfigGroupSchema",
-        "resourceType": "Microsoft.HybridNetwork/publishers/configurationGroupSchemas",
-        "resourceName": "automated-cli-tests-ubuntu-publisher/ConfigGroupSchema"}],
-        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/networkServiceDesignGroups/ubuntu/networkServiceDesignVersions/1.0.0",
-        "resourceType": "Microsoft.HybridNetwork/publishers/networkServiceDesignGroups/networkServiceDesignVersions",
-        "resourceName": "automated-cli-tests-ubuntu-publisher/ubuntu/1.0.0"}]}}'
+        "value": "automated-cli-test-ubuntu-publisher"}, "acrArtifactStoreName": {"type":
+        "String", "value": "ubuntu-acr"}, "nsDesignGroup": {"type": "String", "value":
+        "ubuntu"}, "nsDesignVersion": {"type": "String", "value": "1.0.0"}, "nfviSiteName":
+        {"type": "String", "value": "ubuntu_NFVI"}}, "mode": "Incremental", "provisioningState":
+        "Accepted", "timestamp": "2024-05-15T16:18:05.8548402Z", "duration": "PT0.0009629S",
+        "correlationId": "88e6b253-7a3c-4c6e-938e-189f3b02668d", "providers": [{"namespace":
+        "Microsoft.Hybridnetwork", "resourceTypes": [{"resourceType": "publishers/configurationGroupSchemas",
+        "locations": ["uksouth"]}, {"resourceType": "publishers/networkservicedesigngroups/networkservicedesignversions",
+        "locations": ["uksouth"]}]}], "dependencies": [{"dependsOn": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/automated-cli-test-ubuntu-publisher/configurationGroupSchemas/ConfigGroupSchema",
+        "resourceType": "Microsoft.Hybridnetwork/publishers/configurationGroupSchemas",
+        "resourceName": "automated-cli-test-ubuntu-publisher/ConfigGroupSchema"}],
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/automated-cli-test-ubuntu-publisher/networkservicedesigngroups/ubuntu/networkservicedesignversions/1.0.0",
+        "resourceType": "Microsoft.Hybridnetwork/publishers/networkservicedesigngroups/networkservicedesignversions",
+        "resourceName": "automated-cli-test-ubuntu-publisher/ubuntu/1.0.0"}]}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1713273682/operationStatuses/08584883332040032533?api-version=2022-09-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1715789884/operationStatuses/08584858170000018752?api-version=2022-09-01
       cache-control:
       - no-cache
       content-length:
-      - '2013'
+      - '2008'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:21:21 GMT
+      - Wed, 15 May 2024 16:18:05 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
+      x-msedge-ref:
+      - 'Ref A: B8E19F675FD749B886DFE823F4720CC5 Ref B: AMS231032609045 Ref C: 2024-05-15T16:18:05Z'
     status:
       code: 201
       message: Created
@@ -4319,10 +4474,9 @@ interactions:
       ParameterSetName:
       - --build-output-folder
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883332040032533?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858170000018752?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Accepted"}'
@@ -4334,15 +4488,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:21:21 GMT
+      - Wed, 15 May 2024 16:18:05 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: 26D75C9BE2C949479A521FB5AAFF5055 Ref B: AMS231032609045 Ref C: 2024-05-15T16:18:05Z'
     status:
       code: 200
       message: OK
@@ -4360,10 +4518,9 @@ interactions:
       ParameterSetName:
       - --build-output-folder
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883332040032533?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858170000018752?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Running"}'
@@ -4375,15 +4532,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:21:51 GMT
+      - Wed, 15 May 2024 16:18:35 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: B4FCA68C180940C98C3CD01380971BA5 Ref B: AMS231032609045 Ref C: 2024-05-15T16:18:36Z'
     status:
       code: 200
       message: OK
@@ -4401,10 +4562,9 @@ interactions:
       ParameterSetName:
       - --build-output-folder
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584883332040032533?api-version=2022-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08584858170000018752?api-version=2022-09-01
   response:
     body:
       string: '{"status": "Succeeded"}'
@@ -4416,15 +4576,19 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:22:21 GMT
+      - Wed, 15 May 2024 16:19:05 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: 42D26AB72B2542EF96E71CCD8F60ACB4 Ref B: AMS231032609045 Ref C: 2024-05-15T16:19:06Z'
     status:
       code: 200
       message: OK
@@ -4442,50 +4606,52 @@ interactions:
       ParameterSetName:
       - --build-output-folder
       User-Agent:
-      - AZURECLI/2.57.0.post20240219064455 azsdk-python-core/1.30.0 Python/3.8.10
-        (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+      - AZURECLI/2.56.0 azsdk-python-azure-mgmt-resource/23.1.0b2 Python/3.8.10 (Linux-5.15.146.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2022-09-01
   response:
     body:
-      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1713273682",
-        "name": "AOSM_CLI_deployment_1713273682", "type": "Microsoft.Resources/deployments",
-        "properties": {"templateHash": "7665769847335104070", "parameters": {"location":
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Resources/deployments/AOSM_CLI_deployment_1715789884",
+        "name": "AOSM_CLI_deployment_1715789884", "type": "Microsoft.Resources/deployments",
+        "properties": {"templateHash": "774629352801001138", "parameters": {"location":
         {"type": "String", "value": "uksouth"}, "publisherName": {"type": "String",
-        "value": "automated-cli-tests-ubuntu-publisher"}, "acrArtifactStoreName":
-        {"type": "String", "value": "ubuntu-acr"}, "nsDesignGroup": {"type": "String",
-        "value": "ubuntu"}, "nsDesignVersion": {"type": "String", "value": "1.0.0"},
-        "nfviSiteName": {"type": "String", "value": "ubuntu_NFVI"}}, "mode": "Incremental",
-        "provisioningState": "Succeeded", "timestamp": "2024-04-16T13:22:05.2982239Z",
-        "duration": "PT43.5729392S", "correlationId": "a61f081e-5a1e-46cf-8601-243a87ddf2f7",
-        "providers": [{"namespace": "Microsoft.HybridNetwork", "resourceTypes": [{"resourceType":
-        "publishers/configurationGroupSchemas", "locations": ["uksouth"]}, {"resourceType":
-        "publishers/networkServiceDesignGroups/networkServiceDesignVersions", "locations":
-        ["uksouth"]}]}], "dependencies": [{"dependsOn": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/configurationGroupSchemas/ConfigGroupSchema",
-        "resourceType": "Microsoft.HybridNetwork/publishers/configurationGroupSchemas",
-        "resourceName": "automated-cli-tests-ubuntu-publisher/ConfigGroupSchema"}],
-        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/networkServiceDesignGroups/ubuntu/networkServiceDesignVersions/1.0.0",
-        "resourceType": "Microsoft.HybridNetwork/publishers/networkServiceDesignGroups/networkServiceDesignVersions",
-        "resourceName": "automated-cli-tests-ubuntu-publisher/ubuntu/1.0.0"}], "outputResources":
-        [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/configurationGroupSchemas/ConfigGroupSchema"},
-        {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.HybridNetwork/publishers/automated-cli-tests-ubuntu-publisher/networkServiceDesignGroups/ubuntu/networkServiceDesignVersions/1.0.0"}]}}'
+        "value": "automated-cli-test-ubuntu-publisher"}, "acrArtifactStoreName": {"type":
+        "String", "value": "ubuntu-acr"}, "nsDesignGroup": {"type": "String", "value":
+        "ubuntu"}, "nsDesignVersion": {"type": "String", "value": "1.0.0"}, "nfviSiteName":
+        {"type": "String", "value": "ubuntu_NFVI"}}, "mode": "Incremental", "provisioningState":
+        "Succeeded", "timestamp": "2024-05-15T16:19:01.1089972Z", "duration": "PT55.2551199S",
+        "correlationId": "88e6b253-7a3c-4c6e-938e-189f3b02668d", "providers": [{"namespace":
+        "Microsoft.Hybridnetwork", "resourceTypes": [{"resourceType": "publishers/configurationGroupSchemas",
+        "locations": ["uksouth"]}, {"resourceType": "publishers/networkservicedesigngroups/networkservicedesignversions",
+        "locations": ["uksouth"]}]}], "dependencies": [{"dependsOn": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/automated-cli-test-ubuntu-publisher/configurationGroupSchemas/ConfigGroupSchema",
+        "resourceType": "Microsoft.Hybridnetwork/publishers/configurationGroupSchemas",
+        "resourceName": "automated-cli-test-ubuntu-publisher/ConfigGroupSchema"}],
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/automated-cli-test-ubuntu-publisher/networkservicedesigngroups/ubuntu/networkservicedesignversions/1.0.0",
+        "resourceType": "Microsoft.Hybridnetwork/publishers/networkservicedesigngroups/networkservicedesignversions",
+        "resourceName": "automated-cli-test-ubuntu-publisher/ubuntu/1.0.0"}], "outputResources":
+        [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/automated-cli-test-ubuntu-publisher/configurationGroupSchemas/ConfigGroupSchema"},
+        {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vnf_nsd_000001/providers/Microsoft.Hybridnetwork/publishers/automated-cli-test-ubuntu-publisher/networkservicedesigngroups/ubuntu/networkservicedesignversions/1.0.0"}]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '2518'
+      - '2510'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 16 Apr 2024 13:22:21 GMT
+      - Wed, 15 May 2024 16:19:05 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      x-cache:
+      - CONFIG_NOCACHE
       x-content-type-options:
       - nosniff
+      x-msedge-ref:
+      - 'Ref A: E2F9BBCDAA424ACBB9D236B3AD76EA76 Ref B: AMS231032609045 Ref C: 2024-05-15T16:19:06Z'
     status:
       code: 200
       message: OK

--- a/src/aosm/azext_aosm/tests/latest/integration_tests/test_cnf.py
+++ b/src/aosm/azext_aosm/tests/latest/integration_tests/test_cnf.py
@@ -67,7 +67,7 @@ class TestCNF(unittest.TestCase):
 
                 expected_deploy_params = {
                     "location": "uksouth",
-                    "publisherName": "automated-cli-tests-nginx-publisher",
+                    "publisherName": "automated-cli-test-nginx-publisher",
                     "publisherResourceGroupName": "cli_test_cnf_nfd",
                     "acrArtifactStoreName": "nginx-acr",
                     "acrManifestName": "nginx-acr-manifest-1-0-0",


### PR DESCRIPTION
- We were hitting an error in the integration tests because when running `list_credential` method we do not retry on failure. When running the CLI normally (outside of the testing framework), the retries happen automatically which means that the command would succeed when running outside of the testing framework. This seems like an external issue but can be fixed by adding a short while loop to retry the `list_credential` method
- I have also changed the publisher name in our tests because the US has some publishers laying around with the same name, which meant we could not actually run the tests with the old publisher name